### PR TITLE
PDF导出模板增加序号模板 { index }

### DIFF
--- a/src/components/album/AlbumInfoTab.vue
+++ b/src/components/album/AlbumInfoTab.vue
@@ -64,9 +64,9 @@
         <div v-if="album.description" class="info-row">
           <span class="info-label">描述</span>
           <div class="info-value">
-            <p class="desc-text" :class="{ expanded: descExpanded }">{{ album.description }}</p>
+            <p ref="descTextRef" class="desc-text" :class="{ expanded: descExpanded }">{{ album.description }}</p>
             <button
-              v-if="album.description.length > 200"
+              v-if="descOverflows"
               type="button"
               class="desc-toggle"
               @click="descExpanded = !descExpanded"
@@ -156,7 +156,7 @@
 </template>
 
 <script setup lang="ts">
-import {computed, ref} from 'vue'
+import {computed, nextTick, ref, watch} from 'vue'
 import {useRouter} from 'vue-router'
 import {IonIcon, menuController} from '@ionic/vue'
 import {
@@ -202,6 +202,23 @@ function formatDate(raw: string): string {
 }
 
 const descExpanded = ref(false)
+const descTextRef = ref<HTMLElement | null>(null)
+const descOverflows = ref(false)
+
+function checkDescOverflow() {
+  const el = descTextRef.value
+  if (!el) return
+  if (descExpanded.value) {
+    descOverflows.value = true
+    return
+  }
+  descOverflows.value = el.scrollHeight > el.clientHeight
+}
+
+watch(() => props.album?.description, () => {
+  descExpanded.value = false
+  nextTick(() => checkDescOverflow())
+}, { immediate: true })
 
 const copyText = async (text: string) => {
   try {

--- a/src/components/download/PdfExportBottomSheet.vue
+++ b/src/components/download/PdfExportBottomSheet.vue
@@ -216,7 +216,7 @@ const emit = defineEmits<{
 }>()
 
 // ---- 模板变量 ----
-const templateVars = ['{id}', '{title}', '{chapterName}', '{chapterTitle}', '{chapterId}', '{pageCount}', '{author}', '{authors}', '{tags}']
+const templateVars = PdfExportService.TEMPLATE_VAR_KEYS
 const tagConditionVars = ['{tag=标签名}', '{tag=标签A|标签B}', '{tag=标签A&标签B}']
 
 // 当前选中章节的实际值（用于复制）
@@ -225,13 +225,6 @@ const firstSelectedChapter = computed(() =>
 )
 
 const albumDetail = ref<AlbumDetail | null>(null)
-
-function resolveChapterName(ch: DownloadTask, album: AlbumDetail | null): string {
-  if (album?.seriesId === '0') return album.title || ch.albumTitle
-  const order = ch.chapterSortOrder
-  if (order && order > 0) return `第${order}话`
-  return ch.chapterTitle || ''
-}
 
 function chapterOrderLabel(ch: DownloadTask): string {
   const order = ch.chapterSortOrder
@@ -242,17 +235,12 @@ function chapterOrderLabel(ch: DownloadTask): string {
 const templateValueMap = computed(() => {
   const ch = firstSelectedChapter.value
   if (!ch) return {} as Record<string, string>
-  return {
-    '{id}': ch.albumId,
-    '{title}': ch.albumTitle,
-    '{chapterId}': ch.chapterId,
-    '{chapterName}': resolveChapterName(ch, albumDetail.value),
-    '{chapterTitle}': ch.chapterTitle || '',
-    '{pageCount}': String(ch.totalPages),
-    '{author}': albumDetail.value?.authors?.[0] ?? '',
-    '{authors}': albumDetail.value?.authors?.join('、') ?? '',
-    '{tags}': albumDetail.value?.tags?.join('、') ?? '',
-  } as Record<string, string>
+  const data = PdfExportService.buildTemplateData(ch, albumDetail.value)
+  const map: Record<string, string> = {}
+  for (const v of PdfExportService.TEMPLATE_VAR_DEFS) {
+    map[v.key] = v.render(data)
+  }
+  return map
 })
 
 // ---- 设置（双向绑定到 PdfExportService） ----
@@ -279,17 +267,7 @@ const templatePath = computed(() => {
   const ch = firstSelectedChapter.value
   if (!ch) return PdfExportService.previewPath()
 
-  const data = {
-    id: ch.albumId,
-    title: ch.albumTitle,
-    chapterId: ch.chapterId,
-    chapterName: resolveChapterName(ch, albumDetail.value),
-    chapterTitle: ch.chapterTitle || '',
-    pageCount: ch.totalPages,
-    author: albumDetail.value?.authors?.[0] ?? '',
-    authors: albumDetail.value?.authors?.join('、') ?? '',
-    tags: albumDetail.value?.tags ?? [],
-  }
+  const data = PdfExportService.buildTemplateData(ch, albumDetail.value)
   const dirRendered = PdfExportService.renderTemplate(dirTpl, data)
   const nameRendered = PdfExportService.renderTemplate(nameTpl, data)
   const baseTrimmed = base.replace(/\/+$/, '')

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -26,7 +26,7 @@ export interface PdfTemplateData {
   author: string
   authors: string
   tags: string[]
-  index: number
+  index: number | string
 }
 
 /** 内置示例数据，供预览和设置页渲染值展示复用 */
@@ -168,7 +168,7 @@ export const PdfExportService = {
       author: album?.authors?.[0] ?? '',
       authors: album?.authors?.join('、') ?? '',
       tags: album?.tags ?? [],
-      index: ch.chapterSortOrder || 0,
+      index: ch.chapterSortOrder || '',
     }
   },
 

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -1,3 +1,11 @@
+/**
+ * 增加模板
+ * PdfTemplateData 加字段
+ * PDF_SAMPLE_DATA 加示例值
+ * TEMPLATE_VARS 加 def(...) 条目
+ * buildTemplateData 加字段映射
+ */
+
 import type { AlbumDetail, DownloadTask } from './JmcomicTypes'
 
 const KEY_EXPORT_PATH = 'jq-pdf-export-path'

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -1,3 +1,5 @@
+import type { AlbumDetail, DownloadTask } from './JmcomicTypes'
+
 const KEY_EXPORT_PATH = 'jq-pdf-export-path'
 const KEY_DIR_TEMPLATE = 'jq-pdf-dir-template'
 const KEY_NAME_TEMPLATE = 'jq-pdf-name-template'
@@ -16,6 +18,7 @@ export interface PdfTemplateData {
   author: string
   authors: string
   tags: string[]
+  index: number
 }
 
 /** 内置示例数据，供预览和设置页渲染值展示复用 */
@@ -29,9 +32,53 @@ export const PDF_SAMPLE_DATA: PdfTemplateData = {
   author: '葵季むつみ',
   authors: '葵季むつみ、二丸修一、しぐれうい',
   tags: ['非H', '劇情向', '蘿莉', '純愛', '中文'],
+  index: 1,
+}
+
+// ---- 模板变量注册表 ----
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export interface TemplateVarDef {
+  key: string
+  desc: string
+  sample: string
+  render: (data: PdfTemplateData) => string
+}
+
+function def(key: string, desc: string, render: (d: PdfTemplateData) => string): TemplateVarDef {
+  return { key, desc, sample: render(PDF_SAMPLE_DATA), render }
+}
+
+const TEMPLATE_VARS: TemplateVarDef[] = [
+  def('{id}',           '本子ID',                        d => d.id),
+  def('{title}',        '本子标题',                       d => d.title),
+  def('{chapterId}',    '章节ID',                        d => d.chapterId),
+  def('{chapterName}',  '章节序号（单行本则为标题）',       d => d.chapterName),
+  def('{index}',        '章节原始序号（纯数字）',           d => String(d.index)),
+  def('{chapterTitle}', '章节原始标题',                    d => d.chapterTitle),
+  def('{pageCount}',    '章节页数',                       d => String(d.pageCount)),
+  def('{author}',       '首位作者',                       d => d.author),
+  def('{authors}',      '全部作者，用顿号连接',             d => d.authors),
+  def('{tags}',         '全部标签，用顿号连接',             d => d.tags.join('、')),
+]
+
+export const TEMPLATE_VAR_KEYS = TEMPLATE_VARS.map(v => v.key)
+export const TEMPLATE_VAR_DEFS = TEMPLATE_VARS
+
+function resolveChapterName(ch: DownloadTask, album: AlbumDetail | null): string {
+  if (album?.seriesId === '0') return album.title || ch.albumTitle
+  const order = ch.chapterSortOrder
+  if (order && order > 0) return `第${order}话`
+  return ch.chapterTitle || ''
 }
 
 export const PdfExportService = {
+  TEMPLATE_VAR_KEYS,
+  TEMPLATE_VAR_DEFS,
+
   // ---- 设置读写 ----
 
   /**
@@ -98,19 +145,31 @@ export const PdfExportService = {
 
   // ---- 模板渲染 ----
 
+  /**
+   * 从 DownloadTask + AlbumDetail 构建 PdfTemplateData。
+   * 唯一的模板数据工厂函数，所有调用方统一使用。
+   */
+  buildTemplateData(ch: DownloadTask, album: AlbumDetail | null): PdfTemplateData {
+    return {
+      id: ch.albumId,
+      title: ch.albumTitle,
+      chapterId: ch.chapterId,
+      chapterName: resolveChapterName(ch, album),
+      chapterTitle: ch.chapterTitle || '',
+      pageCount: ch.totalPages,
+      author: album?.authors?.[0] ?? '',
+      authors: album?.authors?.join('、') ?? '',
+      tags: album?.tags ?? [],
+      index: ch.chapterSortOrder || 0,
+    }
+  },
+
   renderTemplate(template: string, data: PdfTemplateData): string {
     let result = template
-      .replace(/\{id\}/g, data.id)
-      .replace(/\{title\}/g, data.title)
-      .replace(/\{chapterId\}/g, data.chapterId)
-      .replace(/\{chapterName\}/g, data.chapterName)
-      .replace(/\{chapterTitle\}/g, data.chapterTitle)
-      .replace(/\{pageCount\}/g, String(data.pageCount))
-      .replace(/\{author\}/g, data.author)
-      .replace(/\{authors\}/g, data.authors)
-      .replace(/\{tags\}/g, data.tags.join('、'))
-    result = PdfExportService.renderTagConditions(result, data.tags)
-    return result
+    for (const v of TEMPLATE_VARS) {
+      result = result.replace(new RegExp(escapeRegex(v.key), 'g'), v.render(data))
+    }
+    return PdfExportService.renderTagConditions(result, data.tags)
   },
 
   /** 处理 {tag=xxx} 内联条件：匹配到则渲染标签名，否则为空 */

--- a/src/views/DownloadPage.vue
+++ b/src/views/DownloadPage.vue
@@ -883,28 +883,11 @@ const onPdfExportConfirm = async (payload: {
     } catch { /* 获取失败则变量渲染为空 */ }
   }
 
-  function resolveChapterName(ch: DownloadTask, album: AlbumDetail | null): string {
-    if (album?.seriesId === '0') return album.title || ch.albumTitle
-    const order = ch.chapterSortOrder
-    if (order && order > 0) return `第${order}话`
-    return ch.chapterTitle || ''
-  }
-
   const tasks: PdfExportTask[] = payload.selectedChapters.map((ch) => {
     const savePath =
       payload.selectedChapters.length === 1
         ? payload.editedPath
-        : PdfExportService.buildFullPath({
-            id: ch.albumId,
-            title: ch.albumTitle,
-            chapterId: ch.chapterId,
-            chapterName: resolveChapterName(ch, albumDetail),
-            chapterTitle: ch.chapterTitle || '',
-            pageCount: ch.totalPages,
-            author: albumDetail?.authors?.[0] ?? '',
-            authors: albumDetail?.authors?.join('、') ?? '',
-            tags: albumDetail?.tags ?? [],
-          })
+        : PdfExportService.buildFullPath(PdfExportService.buildTemplateData(ch, albumDetail))
 
     return {
       albumId: ch.albumId,

--- a/src/views/PdfTemplateHelpPage.vue
+++ b/src/views/PdfTemplateHelpPage.vue
@@ -80,17 +80,11 @@ defineOptions({ name: 'PdfTemplateHelpPage' })
 import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue'
 import { PdfExportService, PDF_SAMPLE_DATA } from '@/services/PdfExportService'
 
-const variables = [
-  { name: '{id}', desc: '本子ID', sample: '295852' },
-  { name: '{title}', desc: '本子标题', sample: '青梅竹馬絕對不會輸的戀愛喜劇～鄰家四姐妹的溫馨日常～' },
-  { name: '{author}', desc: '首位作者', sample: '葵季むつみ' },
-  { name: '{authors}', desc: '全部作者，用顿号连接', sample: '葵季むつみ、二丸修一、しぐれうい' },
-  { name: '{tags}', desc: '全部标签，用顿号连接', sample: '非H、劇情向、蘿莉、純愛、中文' },
-  { name: '{chapterId}', desc: '章节ID', sample: '295852' },
-  { name: '{chapterName}', desc: '章节序号（单行本则为标题）', sample: '第1话' },
-  { name: '{chapterTitle}', desc: '章节原始标题', sample: '' },
-  { name: '{pageCount}', desc: '章节页数', sample: '38' },
-]
+const variables = PdfExportService.TEMPLATE_VAR_DEFS.map(v => ({
+  name: v.key,
+  desc: v.desc,
+  sample: v.sample,
+}))
 
 const render = (tpl: string) => PdfExportService.renderTemplate(tpl, PDF_SAMPLE_DATA)
 

--- a/src/views/SettingPage.vue
+++ b/src/views/SettingPage.vue
@@ -314,6 +314,7 @@
                 <span class="var-tag">{title}</span>
                 <span class="var-tag">{chapterId}</span>
                 <span class="var-tag">{chapterName}</span>
+                <span class="var-tag">{index}</span>
                 <span class="var-tag">{chapterTitle}</span>
                 <span class="var-tag">{pageCount}</span>
                 <span class="var-tag">{author}</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - PDF 保存目录模板新增 `{index}` 变量，用于在模板中引用项目/章节索引信息。
  - 模板变量说明页会自动展示可用变量的名称、说明与示例。
- **改进**
  - PDF 批量导出时的保存路径生成更一致，批量章节信息与默认值处理更准确。
  - 描述文本仅在实际发生溢出时显示“展开/收起”按钮，提升长文体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->