### PR TITLE
fix: 修复详情页加载中切换预览tab后无响应问题

### DIFF
--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -461,6 +461,10 @@ const loadAlbumData = async () => {
     const matched = album.photoMetas.find((m) => m.id === albumId.value)
     selectedChapterId.value = matched?.id ?? album.photoMetas[0]?.id ?? ''
 
+    if (activeTab.value === 'preview') {
+      await loadPreview()
+    }
+
     recordBrowseHistory()
   } catch {
     // 保留 query 数据展示

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -461,10 +461,6 @@ const loadAlbumData = async () => {
     const matched = album.photoMetas.find((m) => m.id === albumId.value)
     selectedChapterId.value = matched?.id ?? album.photoMetas[0]?.id ?? ''
 
-    if (activeTab.value === 'preview') {
-      await loadPreview()
-    }
-
     recordBrowseHistory()
   } catch {
     // 保留 query 数据展示
@@ -485,6 +481,10 @@ const loadAlbumData = async () => {
     }
     chapterDownloadStatuses.value = map
   })
+
+  if (activeTab.value === 'preview') {
+    await loadPreview()
+  }
 }
 
 onMounted(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 进入专辑详情页时，若当前处于“预览”页签，将在下载进度更新后自动同步刷新预览内容。
  * 减少手动等待，提升预览内容的打开与一致性体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->