### PR TITLE
[codex] 修复批量章节选择框覆盖吸顶 Tab

### DIFF
--- a/src/components/album/AlbumChaptersTab.vue
+++ b/src/components/album/AlbumChaptersTab.vue
@@ -574,7 +574,7 @@ const toggleDisplayMode = () => {
   cursor: pointer;
   color: #d0c7c0;
   font-size: 20px;
-  z-index: 999;
+  z-index: 1;
   transition: color 0.18s ease;
   border-radius: 50%;
 }


### PR DESCRIPTION
Fixes #23

## 问题

章节网格进入批量下载模式后，选择框使用了 `z-index: 999`。

页面滚动到 Tab 吸顶位置时，checked 图标会越过内容层，覆盖在“章节”Tab 上方。`z-index` 可不是战斗力数值，堆得太高反而会引发异变 `(；´∀｀)`

## 修复

```diff
- z-index: 999;
+ z-index: 1;
```

调整后形成明确的层叠顺序：

```text
章节卡片 < 批量选择控件 < 吸顶 Tab
```

选择框仍显示在章节卡片上方，但不会再覆盖吸顶 Tab。

没有把 Tab 层级继续堆到 `1000`，层级军备竞赛可不是什么好文明。一行 CSS 精确解决问题，DA☆ZE `(￣▽￣)b`

## 修复前后

| 原始 `master` | 修复后 |
| --- | --- |
| ![原始表现](https://github.com/user-attachments/assets/efb75ea0-9751-41ba-a0df-51122fc5e63a) | ![修复后](https://github.com/user-attachments/assets/7f9ab23f-3fd9-4238-b2cb-0f5661c0f9ba) |

修复前，选中第 1 话并滚动后，checked 图标覆盖“章节 (21)”Tab。

修复后，相同状态下图标会进入 Tab 下方，Tab 文本和点击区域保持正常。

## 影响范围

- 保留现有选择、取消选择和禁用行为
- 不修改批量下载逻辑
- 不修改模板或事件绑定
- 不影响列表模式
- 不引入新的全局层级规则

## 验证

- [x] `git diff --check`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run build:android`
- [x] Android 双列网格未选中与已选中状态
- [x] Tab 滚动吸顶及点击
- [x] 横向滑动切换 Tab
- [x] Android WebView 无崩溃日志

验证设备：

```text
JQViewer_API_36
Android 16 / API 36
1080 × 2400 / 420 dpi
Android Emulator 37.1.11
```

异变解决，检查通过，可以放心审查了 `(｀・ω・´)ゞ`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 调整网格模式批量勾选框的显示层级，改善其与其他界面元素的叠加效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->