### PR TITLE
详情页增加章节批量下载

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JMComic 第三方 Android 漫画阅读器。它把搜索、收藏、下载、本地阅读、PDF 导入导出和批量解析放在一个移动端界面里，适合想在手机上更顺手地整理和阅读漫画的人。
 
-[![Version](https://img.shields.io/badge/Version-1.1.5-brightgreen.svg)](https://github.com/JUKOMU/JQ-Viewer/releases)
+[![Version](https://img.shields.io/badge/Version-1.1.6-brightgreen.svg)](https://github.com/JUKOMU/JQ-Viewer/releases)
 [![Android](https://img.shields.io/badge/Android-7.0%2B-3DDC84?logo=android&logoColor=white)](https://github.com/JUKOMU/JQ-Viewer/releases)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Releases](https://img.shields.io/badge/Download-Releases-blue.svg)](https://github.com/JUKOMU/JQ-Viewer/releases)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,8 +42,8 @@ android {
         applicationId "io.github.jukomu"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 8
-        versionName "1.1.5"
+        versionCode 9
+        versionName "1.1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,5 +13,5 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
-    jmcomicApiVersion = '1.1.5'
+    jmcomicApiVersion = '1.1.6'
 }

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,5 +13,5 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
-    jmcomicApiVersion = '1.1.6'
+    jmcomicApiVersion = '1.1.7'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jq-viewer",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jq-viewer",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@capacitor/android": "^8.3.1",
         "@capacitor/app": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jq-viewer",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/album/AlbumChaptersTab.vue
+++ b/src/components/album/AlbumChaptersTab.vue
@@ -104,11 +104,11 @@ const isDownloadDisabled = (chapterId: string): boolean => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  width: 100%;
+  gap: 10px;
+  width: 85%;
   min-height: 76px;
   box-sizing: border-box;
-  padding: 14px 10px;
+  padding: 10px 8px;
   border: 1px solid rgb(245 210 188 / 0.7);
   border-radius: 12px;
   background: #fffaf6;

--- a/src/components/album/AlbumChaptersTab.vue
+++ b/src/components/album/AlbumChaptersTab.vue
@@ -1,51 +1,143 @@
 <!-- 章节 Tab -->
 <template>
   <section class="chapters-section">
-    <div v-if="photoMetas.length" class="chapter-grid">
+    <!-- 操作栏 -->
+    <div v-if="photoMetas.length" class="chapters-toolbar">
+      <div class="toolbar-left">
+        <template v-if="batchMode">
+          <button type="button" class="toolbar-btn" @click="selectAll">全选</button>
+          <button type="button" class="toolbar-btn" @click="invertSelection">反选</button>
+          <button type="button" class="toolbar-btn" @click="clearSelection">取消</button>
+        </template>
+      </div>
+      <div class="toolbar-right">
+        <button
+          v-if="batchMode"
+          type="button"
+          class="toolbar-btn toolbar-btn-icon"
+          @click="exitBatchMode"
+        >
+          <ion-icon :icon="closeOutline"/>
+        </button>
+        <button
+          type="button"
+          class="toolbar-btn toolbar-btn-icon"
+          @click="toggleDisplayMode"
+        >
+          <ion-icon :icon="displayMode === 'grid' ? listOutline : gridOutline"/>
+        </button>
+        <button
+          type="button"
+          class="toolbar-btn"
+          :class="{
+            'toolbar-btn-primary': !batchMode || hasSelection,
+            disabled: batchMode && !hasSelection,
+          }"
+          @click="onBatchDownloadClick"
+        >
+          {{ batchMode ? `开始下载(${selectedIds.size})` : '批量下载' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- 列表模式 -->
+    <div v-if="photoMetas.length && displayMode === 'list'" class="chapter-list">
+      <div
+        v-for="meta in photoMetas"
+        :key="meta.id"
+        class="list-item"
+        :class="{
+          selected: selectedChapterId === meta.id && !batchMode,
+          downloaded: chapterDownloadStatuses.get(meta.id) === 'completed',
+          'batch-selected': batchMode && selectedIds.has(meta.id),
+          'batch-disabled': batchMode && isDownloadDisabled(meta.id),
+        }"
+        @click="onCardClick(meta.id)"
+      >
+        <span class="list-item-text">第{{ meta.sortOrder }}话  {{ meta.title }}</span>
+        <span
+          v-if="chapterDownloadStatuses.get(meta.id) === 'completed' || chapterPdfStatuses.get(meta.id)"
+          class="list-item-chips"
+        >
+          <span v-if="chapterDownloadStatuses.get(meta.id) === 'completed'"
+                class="chapter-source-chip source-chip-image">
+            <ion-icon :icon="imageOutline"/>
+          </span>
+          <span v-if="chapterPdfStatuses.get(meta.id)" class="chapter-source-chip source-chip-pdf">
+            <ion-icon :icon="documentOutline"/>
+          </span>
+        </span>
+        <span
+          v-if="batchMode"
+          class="batch-check-inline"
+          :class="{ checked: selectedIds.has(meta.id), disabled: isDownloadDisabled(meta.id) }"
+          @click.stop="toggleSelect(meta.id)"
+        >
+          <ion-icon v-if="selectedIds.has(meta.id)" :icon="checkmark"/>
+          <span v-else class="check-empty"/>
+        </span>
+      </div>
+    </div>
+
+    <!-- 网格模式 -->
+    <div v-else-if="photoMetas.length" class="chapter-grid">
       <div
         v-for="meta in photoMetas"
         :key="meta.id"
         class="chapter-item"
       >
-        <button
-          type="button"
-          class="chapter-card"
-          :class="{
-            selected: selectedChapterId === meta.id,
-            downloaded: chapterDownloadStatuses.get(meta.id) === 'completed',
-          }"
-          @click="$emit('select-chapter', meta.id)"
-        >
-          <Transition name="action-swap" mode="out-in">
-            <span
-              v-if="!(showActions && selectedChapterId === meta.id)"
-              key="num"
-              class="chapter-num"
-            >
-              第{{ meta.sortOrder }}话
-            </span>
-            <div v-else key="actions" class="chapter-actions">
-              <button
-                type="button"
-                class="action-btn"
-                :class="{ disabled: isDownloadDisabled(meta.id) }"
-                :disabled="isDownloadDisabled(meta.id)"
-                @click.stop="$emit('download-chapter', meta.id)"
+        <div class="card-wrapper">
+          <button
+            type="button"
+            class="chapter-card"
+            :class="{
+              selected: selectedChapterId === meta.id && !batchMode,
+              downloaded: chapterDownloadStatuses.get(meta.id) === 'completed',
+              'batch-selected': batchMode && selectedIds.has(meta.id),
+            }"
+            @click="onCardClick(meta.id)"
+          >
+            <Transition name="action-swap" mode="out-in">
+              <span
+                v-if="!(showActions && selectedChapterId === meta.id && !batchMode)"
+                key="num"
+                class="chapter-num"
               >
-                <ion-icon :icon="cloudDownloadOutline"/>
-              </button>
-              <button type="button" class="action-btn" @click.stop="$emit('dismiss-actions')">
-                <ion-icon :icon="arrowBack"/>
-              </button>
-            </div>
-          </Transition>
-          <span class="chapter-title">{{ meta.title }}</span>
-        </button>
+                第{{ meta.sortOrder }}话
+              </span>
+              <div v-else key="actions" class="chapter-actions">
+                <button
+                  type="button"
+                  class="action-btn"
+                  :class="{ disabled: isDownloadDisabled(meta.id) }"
+                  :disabled="isDownloadDisabled(meta.id)"
+                  @click.stop="$emit('download-chapter', meta.id)"
+                >
+                  <ion-icon :icon="cloudDownloadOutline"/>
+                </button>
+                <button type="button" class="action-btn" @click.stop="$emit('dismiss-actions')">
+                  <ion-icon :icon="arrowBack"/>
+                </button>
+              </div>
+            </Transition>
+            <span class="chapter-title">{{ meta.title }}</span>
+          </button>
+          <span
+            v-if="batchMode"
+            class="batch-check"
+            :class="{ checked: selectedIds.has(meta.id), disabled: isDownloadDisabled(meta.id) }"
+            @click.stop="toggleSelect(meta.id)"
+          >
+            <ion-icon v-if="selectedIds.has(meta.id)" :icon="checkmark"/>
+            <span v-else class="check-empty"/>
+          </span>
+        </div>
         <span
           v-if="chapterDownloadStatuses.get(meta.id) === 'completed' || chapterPdfStatuses.get(meta.id)"
           class="chapter-source-row"
         >
-          <span v-if="chapterDownloadStatuses.get(meta.id) === 'completed'" class="chapter-source-chip source-chip-image">
+          <span v-if="chapterDownloadStatuses.get(meta.id) === 'completed'"
+                class="chapter-source-chip source-chip-image">
             <ion-icon :icon="imageOutline"/>
           </span>
           <span v-if="chapterPdfStatuses.get(meta.id)" class="chapter-source-chip source-chip-pdf">
@@ -65,8 +157,21 @@
 </template>
 
 <script setup lang="ts">
-defineOptions({name: 'AlbumChaptersTab'})
+import {computed, ref} from 'vue'
+import {IonIcon} from '@ionic/vue'
+import {
+  arrowBack,
+  checkmark,
+  closeOutline,
+  cloudDownloadOutline,
+  documentOutline,
+  gridOutline,
+  imageOutline,
+  listOutline,
+} from 'ionicons/icons'
+import type {PhotoMeta} from '@/services/JmcomicTypes'
 
+defineOptions({name: 'AlbumChaptersTab'})
 const props = defineProps<{
   photoMetas: PhotoMeta[]
   selectedChapterId: string
@@ -75,14 +180,13 @@ const props = defineProps<{
   chapterDownloadStatuses: Map<string, string>
   chapterPdfStatuses: Map<string, boolean>
 }>()
-defineEmits<{
+
+const emit = defineEmits<{
   'select-chapter': [chapterId: string]
   'download-chapter': [chapterId: string]
   'dismiss-actions': []
+  'batch-download': [chapterIds: string[]]
 }>()
-import {IonIcon} from '@ionic/vue'
-import {arrowBack, cloudDownloadOutline, documentOutline, imageOutline} from 'ionicons/icons'
-import type {PhotoMeta} from '@/services/JmcomicTypes'
 
 const isDownloadDisabled = (chapterId: string): boolean => {
   const status = props.chapterDownloadStatuses.get(chapterId)
@@ -90,13 +194,250 @@ const isDownloadDisabled = (chapterId: string): boolean => {
     status === 'queued' || status === 'downloading' || status === 'paused' || status === 'completed'
   )
 }
+
+// ---- 批量选择 ----
+const batchMode = ref(false)
+const selectedIds = ref<Set<string>>(new Set())
+const hasSelection = computed(() => selectedIds.value.size > 0)
+
+const enterBatchMode = () => {
+  batchMode.value = true
+  selectedIds.value = new Set()
+}
+
+const exitBatchMode = () => {
+  batchMode.value = false
+  selectedIds.value = new Set()
+}
+
+const toggleSelect = (chapterId: string) => {
+  if (isDownloadDisabled(chapterId)) return
+  const next = new Set(selectedIds.value)
+  if (next.has(chapterId)) {
+    next.delete(chapterId)
+  } else {
+    next.add(chapterId)
+  }
+  selectedIds.value = next
+}
+
+const selectAll = () => {
+  selectedIds.value = new Set(
+    props.photoMetas.filter((m) => !isDownloadDisabled(m.id)).map((m) => m.id),
+  )
+}
+
+const invertSelection = () => {
+  const next = new Set<string>()
+  for (const meta of props.photoMetas) {
+    const wasSelected = selectedIds.value.has(meta.id)
+    const disabled = isDownloadDisabled(meta.id)
+    if (disabled) continue
+    if (!wasSelected) next.add(meta.id)
+  }
+  selectedIds.value = next
+}
+
+const clearSelection = () => {
+  selectedIds.value = new Set()
+}
+
+const onBatchDownloadClick = () => {
+  if (!batchMode.value) {
+    enterBatchMode()
+    return
+  }
+  if (!hasSelection.value) return
+  emit('batch-download', [...selectedIds.value])
+  exitBatchMode()
+}
+
+const onCardClick = (chapterId: string) => {
+  if (batchMode.value) {
+    toggleSelect(chapterId)
+  } else {
+    emit('select-chapter', chapterId)
+  }
+}
+
+// ---- 显示模式 ----
+const displayMode = ref<'grid' | 'list'>('grid')
+
+const toggleDisplayMode = () => {
+  displayMode.value = displayMode.value === 'grid' ? 'list' : 'grid'
+}
 </script>
 
 <style scoped>
+/* ---- 操作栏 ---- */
+.chapters-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 10px;
+}
+
+.toolbar-left {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+
+.toolbar-right {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.toolbar-btn {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid rgb(245 210 188 / 0.5);
+  border-radius: 6px;
+  background: #fffaf6;
+  color: #8a6048;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.18s ease, opacity 0.18s ease;
+  white-space: nowrap;
+}
+
+.toolbar-btn:active {
+  background: #ffe4d1;
+}
+
+.toolbar-btn-icon {
+  width: 28px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}
+
+.toolbar-btn-primary {
+  background: linear-gradient(145deg, #fa9c69, #f28752);
+  color: #fff;
+  border-color: transparent;
+}
+
+.toolbar-btn-primary:active {
+  background: linear-gradient(145deg, #f28752, #e07030);
+}
+
+.toolbar-btn-primary.disabled,
+.toolbar-btn.disabled {
+  background: #d0c7c0;
+  color: #9a9088;
+  border-color: transparent;
+  pointer-events: none;
+}
+
+/* ---- 列表模式 ---- */
+.chapter-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgb(245 210 188 / 0.5);
+  border-radius: 8px;
+  background: #fffaf6;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease;
+}
+
+.list-item:active {
+  background: #fff0e7;
+}
+
+.list-item.selected {
+  border-color: #fa9c69;
+}
+
+.list-item.downloaded {
+  background: #f0faf3;
+  border-color: #6dbf87;
+}
+
+.list-item.batch-selected {
+  border-color: #fa9c69;
+  background: #fff0e7;
+}
+
+.list-item.batch-disabled {
+  opacity: 0.45;
+}
+
+.list-item-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #5a3d2e;
+  min-width: 0;
+}
+
+.list-item-chips {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.batch-check-inline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  cursor: pointer;
+  color: #d0c7c0;
+  font-size: 20px;
+  border-radius: 50%;
+}
+
+.batch-check-inline.checked {
+  color: #ffffff;
+}
+
+.batch-check-inline.checked ion-icon {
+  background-color: #fa9c69;
+  border-radius: 50%;
+  font-size: 16px;
+  padding: 1px;
+}
+
+.batch-check-inline.disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.check-empty {
+  width: 18px;
+  height: 18px;
+  border: 2px solid #d0c7c0;
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+
+/* ---- 网格模式 ---- */
 .chapter-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 8px;
+}
+
+.card-wrapper {
+  position: relative;
+  width: 85%;
 }
 
 .chapter-card {
@@ -105,7 +446,7 @@ const isDownloadDisabled = (chapterId: string): boolean => {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  width: 85%;
+  width: 100%;
   min-height: 76px;
   box-sizing: border-box;
   padding: 10px 8px;
@@ -133,6 +474,12 @@ const isDownloadDisabled = (chapterId: string): boolean => {
   border-color: #fa9c69;
 }
 
+.chapter-card.batch-selected {
+  background: #fff0e7;
+  border-color: #fa9c69;
+  box-shadow: 0 0 0 1px #fa9c69;
+}
+
 .chapter-num {
   font-size: 11px;
   font-weight: 700;
@@ -149,6 +496,10 @@ const isDownloadDisabled = (chapterId: string): boolean => {
 }
 
 .chapter-card.selected.downloaded .chapter-num {
+  color: #e07030;
+}
+
+.chapter-card.batch-selected .chapter-num {
   color: #e07030;
 }
 
@@ -198,6 +549,40 @@ const isDownloadDisabled = (chapterId: string): boolean => {
   border-color: #e05555;
   background: #fdf0f0;
   color: #c03939;
+}
+
+/* ---- 批量勾选框（网格模式） ---- */
+.batch-check {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #d0c7c0;
+  font-size: 20px;
+  z-index: 999;
+  transition: color 0.18s ease;
+  border-radius: 50%;
+}
+
+.batch-check.checked {
+  color: #ffffff;
+}
+
+.batch-check.checked ion-icon {
+  background-color: #fa9c69;
+  border-radius: 50%;
+  font-size: 16px;
+  padding: 1px;
+}
+
+.batch-check.disabled {
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 /* ---- 操作按钮 ---- */

--- a/src/components/album/AlbumChaptersTab.vue
+++ b/src/components/album/AlbumChaptersTab.vue
@@ -94,6 +94,7 @@
               selected: selectedChapterId === meta.id && !batchMode,
               downloaded: chapterDownloadStatuses.get(meta.id) === 'completed',
               'batch-selected': batchMode && selectedIds.has(meta.id),
+              'batch-disabled': batchMode && isDownloadDisabled(meta.id),
             }"
             @click="onCardClick(meta.id)"
           >
@@ -501,6 +502,10 @@ const toggleDisplayMode = () => {
 
 .chapter-card.batch-selected .chapter-num {
   color: #e07030;
+}
+
+.chapter-card.batch-disabled {
+  opacity: 0.45;
 }
 
 .chapter-title {

--- a/src/components/album/AlbumChaptersTab.vue
+++ b/src/components/album/AlbumChaptersTab.vue
@@ -141,7 +141,7 @@ const isDownloadDisabled = (chapterId: string): boolean => {
 }
 
 .chapter-card.selected .chapter-num {
-  color: #e07030;
+  color: #5e8afd;
 }
 
 .chapter-card.downloaded .chapter-num {
@@ -158,7 +158,6 @@ const isDownloadDisabled = (chapterId: string): boolean => {
   min-height: 29px;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
 

--- a/src/components/album/AlbumHeader.vue
+++ b/src/components/album/AlbumHeader.vue
@@ -11,7 +11,7 @@
       </button>
       <div class="header-body">
         <div class="cover-col">
-          <img v-if="coverUrl" :src="coverUrl" class="cover-img" :alt="title"/>
+          <img v-if="coverUrl" :src="coverUrl" class="cover-img" :alt="title" @click="showPreview = true"/>
           <div v-else class="cover-placeholder"/>
         </div>
         <div class="info-col">
@@ -70,10 +70,20 @@
         </div>
       </div>
     </div>
+    <!-- 封面预览遮罩 -->
+    <Teleport to="body">
+      <div v-if="showPreview" class="cover-preview-overlay" @click="showPreview = false">
+        <img :src="coverUrl" class="cover-preview-img" :alt="title"/>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+import {IonIcon} from '@ionic/vue'
+import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline,} from 'ionicons/icons'
+
 defineOptions({name: 'AlbumHeader'})
 
 defineProps<{
@@ -94,8 +104,8 @@ defineEmits<{
   'select-source': [source: 'network' | 'download' | 'pdf']
   back: []
 }>()
-import {IonIcon} from '@ionic/vue'
-import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline,} from 'ionicons/icons'
+
+const showPreview = ref(false)
 </script>
 
 <style scoped>
@@ -147,7 +157,7 @@ import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline
 .header-body {
   display: flex;
   gap: 14px;
-  align-items: flex-end;
+  align-items: flex-start;
 }
 
 .cover-col {
@@ -163,6 +173,7 @@ import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline
   width: 100%;
   aspect-ratio: 3 / 4;
   object-fit: cover;
+  cursor: pointer;
 }
 
 .cover-placeholder {
@@ -190,7 +201,6 @@ import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline
   line-height: 1.35;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
   overflow: hidden;
 }
 
@@ -367,5 +377,25 @@ import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline
   .album-title {
     font-size: 20px;
   }
+}
+
+/* 封面预览遮罩 */
+.cover-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 0.85);
+  backdrop-filter: blur(12px);
+}
+
+.cover-preview-img {
+  max-width: 98vw;
+  max-height: 98vh;
+  border-radius: 0px;
+  box-shadow: 0 8px 40px rgb(0 0 0 / 0.5);
+  object-fit: contain;
 }
 </style>

--- a/src/components/album/AlbumHeader.vue
+++ b/src/components/album/AlbumHeader.vue
@@ -95,13 +95,7 @@ defineEmits<{
   back: []
 }>()
 import {IonIcon} from '@ionic/vue'
-import {
-  arrowBack,
-  ellipsisVertical,
-  globeOutline,
-  documentOutline,
-  imageOutline,
-} from 'ionicons/icons'
+import {arrowBack, documentOutline, ellipsisVertical, globeOutline, imageOutline,} from 'ionicons/icons'
 </script>
 
 <style scoped>

--- a/src/components/album/AlbumInfoTab.vue
+++ b/src/components/album/AlbumInfoTab.vue
@@ -76,7 +76,7 @@
           </div>
         </div>
         <div v-if="album.authors.length" class="info-row">
-          <span class="info-label">Authors</span>
+          <span class="info-label">作者</span>
           <div class="info-tags">
             <span v-for="author in album.authors" :key="author" class="tag tag-clickable" @click="searchByTag(author)">{{
                 author
@@ -84,7 +84,7 @@
           </div>
         </div>
         <div v-if="album.tags.length" class="info-row">
-          <span class="info-label">Tags</span>
+          <span class="info-label">标签</span>
           <div class="info-tags">
             <span v-for="tag in album.tags" :key="tag" class="tag tag-clickable" @click="searchByTag(tag)">{{
                 tag
@@ -92,13 +92,13 @@
           </div>
         </div>
         <div v-if="album.actors.length" class="info-row">
-          <span class="info-label">Actors</span>
+          <span class="info-label">登场人物</span>
           <div class="info-tags">
             <span v-for="actor in album.actors" :key="actor" class="tag">{{ actor }}</span>
           </div>
         </div>
         <div v-if="album.works.length" class="info-row">
-          <span class="info-label">Works</span>
+          <span class="info-label">作品</span>
           <div class="info-tags">
             <span v-for="work in album.works" :key="work" class="tag">{{ work }}</span>
           </div>

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -932,7 +932,8 @@ const downloadSingleChapter = async (chapterId: string): Promise<boolean> => {
       createdAt: Date.now(),
     })
     return true
-  } catch {
+  } catch (e: any) {
+    await showToast(sanitizeError(e, '下载提交失败'), 'danger')
     return false
   }
 }
@@ -954,8 +955,6 @@ const handleDownload = async () => {
   if (success) {
     await showToast('已加入下载队列', 'success')
     await refreshDownloadStatuses()
-  } else {
-    await showToast('下载提交失败', 'danger')
   }
 }
 

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -1006,7 +1006,7 @@ const handleScroll = async () => {
 
 .tab-bar.sticky {
   position: sticky;
-  top: 0;
+  top: var(--ion-safe-area-top);
   box-shadow: 0 2px 10px rgb(76 42 24 / 0.08);
 }
 

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -59,6 +59,7 @@
           @select-chapter="selectChapter"
           @download-chapter="onDownloadChapter"
           @dismiss-actions="showChapterActions = false"
+          @batch-download="onBatchDownload"
         />
         <AlbumPreviewTab
           v-else-if="activeTab === 'preview'"
@@ -515,8 +516,7 @@ const selectChapter = async (chapterId: string) => {
   chapterLoading.value = true
 
   try {
-    const photo = await JmcomicService.getPhoto(chapterId)
-    photoDetail.value = photo
+    photoDetail.value = await JmcomicService.getPhoto(chapterId)
     recordBrowseHistory()
   } catch (e: any) {
     await showToast(sanitizeError(e, '章节加载失败'), 'danger')
@@ -898,12 +898,50 @@ const handleToggleFavorite = async () => {
   void openFolderPicker()
 }
 
+const downloadSingleChapter = async (chapterId: string): Promise<boolean> => {
+  if (!albumDetail.value) return false
+
+  const taskId = makeTaskId(albumId.value, chapterId)
+  const existing = OfflineDownloadService.getAll().find(
+    (t) => t.taskId === taskId && t.status !== 'failed',
+  )
+  if (existing) return false
+
+  const chapterTitle =
+    albumDetail.value.photoMetas.find((m) => m.id === chapterId)?.title || chapterId
+
+  try {
+    await JmcomicService.downloadChapter(
+      albumId.value,
+      chapterId,
+      albumDetail.value.title,
+      chapterTitle,
+      albumDetail.value.image,
+    )
+    OfflineDownloadService.addTask({
+      taskId,
+      albumId: albumId.value,
+      chapterId,
+      albumTitle: albumDetail.value.title,
+      chapterTitle,
+      coverUrl: albumDetail.value.image,
+      isSingleEpisode: albumDetail.value.isSingleEpisode,
+      totalPages: 0,
+      downloadedPages: 0,
+      status: 'queued',
+      createdAt: Date.now(),
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
 const handleDownload = async () => {
   const chapterId = selectedChapterId.value
   if (!chapterId || !albumDetail.value) return
 
   const taskId = makeTaskId(albumId.value, chapterId)
-  // 避免重复提交
   const existing = OfflineDownloadService.getAll().find(
     (t) => t.taskId === taskId && t.status !== 'failed',
   )
@@ -912,38 +950,26 @@ const handleDownload = async () => {
     return
   }
 
-  // 组装参数
-  const albumTitle2 = albumDetail.value.title
-  const coverUrl2 = albumDetail.value.image
-  const chapterTitle2 =
-    albumDetail.value.photoMetas.find((m) => m.id === chapterId)?.title || chapterId
-
-  try {
-    await JmcomicService.downloadChapter(
-      albumId.value,
-      chapterId,
-      albumTitle2,
-      chapterTitle2,
-      coverUrl2,
-    )
-    // 乐观写入 localStorage
-    OfflineDownloadService.addTask({
-      taskId,
-      albumId: albumId.value,
-      chapterId,
-      albumTitle: albumTitle2,
-      chapterTitle: chapterTitle2,
-      coverUrl: coverUrl2,
-      isSingleEpisode: albumDetail.value.isSingleEpisode,
-      totalPages: 0,
-      downloadedPages: 0,
-      status: 'queued',
-      createdAt: Date.now(),
-    })
+  const success = await downloadSingleChapter(chapterId)
+  if (success) {
     await showToast('已加入下载队列', 'success')
     await refreshDownloadStatuses()
-  } catch (e: any) {
-    await showToast(sanitizeError(e, '下载提交失败'), 'danger')
+  } else {
+    await showToast('下载提交失败', 'danger')
+  }
+}
+
+const onBatchDownload = async (chapterIds: string[]) => {
+  if (!chapterIds.length) return
+  let successCount = 0
+  for (const id of chapterIds) {
+    if (await downloadSingleChapter(id)) {
+      successCount++
+    }
+  }
+  if (successCount > 0) {
+    await showToast(`已加入 ${successCount} 个下载任务`, 'success')
+    await refreshDownloadStatuses()
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持章节批量选择（全选/反选/清空）及批量加入下载队列；新增批量下载入口，并提供列表/网格展示切换。
  * 点击专辑封面可打开大图预览遮罩，支持点击任意位置关闭。
* **改进**
  * 单章与批量下载更稳：自动去重，仅在提交成功后刷新状态并给出对应提示；禁用下载的章节在批量选择中不可用。
  * 信息页作者/标签/登场人物/作品等改为中文展示；章节 Tab 吸顶适配安全区。
* **版本更新**
  * 应用版本更新至 **1.1.6**。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->