### PR TITLE
fix: 修复损坏下载图片的自动恢复

### DIFF
--- a/android/app/src/androidTest/java/io/github/jukomu/data/FileStoreDownloadValidationInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/FileStoreDownloadValidationInstrumentedTest.java
@@ -1,0 +1,113 @@
+package io.github.jukomu.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import io.github.jukomu.jmcomic.api.model.JmImage;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class FileStoreDownloadValidationInstrumentedTest {
+
+    @Test
+    public void acceptsCompleteDecodableDownloadSet() throws Exception {
+        File chapterDir = createChapterDir("valid");
+        try {
+            writeBitmap(new File(chapterDir, "page-1.png"), Bitmap.CompressFormat.PNG);
+            writeBitmap(new File(chapterDir, "page-2.jpg"), Bitmap.CompressFormat.JPEG);
+
+            FileStore.DownloadValidationResult result = FileStore.validateDownloadedImages(
+                chapterDir,
+                Arrays.asList(image(1, "page-1.png"), image(2, "page-2.jpg")));
+
+            assertTrue(result.isComplete());
+            assertEquals(2, result.getExpectedCount());
+            assertEquals(2, result.getValidCount());
+            assertEquals(0, result.getInvalidContentCount());
+            assertEquals(0, result.getMissingCount());
+        } finally {
+            deleteRecursively(chapterDir);
+        }
+    }
+
+    @Test
+    public void rejectsAndDeletesInvalidDownloadedContent() throws Exception {
+        File chapterDir = createChapterDir("invalid");
+        File corruptImage = new File(chapterDir, "page-2.jpg");
+        try {
+            writeBitmap(new File(chapterDir, "page-1.png"), Bitmap.CompressFormat.PNG);
+            try (FileOutputStream output = new FileOutputStream(corruptImage)) {
+                output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
+            }
+
+            List<JmImage> images = Arrays.asList(
+                image(1, "page-1.png"),
+                image(2, "page-2.jpg"),
+                image(3, "page-3.png"));
+            FileStore.DownloadValidationResult result =
+                FileStore.validateDownloadedImages(chapterDir, images);
+
+            assertFalse(result.isComplete());
+            assertEquals(3, result.getExpectedCount());
+            assertEquals(1, result.getValidCount());
+            assertEquals(1, result.getInvalidContentCount());
+            assertEquals(1, result.getMissingCount());
+            assertEquals(0, result.getCleanupFailureCount());
+            assertFalse(corruptImage.exists());
+            assertTrue(result.getFailureMessage().contains("2/3 张图片下载失败"));
+        } finally {
+            deleteRecursively(chapterDir);
+        }
+    }
+
+    private static File createChapterDir(String suffix) {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File directory = new File(context.getCacheDir(),
+            "download-validation-" + suffix + "-" + System.nanoTime());
+        if (!directory.mkdirs()) {
+            throw new IllegalStateException("Failed to create test directory");
+        }
+        return directory;
+    }
+
+    private static void writeBitmap(File target, Bitmap.CompressFormat format) throws Exception {
+        Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
+        try (FileOutputStream output = new FileOutputStream(target)) {
+            if (!bitmap.compress(format, 100, output)) {
+                throw new IllegalStateException("Failed to create image fixture");
+            }
+        } finally {
+            bitmap.recycle();
+        }
+    }
+
+    private static JmImage image(int sortOrder, String filename) {
+        return new JmImage("photo", "scramble", filename,
+            "https://example.invalid/" + filename, "", sortOrder);
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) return;
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+}

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
@@ -30,7 +30,7 @@ public class ImageCacheFileResponseInstrumentedTest {
 
     @Test
     public void decodeValidationRejectsGarbageAndAcceptsPng() {
-        assertFalse(ImageCache.isDecodableImage(
+        assertEquals(ImageValidator.Status.UNDECODABLE, ImageValidator.validate(
             "not-an-image".getBytes(StandardCharsets.UTF_8)));
 
         Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
@@ -38,20 +38,23 @@ public class ImageCacheFileResponseInstrumentedTest {
         try {
             assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output));
             byte[] png = output.toByteArray();
-            assertTrue(ImageCache.isDecodableImage(png));
-            assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(png, 33)));
+            assertEquals(ImageValidator.Status.VALID, ImageValidator.validate(png));
+            assertEquals(ImageValidator.Status.INCOMPLETE,
+                ImageValidator.validate(Arrays.copyOf(png, 33)));
 
             output.reset();
             assertTrue(bitmap.compress(Bitmap.CompressFormat.WEBP, 100, output));
             byte[] webp = output.toByteArray();
-            assertTrue(ImageCache.isDecodableImage(webp));
-            assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(webp, webp.length - 1)));
+            assertEquals(ImageValidator.Status.VALID, ImageValidator.validate(webp));
+            assertEquals(ImageValidator.Status.INCOMPLETE,
+                ImageValidator.validate(Arrays.copyOf(webp, webp.length - 1)));
 
             output.reset();
             assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, output));
             byte[] jpeg = output.toByteArray();
-            assertTrue(ImageCache.isDecodableImage(jpeg));
-            assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(jpeg, jpeg.length - 1)));
+            assertEquals(ImageValidator.Status.VALID, ImageValidator.validate(jpeg));
+            assertEquals(ImageValidator.Status.INCOMPLETE,
+                ImageValidator.validate(Arrays.copyOf(jpeg, jpeg.length - 1)));
         } finally {
             bitmap.recycle();
         }
@@ -68,7 +71,7 @@ public class ImageCacheFileResponseInstrumentedTest {
             assertTrue(cache.put("cache-header-photo/1", new byte[]{1, 2, 3}, "image/jpeg"));
 
             WebResourceResponse response = ImageCache.handleRequest(
-                "https://jqviewer.local/image/cache-header-photo/1?repair=1");
+                "https://jqviewer.local/image/cache-header-photo/1?retry=1");
 
             assertNotNull(response);
             assertNull(response.getEncoding());
@@ -96,6 +99,9 @@ public class ImageCacheFileResponseInstrumentedTest {
 
             assertEquals(validImage, ImageCache.validatedStoredImageFile(validImage));
             assertTrue(validImage.exists());
+            assertEquals(ImageValidator.Status.INCOMPLETE,
+                ImageValidator.validate(corruptImage));
+            assertTrue(corruptImage.exists());
             assertNull(ImageCache.validatedStoredImageFile(corruptImage));
             assertFalse(corruptImage.exists());
         } finally {

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
@@ -2,9 +2,12 @@ package io.github.jukomu.data;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.webkit.WebResourceResponse;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -13,12 +16,38 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 @RunWith(AndroidJUnit4.class)
 public class ImageCacheFileResponseInstrumentedTest {
+
+    @Test
+    public void decodeValidationRejectsGarbageAndAcceptsPng() {
+        assertFalse(ImageCache.isDecodableImage(
+            "not-an-image".getBytes(StandardCharsets.UTF_8)));
+
+        Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output));
+            byte[] png = output.toByteArray();
+            assertTrue(ImageCache.isDecodableImage(png));
+            assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(png, 33)));
+
+            output.reset();
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSLESS, 100, output));
+            byte[] webp = output.toByteArray();
+            assertTrue(ImageCache.isDecodableImage(webp));
+            assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(webp, webp.length - 1)));
+        } finally {
+            bitmap.recycle();
+        }
+    }
 
     @Test
     public void fullImageFallsBackToFileStreamWhenReservationIsUnavailable() throws Exception {

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
@@ -42,7 +42,7 @@ public class ImageCacheFileResponseInstrumentedTest {
             assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(png, 33)));
 
             output.reset();
-            assertTrue(bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSLESS, 100, output));
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.WEBP, 100, output));
             byte[] webp = output.toByteArray();
             assertTrue(ImageCache.isDecodableImage(webp));
             assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(webp, webp.length - 1)));

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
@@ -3,6 +3,7 @@ package io.github.jukomu.data;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -44,8 +45,36 @@ public class ImageCacheFileResponseInstrumentedTest {
             byte[] webp = output.toByteArray();
             assertTrue(ImageCache.isDecodableImage(webp));
             assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(webp, webp.length - 1)));
+
+            output.reset();
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, output));
+            byte[] jpeg = output.toByteArray();
+            assertTrue(ImageCache.isDecodableImage(jpeg));
+            assertFalse(ImageCache.isDecodableImage(Arrays.copyOf(jpeg, jpeg.length - 1)));
         } finally {
             bitmap.recycle();
+        }
+    }
+
+    @Test
+    public void interceptedImageResponseDisablesWebViewCaching() throws Exception {
+        ImageCache cache = ImageCache.getInstance();
+        cache.applyPolicy(new CacheCapacityPolicy().calculate(
+            16L, 64L * CacheCapacityPolicy.MIB, false,
+            CacheCapacityPolicy.PressureLevel.NORMAL));
+        cache.clear();
+        try {
+            assertTrue(cache.put("cache-header-photo/1", new byte[]{1, 2, 3}, "image/jpeg"));
+
+            WebResourceResponse response = ImageCache.handleRequest(
+                "https://jqviewer.local/image/cache-header-photo/1?repair=1");
+
+            assertNotNull(response);
+            assertNull(response.getEncoding());
+            assertNoCache(response);
+            response.getData().close();
+        } finally {
+            cache.clear();
         }
     }
 
@@ -67,6 +96,7 @@ public class ImageCacheFileResponseInstrumentedTest {
 
             WebResourceResponse response = ImageCache.createFileResponse(image);
             assertEquals("image/jpeg", response.getMimeType());
+            assertNoCache(response);
             try (InputStream input = response.getData()) {
                 byte[] header = new byte[3];
                 assertEquals(3, input.read(header));
@@ -78,5 +108,13 @@ public class ImageCacheFileResponseInstrumentedTest {
         } finally {
             image.delete();
         }
+    }
+
+    private static void assertNoCache(WebResourceResponse response) {
+        assertNotNull(response.getResponseHeaders());
+        assertEquals("no-store, no-cache, must-revalidate, max-age=0",
+            response.getResponseHeaders().get("Cache-Control"));
+        assertEquals("no-cache", response.getResponseHeaders().get("Pragma"));
+        assertEquals("0", response.getResponseHeaders().get("Expires"));
     }
 }

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageCacheFileResponseInstrumentedTest.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
@@ -75,6 +76,32 @@ public class ImageCacheFileResponseInstrumentedTest {
             response.getData().close();
         } finally {
             cache.clear();
+        }
+    }
+
+    @Test
+    public void storedImageValidationRejectsAndDeletesCorruptFile() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File validImage = File.createTempFile("image-cache-valid-", ".png", context.getCacheDir());
+        File corruptImage = File.createTempFile(
+            "image-cache-corrupt-", ".jpg", context.getCacheDir());
+        Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
+        try {
+            try (FileOutputStream output = new FileOutputStream(validImage)) {
+                assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output));
+            }
+            try (FileOutputStream output = new FileOutputStream(corruptImage)) {
+                output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
+            }
+
+            assertEquals(validImage, ImageCache.validatedStoredImageFile(validImage));
+            assertTrue(validImage.exists());
+            assertNull(ImageCache.validatedStoredImageFile(corruptImage));
+            assertFalse(corruptImage.exists());
+        } finally {
+            bitmap.recycle();
+            validImage.delete();
+            corruptImage.delete();
         }
     }
 

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageValidatorInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageValidatorInstrumentedTest.java
@@ -10,18 +10,15 @@ import android.graphics.Bitmap;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
-import io.github.jukomu.jmcomic.api.model.JmImage;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Arrays;
-import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
-public class FileStoreDownloadValidationInstrumentedTest {
+public class ImageValidatorInstrumentedTest {
 
     @Test
     public void acceptsCompleteDecodableDownloadSet() throws Exception {
@@ -30,22 +27,47 @@ public class FileStoreDownloadValidationInstrumentedTest {
             writeBitmap(new File(chapterDir, "page-1.png"), Bitmap.CompressFormat.PNG);
             writeBitmap(new File(chapterDir, "page-2.jpg"), Bitmap.CompressFormat.JPEG);
 
-            FileStore.DownloadValidationResult result = FileStore.validateDownloadedImages(
-                chapterDir,
-                Arrays.asList(image(1, "page-1.png"), image(2, "page-2.jpg")));
+            ImageValidator.DownloadValidationResult result =
+                ImageValidator.validateDownloadedImages(chapterDir, 2,
+                    Arrays.asList("page-1.png", "page-2.jpg"));
 
             assertTrue(result.isComplete());
             assertEquals(2, result.getExpectedCount());
+            assertEquals(2, result.getMappedCount());
             assertEquals(2, result.getValidCount());
             assertEquals(0, result.getInvalidContentCount());
             assertEquals(0, result.getMissingCount());
+            assertTrue(result.getInvalidFiles().isEmpty());
         } finally {
             deleteRecursively(chapterDir);
         }
     }
 
     @Test
-    public void rejectsAndDeletesInvalidDownloadedContent() throws Exception {
+    public void rejectsUnexpectedPageMappingsWithoutReportingCompletedProgress()
+        throws Exception {
+        File chapterDir = createChapterDir("extra-mapping");
+        try {
+            writeBitmap(new File(chapterDir, "page-1.png"), Bitmap.CompressFormat.PNG);
+            writeBitmap(new File(chapterDir, "page-2.png"), Bitmap.CompressFormat.PNG);
+
+            ImageValidator.DownloadValidationResult result =
+                ImageValidator.validateDownloadedImages(chapterDir, 1,
+                    Arrays.asList("page-1.png", "page-2.png"));
+
+            assertFalse(result.isComplete());
+            assertEquals(1, result.getExpectedCount());
+            assertEquals(2, result.getMappedCount());
+            assertEquals(2, result.getValidCount());
+            assertEquals(0, result.getFailedProgressCount());
+            assertTrue(result.getFailureMessage(0).contains("页映射 2/1"));
+        } finally {
+            deleteRecursively(chapterDir);
+        }
+    }
+
+    @Test
+    public void reportsInvalidAndMissingFilesWithoutDeletingThem() throws Exception {
         File chapterDir = createChapterDir("invalid");
         File corruptImage = new File(chapterDir, "page-2.jpg");
         try {
@@ -54,21 +76,42 @@ public class FileStoreDownloadValidationInstrumentedTest {
                 output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
             }
 
-            List<JmImage> images = Arrays.asList(
-                image(1, "page-1.png"),
-                image(2, "page-2.jpg"),
-                image(3, "page-3.png"));
-            FileStore.DownloadValidationResult result =
-                FileStore.validateDownloadedImages(chapterDir, images);
+            ImageValidator.DownloadValidationResult result =
+                ImageValidator.validateDownloadedImages(chapterDir, 3,
+                    Arrays.asList("page-1.png", "page-2.jpg", "page-3.png"));
 
             assertFalse(result.isComplete());
             assertEquals(3, result.getExpectedCount());
             assertEquals(1, result.getValidCount());
             assertEquals(1, result.getInvalidContentCount());
             assertEquals(1, result.getMissingCount());
-            assertEquals(0, result.getCleanupFailureCount());
-            assertFalse(corruptImage.exists());
-            assertTrue(result.getFailureMessage().contains("2/3 张图片下载失败"));
+            assertEquals(Arrays.asList(corruptImage.getCanonicalFile()),
+                result.getInvalidFiles());
+            assertTrue(corruptImage.exists());
+            assertTrue(result.getFailureMessage(0).contains("2/3 张图片下载失败"));
+        } finally {
+            deleteRecursively(chapterDir);
+        }
+    }
+
+    @Test
+    public void distinguishesMissingEmptyIncompleteAndUndecodableInput() throws Exception {
+        File chapterDir = createChapterDir("status");
+        File empty = new File(chapterDir, "empty.jpg");
+        File incomplete = new File(chapterDir, "incomplete.jpg");
+        try {
+            assertTrue(empty.createNewFile());
+            try (FileOutputStream output = new FileOutputStream(incomplete)) {
+                output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
+            }
+
+            assertEquals(ImageValidator.Status.MISSING,
+                ImageValidator.validate(new File(chapterDir, "missing.jpg")));
+            assertEquals(ImageValidator.Status.EMPTY, ImageValidator.validate(empty));
+            assertEquals(ImageValidator.Status.INCOMPLETE,
+                ImageValidator.validate(incomplete));
+            assertEquals(ImageValidator.Status.UNDECODABLE,
+                ImageValidator.validate(new byte[]{1, 2, 3, 4}));
         } finally {
             deleteRecursively(chapterDir);
         }
@@ -77,7 +120,7 @@ public class FileStoreDownloadValidationInstrumentedTest {
     private static File createChapterDir(String suffix) {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         File directory = new File(context.getCacheDir(),
-            "download-validation-" + suffix + "-" + System.nanoTime());
+            "image-validation-" + suffix + "-" + System.nanoTime());
         if (!directory.mkdirs()) {
             throw new IllegalStateException("Failed to create test directory");
         }
@@ -93,11 +136,6 @@ public class FileStoreDownloadValidationInstrumentedTest {
         } finally {
             bitmap.recycle();
         }
-    }
-
-    private static JmImage image(int sortOrder, String filename) {
-        return new JmImage("photo", "scramble", filename,
-            "https://example.invalid/" + filename, "", sortOrder);
     }
 
     private static void deleteRecursively(File file) {

--- a/android/app/src/androidTest/java/io/github/jukomu/service/DownloadServiceCompletedValidationInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/service/DownloadServiceCompletedValidationInstrumentedTest.java
@@ -1,7 +1,6 @@
 package io.github.jukomu.service;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -76,24 +75,40 @@ public class DownloadServiceCompletedValidationInstrumentedTest {
     }
 
     @Test
-    public void corruptCompletedDownloadIsDowngradedAndPreparedForRedownload()
+    public void openingCompletedDownloadDoesNotDecodeEveryImage()
         throws Exception {
         File imageFile = createCompletedTask();
         try (FileOutputStream output = new FileOutputStream(imageFile)) {
             output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
         }
 
+        JSONObject photo = createService().getDownloadedPhoto(albumId, chapterId);
+
+        assertEquals(chapterId, photo.getString("id"));
+        assertEquals(1, photo.getJSONArray("images").length());
+        assertEquals("completed", downloadStore.getTask(taskId).getString("status"));
+        assertTrue(imageFile.exists());
+        assertNotNull(fileStore.getImageFileByPhotoId(chapterId, 1));
+    }
+
+    @Test
+    public void inconsistentPageMappingIsRejectedWithoutDecodingFiles()
+        throws Exception {
+        File imageFile = createCompletedTask();
+        writeBitmap(imageFile);
+        downloadStore.deleteImages(taskId);
+
         DownloadService.InvalidDownloadedContentException error = assertThrows(
             DownloadService.InvalidDownloadedContentException.class,
             () -> createService().getDownloadedPhoto(albumId, chapterId));
 
-        assertTrue(error.getMessage().contains("1/1 张图片下载失败"));
+        assertTrue(error.getMessage().contains("页映射 0/1"));
         JSONObject task = downloadStore.getTask(taskId);
         assertNotNull(task);
         assertEquals("failed", task.getString("status"));
         assertEquals(0, task.getInt("downloadedPages"));
-        assertTrue(task.getString("error").contains("文件校验未通过"));
-        assertFalse(imageFile.exists());
+        assertTrue(task.getString("error").contains("页映射 0/1"));
+        assertTrue(imageFile.exists());
         assertNull(fileStore.getImageFileByPhotoId(chapterId, 1));
     }
 

--- a/android/app/src/androidTest/java/io/github/jukomu/service/DownloadServiceCompletedValidationInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/service/DownloadServiceCompletedValidationInstrumentedTest.java
@@ -1,0 +1,162 @@
+package io.github.jukomu.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import io.github.jukomu.data.DownloadStore;
+import io.github.jukomu.data.FileStore;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@RunWith(AndroidJUnit4.class)
+public class DownloadServiceCompletedValidationInstrumentedTest {
+
+    private Context context;
+    private DownloadStore downloadStore;
+    private FileStore fileStore;
+    private ExecutorService prepareExecutor;
+    private String albumId;
+    private String chapterId;
+    private String taskId;
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        downloadStore = DownloadStore.getInstance(context);
+        fileStore = FileStore.getInstance();
+        fileStore.init(context, downloadStore, false);
+        prepareExecutor = Executors.newSingleThreadExecutor();
+        String suffix = Long.toString(System.nanoTime());
+        albumId = "validation-album-" + suffix;
+        chapterId = "validation-chapter-" + suffix;
+        taskId = albumId + "_" + chapterId;
+    }
+
+    @After
+    public void tearDown() {
+        prepareExecutor.shutdownNow();
+        fileStore.deleteChapter(albumId, chapterId);
+        downloadStore.deleteImages(taskId);
+        downloadStore.deleteTask(taskId);
+    }
+
+    @Test
+    public void completedDownloadWithValidImageCanBeOpened() throws Exception {
+        File imageFile = createCompletedTask();
+        writeBitmap(imageFile);
+
+        JSONObject photo = createService().getDownloadedPhoto(albumId, chapterId);
+
+        assertEquals(chapterId, photo.getString("id"));
+        assertEquals(1, photo.getJSONArray("images").length());
+        assertEquals("completed", downloadStore.getTask(taskId).getString("status"));
+        assertTrue(imageFile.exists());
+    }
+
+    @Test
+    public void corruptCompletedDownloadIsDowngradedAndPreparedForRedownload()
+        throws Exception {
+        File imageFile = createCompletedTask();
+        try (FileOutputStream output = new FileOutputStream(imageFile)) {
+            output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
+        }
+
+        DownloadService.InvalidDownloadedContentException error = assertThrows(
+            DownloadService.InvalidDownloadedContentException.class,
+            () -> createService().getDownloadedPhoto(albumId, chapterId));
+
+        assertTrue(error.getMessage().contains("1/1 张图片下载失败"));
+        JSONObject task = downloadStore.getTask(taskId);
+        assertNotNull(task);
+        assertEquals("failed", task.getString("status"));
+        assertEquals(0, task.getInt("downloadedPages"));
+        assertTrue(task.getString("error").contains("文件校验未通过"));
+        assertFalse(imageFile.exists());
+        assertNull(fileStore.getImageFileByPhotoId(chapterId, 1));
+    }
+
+    @Test
+    public void startupValidationDowngradesCorruptTaskWithoutDeletingItsFile()
+        throws Exception {
+        File imageFile = createCompletedTask();
+        try (FileOutputStream output = new FileOutputStream(imageFile)) {
+            output.write(new byte[]{(byte) 0xff, (byte) 0xd8, 1, 2, 3});
+        }
+
+        downloadStore.validateOnStartup(fileStore.getBaseDir());
+        fileStore.init(context, downloadStore, false);
+
+        JSONObject task = downloadStore.getTask(taskId);
+        assertNotNull(task);
+        assertEquals("failed", task.getString("status"));
+        assertEquals(0, task.getInt("downloadedPages"));
+        assertTrue(imageFile.exists());
+        assertNull(fileStore.getImageFileByPhotoId(chapterId, 1));
+    }
+
+    @Test
+    public void refreshingDownloadMetadataRemovesStalePageMappings() throws Exception {
+        JmImage first = new JmImage(chapterId, "scramble", "page-1.png",
+            "https://example.invalid/page-1.png", "", 1);
+        JmImage stale = new JmImage(chapterId, "scramble", "page-2.png",
+            "https://example.invalid/page-2.png", "", 2);
+        downloadStore.insertTask(taskId, albumId, chapterId,
+            "Album", "Chapter", "");
+        downloadStore.insertImages(taskId, Arrays.asList(first, stale));
+        assertEquals(2, downloadStore.getImages(taskId).size());
+
+        downloadStore.insertImages(taskId, Collections.singletonList(first));
+
+        assertEquals(1, downloadStore.getImages(taskId).size());
+        assertEquals(1, downloadStore.getImages(taskId).get(0).getInt("sortOrder"));
+    }
+
+    private DownloadService createService() {
+        return new DownloadService(downloadStore, fileStore, null, prepareExecutor,
+            null, context);
+    }
+
+    private File createCompletedTask() {
+        JmImage image = new JmImage(chapterId, "scramble", "page-1.png",
+            "https://example.invalid/page-1.png", "", 1);
+        downloadStore.insertTask(taskId, albumId, chapterId,
+            "Album", "Chapter", "");
+        downloadStore.insertImages(taskId, Collections.singletonList(image));
+        downloadStore.updateTaskDetail(taskId, 1, "", "[]", 1, false);
+        downloadStore.updateCompleted(taskId, 1, 1);
+        File chapterDir = fileStore.ensureChapterDir(albumId, chapterId);
+        fileStore.refreshMappings(albumId, chapterId, downloadStore);
+        return new File(chapterDir, image.getFilename());
+    }
+
+    private static void writeBitmap(File target) throws Exception {
+        Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
+        try (FileOutputStream output = new FileOutputStream(target)) {
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output));
+        } finally {
+            bitmap.recycle();
+        }
+    }
+}

--- a/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import io.github.jukomu.data.CacheCapacityPolicy;
 import io.github.jukomu.data.FileStore;
 import io.github.jukomu.data.ImageCache;
+import io.github.jukomu.data.ImageValidator;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -146,9 +147,9 @@ public class PreloadServiceTest {
     }
 
     @Test
-    public void repairImageBypassesCorruptMemoryCache() throws Exception {
-        byte[] repairedBytes = createPng();
-        imageCache.put("repair-photo/1",
+    public void retryImageBypassesCorruptMemoryCache() throws Exception {
+        byte[] retriedBytes = createPng();
+        imageCache.put("retry-photo/1",
             "not-an-image".getBytes(StandardCharsets.UTF_8), "image/jpeg");
 
         AtomicInteger fetchCount = new AtomicInteger();
@@ -158,23 +159,23 @@ public class PreloadServiceTest {
             new CacheCapacityPolicy(), 2,
             image -> {
                 fetchCount.incrementAndGet();
-                return repairedBytes;
+                return retriedBytes;
             });
 
-        RepairOutcome outcome = repair(service, "repair-photo", repairImage());
+        RetryOutcome outcome = retry(service, "retry-photo", retryImage());
 
         assertNull(outcome.error);
-        assertEquals(Boolean.FALSE, outcome.persisted);
+        assertTrue(outcome.success);
         assertEquals(1, fetchCount.get());
-        ImageCache.ImageEntry entry = imageCache.get("repair-photo/1");
+        ImageCache.ImageEntry entry = imageCache.get("retry-photo/1");
         assertNotNull(entry);
-        assertArrayEquals(repairedBytes, entry.data);
-        assertTrue(ImageCache.isDecodableImage(entry.data));
+        assertArrayEquals(retriedBytes, entry.data);
+        assertEquals(ImageValidator.Status.VALID, ImageValidator.validate(entry.data));
     }
 
     @Test
-    public void repairImageReportsFetchFailureAndReleasesPermit() throws Exception {
-        byte[] repairedBytes = createPng();
+    public void retryImageReportsFetchFailureAndReleasesPermit() throws Exception {
+        byte[] retriedBytes = createPng();
         AtomicInteger fetchCount = new AtomicInteger();
         PreloadService service = new PreloadService(
             imageCache, FileStore.getInstance(), null, null,
@@ -184,41 +185,41 @@ public class PreloadServiceTest {
                 if (fetchCount.incrementAndGet() == 1) {
                     throw new IOException("fetch failed");
                 }
-                return repairedBytes;
+                return retriedBytes;
             });
 
-        RepairOutcome failed = repair(service, "fetch-failure-photo", repairImage());
-        RepairOutcome retried = repair(service, "fetch-failure-photo", repairImage());
+        RetryOutcome failed = retry(service, "fetch-failure-photo", retryImage());
+        RetryOutcome retried = retry(service, "fetch-failure-photo", retryImage());
 
         assertNotNull(failed.error);
-        assertNull(failed.persisted);
+        assertFalse(failed.success);
         assertNull(retried.error);
-        assertEquals(Boolean.FALSE, retried.persisted);
+        assertTrue(retried.success);
         assertEquals(2, fetchCount.get());
     }
 
     @Test
-    public void repairImageRejectsUndecodableBytesWithoutReplacingCache() throws Exception {
+    public void retryImageRejectsUndecodableBytesWithoutReplacingCache() throws Exception {
         byte[] originalBytes = "old-corrupt-cache".getBytes(StandardCharsets.UTF_8);
-        imageCache.put("invalid-repair-photo/1", originalBytes, "image/jpeg");
+        imageCache.put("invalid-retry-photo/1", originalBytes, "image/jpeg");
         PreloadService service = new PreloadService(
             imageCache, FileStore.getInstance(), null, null,
             imageExecutor, networkExecutor, null, null,
             new CacheCapacityPolicy(), 1,
             image -> "not-an-image".getBytes(StandardCharsets.UTF_8));
 
-        RepairOutcome outcome = repair(service, "invalid-repair-photo", repairImage());
+        RetryOutcome outcome = retry(service, "invalid-retry-photo", retryImage());
 
         assertNotNull(outcome.error);
-        assertNull(outcome.persisted);
+        assertFalse(outcome.success);
         assertTrue(outcome.error.getMessage().contains("无法解码"));
-        assertArrayEquals(originalBytes, imageCache.get("invalid-repair-photo/1").data);
+        assertArrayEquals(originalBytes, imageCache.get("invalid-retry-photo/1").data);
     }
 
     @Test
-    public void repairImageDoesNotFetchOrWriteDuringCompletePressure() throws Exception {
+    public void retryImageDoesNotFetchOrWriteDuringCompletePressure() throws Exception {
         byte[] originalBytes = "old-cache".getBytes(StandardCharsets.UTF_8);
-        imageCache.put("complete-repair-photo/1", originalBytes, "image/jpeg");
+        imageCache.put("complete-retry-photo/1", originalBytes, "image/jpeg");
         AtomicInteger fetchCount = new AtomicInteger();
         PreloadService service = new PreloadService(
             imageCache, FileStore.getInstance(), null, null,
@@ -230,22 +231,22 @@ public class PreloadServiceTest {
             });
         service.setMemoryPressureLevel(CacheCapacityPolicy.PressureLevel.COMPLETE);
 
-        RepairOutcome outcome = repair(service, "complete-repair-photo", repairImage());
+        RetryOutcome outcome = retry(service, "complete-retry-photo", retryImage());
 
         assertNotNull(outcome.error);
-        assertNull(outcome.persisted);
+        assertFalse(outcome.success);
         assertEquals(0, fetchCount.get());
-        assertArrayEquals(originalBytes, imageCache.get("complete-repair-photo/1").data);
+        assertArrayEquals(originalBytes, imageCache.get("complete-retry-photo/1").data);
     }
 
     @Test
-    public void repairImageDiscardsInFlightResultDuringCompletePressure() throws Exception {
+    public void retryImageDiscardsInFlightResultDuringCompletePressure() throws Exception {
         byte[] originalBytes = "old-cache".getBytes(StandardCharsets.UTF_8);
-        imageCache.put("in-flight-repair-photo/1", originalBytes, "image/jpeg");
+        imageCache.put("in-flight-retry-photo/1", originalBytes, "image/jpeg");
         CountDownLatch fetchStarted = new CountDownLatch(1);
         CountDownLatch allowFetchFinish = new CountDownLatch(1);
         CountDownLatch completed = new CountDownLatch(1);
-        AtomicReference<Boolean> persisted = new AtomicReference<>();
+        AtomicReference<Boolean> success = new AtomicReference<>(false);
         AtomicReference<Exception> error = new AtomicReference<>();
         PreloadService service = new PreloadService(
             imageCache, FileStore.getInstance(), null, null,
@@ -257,17 +258,17 @@ public class PreloadServiceTest {
                 return createPng();
             });
 
-        service.repairImage("in-flight-repair-photo", repairImage(),
-            new PreloadService.ImageRepairCallback() {
+        service.retryImage("in-flight-retry-photo", retryImage(),
+            new PreloadService.ImageRetryCallback() {
                 @Override
-                public void onSuccess(boolean wasPersisted) {
-                    persisted.set(wasPersisted);
+                public void onSuccess() {
+                    success.set(true);
                     completed.countDown();
                 }
 
                 @Override
-                public void onError(Exception repairError) {
-                    error.set(repairError);
+                public void onError(Exception retryError) {
+                    error.set(retryError);
                     completed.countDown();
                 }
             });
@@ -278,33 +279,33 @@ public class PreloadServiceTest {
 
         assertTrue(completed.await(2, TimeUnit.SECONDS));
         assertNotNull(error.get());
-        assertNull(persisted.get());
-        assertArrayEquals(originalBytes, imageCache.get("in-flight-repair-photo/1").data);
+        assertFalse(success.get());
+        assertArrayEquals(originalBytes, imageCache.get("in-flight-retry-photo/1").data);
     }
 
-    private RepairOutcome repair(PreloadService service, String photoId, JSONObject image)
+    private RetryOutcome retry(PreloadService service, String photoId, JSONObject image)
         throws Exception {
         CountDownLatch completed = new CountDownLatch(1);
-        AtomicReference<Boolean> persisted = new AtomicReference<>();
+        AtomicReference<Boolean> success = new AtomicReference<>(false);
         AtomicReference<Exception> error = new AtomicReference<>();
-        service.repairImage(photoId, image, new PreloadService.ImageRepairCallback() {
+        service.retryImage(photoId, image, new PreloadService.ImageRetryCallback() {
             @Override
-            public void onSuccess(boolean wasPersisted) {
-                persisted.set(wasPersisted);
+            public void onSuccess() {
+                success.set(true);
                 completed.countDown();
             }
 
             @Override
-            public void onError(Exception repairError) {
-                error.set(repairError);
+            public void onError(Exception retryError) {
+                error.set(retryError);
                 completed.countDown();
             }
         });
         assertTrue(completed.await(2, TimeUnit.SECONDS));
-        return new RepairOutcome(persisted.get(), error.get());
+        return new RetryOutcome(success.get(), error.get());
     }
 
-    private static JSONObject repairImage() throws Exception {
+    private static JSONObject retryImage() throws Exception {
         return new JSONObject()
             .put("sortOrder", 1)
             .put("scrambleId", "scramble")
@@ -325,12 +326,12 @@ public class PreloadServiceTest {
         }
     }
 
-    private static final class RepairOutcome {
-        final Boolean persisted;
+    private static final class RetryOutcome {
+        final boolean success;
         final Exception error;
 
-        RepairOutcome(Boolean persisted, Exception error) {
-            this.persisted = persisted;
+        RetryOutcome(boolean success, Exception error) {
+            this.success = success;
             this.error = error;
         }
     }

--- a/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
@@ -15,14 +15,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -150,9 +151,7 @@ public class PreloadServiceTest {
         imageCache.put("repair-photo/1",
             "not-an-image".getBytes(StandardCharsets.UTF_8), "image/jpeg");
 
-        CountDownLatch completed = new CountDownLatch(1);
         AtomicInteger fetchCount = new AtomicInteger();
-        AtomicReference<Exception> error = new AtomicReference<>();
         PreloadService service = new PreloadService(
             imageCache, FileStore.getInstance(), null, null,
             imageExecutor, networkExecutor, null, null,
@@ -162,14 +161,136 @@ public class PreloadServiceTest {
                 return repairedBytes;
             });
 
-        JSONObject image = new JSONObject()
-            .put("sortOrder", 1)
-            .put("scrambleId", "scramble")
-            .put("filename", "page.png")
-            .put("url", "https://example.invalid/page.png");
-        service.repairImage("repair-photo", image, new PreloadService.ImageRepairCallback() {
+        RepairOutcome outcome = repair(service, "repair-photo", repairImage());
+
+        assertNull(outcome.error);
+        assertEquals(Boolean.FALSE, outcome.persisted);
+        assertEquals(1, fetchCount.get());
+        ImageCache.ImageEntry entry = imageCache.get("repair-photo/1");
+        assertNotNull(entry);
+        assertArrayEquals(repairedBytes, entry.data);
+        assertTrue(ImageCache.isDecodableImage(entry.data));
+    }
+
+    @Test
+    public void repairImageReportsFetchFailureAndReleasesPermit() throws Exception {
+        byte[] repairedBytes = createPng();
+        AtomicInteger fetchCount = new AtomicInteger();
+        PreloadService service = new PreloadService(
+            imageCache, FileStore.getInstance(), null, null,
+            imageExecutor, networkExecutor, null, null,
+            new CacheCapacityPolicy(), 1,
+            image -> {
+                if (fetchCount.incrementAndGet() == 1) {
+                    throw new IOException("fetch failed");
+                }
+                return repairedBytes;
+            });
+
+        RepairOutcome failed = repair(service, "fetch-failure-photo", repairImage());
+        RepairOutcome retried = repair(service, "fetch-failure-photo", repairImage());
+
+        assertNotNull(failed.error);
+        assertNull(failed.persisted);
+        assertNull(retried.error);
+        assertEquals(Boolean.FALSE, retried.persisted);
+        assertEquals(2, fetchCount.get());
+    }
+
+    @Test
+    public void repairImageRejectsUndecodableBytesWithoutReplacingCache() throws Exception {
+        byte[] originalBytes = "old-corrupt-cache".getBytes(StandardCharsets.UTF_8);
+        imageCache.put("invalid-repair-photo/1", originalBytes, "image/jpeg");
+        PreloadService service = new PreloadService(
+            imageCache, FileStore.getInstance(), null, null,
+            imageExecutor, networkExecutor, null, null,
+            new CacheCapacityPolicy(), 1,
+            image -> "not-an-image".getBytes(StandardCharsets.UTF_8));
+
+        RepairOutcome outcome = repair(service, "invalid-repair-photo", repairImage());
+
+        assertNotNull(outcome.error);
+        assertNull(outcome.persisted);
+        assertTrue(outcome.error.getMessage().contains("无法解码"));
+        assertArrayEquals(originalBytes, imageCache.get("invalid-repair-photo/1").data);
+    }
+
+    @Test
+    public void repairImageDoesNotFetchOrWriteDuringCompletePressure() throws Exception {
+        byte[] originalBytes = "old-cache".getBytes(StandardCharsets.UTF_8);
+        imageCache.put("complete-repair-photo/1", originalBytes, "image/jpeg");
+        AtomicInteger fetchCount = new AtomicInteger();
+        PreloadService service = new PreloadService(
+            imageCache, FileStore.getInstance(), null, null,
+            imageExecutor, networkExecutor, null, null,
+            new CacheCapacityPolicy(), 1,
+            image -> {
+                fetchCount.incrementAndGet();
+                return createPng();
+            });
+        service.setMemoryPressureLevel(CacheCapacityPolicy.PressureLevel.COMPLETE);
+
+        RepairOutcome outcome = repair(service, "complete-repair-photo", repairImage());
+
+        assertNotNull(outcome.error);
+        assertNull(outcome.persisted);
+        assertEquals(0, fetchCount.get());
+        assertArrayEquals(originalBytes, imageCache.get("complete-repair-photo/1").data);
+    }
+
+    @Test
+    public void repairImageDiscardsInFlightResultDuringCompletePressure() throws Exception {
+        byte[] originalBytes = "old-cache".getBytes(StandardCharsets.UTF_8);
+        imageCache.put("in-flight-repair-photo/1", originalBytes, "image/jpeg");
+        CountDownLatch fetchStarted = new CountDownLatch(1);
+        CountDownLatch allowFetchFinish = new CountDownLatch(1);
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Boolean> persisted = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+        PreloadService service = new PreloadService(
+            imageCache, FileStore.getInstance(), null, null,
+            imageExecutor, networkExecutor, null, null,
+            new CacheCapacityPolicy(), 1,
+            image -> {
+                fetchStarted.countDown();
+                allowFetchFinish.await(2, TimeUnit.SECONDS);
+                return createPng();
+            });
+
+        service.repairImage("in-flight-repair-photo", repairImage(),
+            new PreloadService.ImageRepairCallback() {
+                @Override
+                public void onSuccess(boolean wasPersisted) {
+                    persisted.set(wasPersisted);
+                    completed.countDown();
+                }
+
+                @Override
+                public void onError(Exception repairError) {
+                    error.set(repairError);
+                    completed.countDown();
+                }
+            });
+        assertTrue(fetchStarted.await(2, TimeUnit.SECONDS));
+
+        service.setMemoryPressureLevel(CacheCapacityPolicy.PressureLevel.COMPLETE);
+        allowFetchFinish.countDown();
+
+        assertTrue(completed.await(2, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertNull(persisted.get());
+        assertArrayEquals(originalBytes, imageCache.get("in-flight-repair-photo/1").data);
+    }
+
+    private RepairOutcome repair(PreloadService service, String photoId, JSONObject image)
+        throws Exception {
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Boolean> persisted = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+        service.repairImage(photoId, image, new PreloadService.ImageRepairCallback() {
             @Override
-            public void onSuccess(boolean persisted) {
+            public void onSuccess(boolean wasPersisted) {
+                persisted.set(wasPersisted);
                 completed.countDown();
             }
 
@@ -179,14 +300,16 @@ public class PreloadServiceTest {
                 completed.countDown();
             }
         });
+        assertTrue(completed.await(2, TimeUnit.SECONDS));
+        return new RepairOutcome(persisted.get(), error.get());
+    }
 
-        assertTrue(completed.await(1, TimeUnit.SECONDS));
-        assertNull(error.get());
-        assertEquals(1, fetchCount.get());
-        ImageCache.ImageEntry entry = imageCache.get("repair-photo/1");
-        assertNotNull(entry);
-        assertArrayEquals(repairedBytes, entry.data);
-        assertTrue(ImageCache.isDecodableImage(entry.data));
+    private static JSONObject repairImage() throws Exception {
+        return new JSONObject()
+            .put("sortOrder", 1)
+            .put("scrambleId", "scramble")
+            .put("filename", "page.png")
+            .put("url", "https://example.invalid/page.png");
     }
 
     private static byte[] createPng() {
@@ -199,6 +322,16 @@ public class PreloadServiceTest {
             return output.toByteArray();
         } finally {
             bitmap.recycle();
+        }
+    }
+
+    private static final class RepairOutcome {
+        final Boolean persisted;
+        final Exception error;
+
+        RepairOutcome(Boolean persisted, Exception error) {
+            this.persisted = persisted;
+            this.error = error;
         }
     }
 }

--- a/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -217,6 +218,26 @@ public class PreloadServiceTest {
     }
 
     @Test
+    public void retryImageKeepsExistingCacheWhenReplacementCannotFit() throws Exception {
+        byte[] originalBytes = "old-cache".getBytes(StandardCharsets.UTF_8);
+        byte[] retriedBytes = createPng();
+        imageCache.put("oversized-retry-photo/1", originalBytes, "image/jpeg");
+        setCacheCapacity(retriedBytes.length - 1L);
+        PreloadService service = new PreloadService(
+            imageCache, FileStore.getInstance(), null, null,
+            imageExecutor, networkExecutor, null, null,
+            new CacheCapacityPolicy(), 1,
+            image -> retriedBytes);
+
+        RetryOutcome outcome = retry(service, "oversized-retry-photo", retryImage());
+
+        assertNotNull(outcome.error);
+        assertFalse(outcome.success);
+        assertTrue(outcome.error.getMessage().contains("无法写入内存缓存"));
+        assertArrayEquals(originalBytes, imageCache.get("oversized-retry-photo/1").data);
+    }
+
+    @Test
     public void retryImageDoesNotFetchOrWriteDuringCompletePressure() throws Exception {
         byte[] originalBytes = "old-cache".getBytes(StandardCharsets.UTF_8);
         imageCache.put("complete-retry-photo/1", originalBytes, "image/jpeg");
@@ -324,6 +345,12 @@ public class PreloadServiceTest {
         } finally {
             bitmap.recycle();
         }
+    }
+
+    private void setCacheCapacity(long capacity) throws Exception {
+        Field field = ImageCache.class.getDeclaredField("capacity");
+        field.setAccessible(true);
+        field.setLong(imageCache, capacity);
     }
 
     private static final class RetryOutcome {

--- a/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/service/PreloadServiceTest.java
@@ -2,6 +2,8 @@ package io.github.jukomu.service;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import android.graphics.Bitmap;
+
 import io.github.jukomu.data.CacheCapacityPolicy;
 import io.github.jukomu.data.FileStore;
 import io.github.jukomu.data.ImageCache;
@@ -18,9 +20,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -134,5 +142,63 @@ public class PreloadServiceTest {
         networkExecutor.submit(() -> {}).get(1, TimeUnit.SECONDS);
 
         assertFalse(imageCache.has("in-flight-complete-photo/1"));
+    }
+
+    @Test
+    public void repairImageBypassesCorruptMemoryCache() throws Exception {
+        byte[] repairedBytes = createPng();
+        imageCache.put("repair-photo/1",
+            "not-an-image".getBytes(StandardCharsets.UTF_8), "image/jpeg");
+
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicInteger fetchCount = new AtomicInteger();
+        AtomicReference<Exception> error = new AtomicReference<>();
+        PreloadService service = new PreloadService(
+            imageCache, FileStore.getInstance(), null, null,
+            imageExecutor, networkExecutor, null, null,
+            new CacheCapacityPolicy(), 2,
+            image -> {
+                fetchCount.incrementAndGet();
+                return repairedBytes;
+            });
+
+        JSONObject image = new JSONObject()
+            .put("sortOrder", 1)
+            .put("scrambleId", "scramble")
+            .put("filename", "page.png")
+            .put("url", "https://example.invalid/page.png");
+        service.repairImage("repair-photo", image, new PreloadService.ImageRepairCallback() {
+            @Override
+            public void onSuccess(boolean persisted) {
+                completed.countDown();
+            }
+
+            @Override
+            public void onError(Exception repairError) {
+                error.set(repairError);
+                completed.countDown();
+            }
+        });
+
+        assertTrue(completed.await(1, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(1, fetchCount.get());
+        ImageCache.ImageEntry entry = imageCache.get("repair-photo/1");
+        assertNotNull(entry);
+        assertArrayEquals(repairedBytes, entry.data);
+        assertTrue(ImageCache.isDecodableImage(entry.data));
+    }
+
+    private static byte[] createPng() {
+        Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                throw new IllegalStateException("Failed to create PNG fixture");
+            }
+            return output.toByteArray();
+        } finally {
+            bitmap.recycle();
+        }
     }
 }

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -1160,6 +1160,36 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
         }
     }
 
+    @PluginMethod
+    public void repairImage(PluginCall call) {
+        String photoId = call.getString("photoId");
+        JSObject image = call.getObject("image");
+        if (photoId == null || photoId.isEmpty()) {
+            call.reject("photoId is required");
+            return;
+        }
+        if (image == null) {
+            call.reject("image is required");
+            return;
+        }
+
+        preloadService.repairImage(photoId, image, new PreloadService.ImageRepairCallback() {
+            @Override
+            public void onSuccess(boolean persisted) {
+                JSObject result = new JSObject();
+                result.put("success", true);
+                result.put("persisted", persisted);
+                call.resolve(result);
+            }
+
+            @Override
+            public void onError(Exception error) {
+                Log.w(TAG, "图片恢复失败", error);
+                call.reject("图片恢复失败", error);
+            }
+        });
+    }
+
     // @PluginMethod  // 暂不暴露给 Vue，后续需要时取消注释
     public void clearPhotoCache(PluginCall call) {
         String photoId = call.getString("photoId");

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -170,6 +170,7 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
             }
 
             downloadDb.validateOnStartup(FileStore.getInstance().getBaseDir());
+            FileStore.getInstance().init(ctx, downloadDb, usePublicDir);
         }
 
         // 读取用户期望容量，通过统一策略初始化实际缓存上限
@@ -1161,7 +1162,7 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
     }
 
     @PluginMethod
-    public void repairImage(PluginCall call) {
+    public void retryImage(PluginCall call) {
         String photoId = call.getString("photoId");
         JSObject image = call.getObject("image");
         if (photoId == null || photoId.isEmpty()) {
@@ -1173,19 +1174,18 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
             return;
         }
 
-        preloadService.repairImage(photoId, image, new PreloadService.ImageRepairCallback() {
+        preloadService.retryImage(photoId, image, new PreloadService.ImageRetryCallback() {
             @Override
-            public void onSuccess(boolean persisted) {
+            public void onSuccess() {
                 JSObject result = new JSObject();
                 result.put("success", true);
-                result.put("persisted", persisted);
                 call.resolve(result);
             }
 
             @Override
             public void onError(Exception error) {
-                Log.w(TAG, "图片恢复失败", error);
-                call.reject("图片恢复失败", error);
+                Log.w(TAG, "图片重试失败", error);
+                call.reject("图片重试失败", error);
             }
         });
     }
@@ -1844,6 +1844,8 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
             }
             JSONObject result = downloadService.getDownloadedPhoto(albumId, chapterId);
             call.resolve(JSObject.fromJSONObject(result));
+        } catch (DownloadService.InvalidDownloadedContentException e) {
+            call.reject(e.getMessage(), DownloadService.INVALID_DOWNLOAD_CODE);
         } catch (IllegalArgumentException | IllegalStateException e) {
             call.reject(e.getMessage());
         } catch (Exception e) {

--- a/android/app/src/main/java/io/github/jukomu/data/DownloadStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/DownloadStore.java
@@ -271,6 +271,7 @@ public class DownloadStore extends SQLiteOpenHelper {
         SQLiteDatabase db = getWritableDatabase();
         db.beginTransaction();
         try {
+            db.delete(TABLE_IMAGES, COL_TASK_ID + " = ?", new String[]{taskId});
             ContentValues cv = new ContentValues();
             for (io.github.jukomu.jmcomic.api.model.JmImage img : images) {
                 cv.clear();
@@ -337,7 +338,7 @@ public class DownloadStore extends SQLiteOpenHelper {
             db.update(TABLE_TASKS, cvZombie,
                 COL_STATUS + " IN ('queued', 'downloading', 'paused')", null);
 
-            // 2. 校验 completed 任务的文件完整性
+            // 2. 按持久化页映射校验 completed 任务的图片内容
             Cursor c = db.query(TABLE_TASKS,
                 new String[]{COL_TASK_ID, COL_ALBUM_ID, COL_CHAPTER_ID, COL_TOTAL_PAGES},
                 COL_STATUS + " = ?", new String[]{"completed"},
@@ -352,39 +353,20 @@ public class DownloadStore extends SQLiteOpenHelper {
 
                         File chapterDir = new File(baseDir,
                             aid + File.separator + cid);
-                        if (!chapterDir.isDirectory()) {
+                        ImageValidator.DownloadValidationResult validation =
+                            ImageValidator.validateDownloadedImages(chapterDir, total,
+                                getImageFilenames(db, taskId));
+                        if (!validation.isComplete()) {
                             ContentValues cv = new ContentValues();
                             cv.put(COL_STATUS, "failed");
-                            cv.put(COL_ERROR, "Download file directory missing");
-                            db.update(TABLE_TASKS, cv,
-                                COL_TASK_ID + " = ?", new String[]{taskId});
-                            Log.w(TAG, "Startup check: mark " + taskId + " failed (dir missing)");
-                            continue;
-                        }
-
-                        // 检查 meta.json 是否存在作为快速校验
-                        File metaFile = new File(chapterDir, "meta.json");
-                        if (!metaFile.exists()) {
-                            ContentValues cv = new ContentValues();
-                            cv.put(COL_STATUS, "failed");
-                            cv.put(COL_ERROR, "meta.json missing");
-                            db.update(TABLE_TASKS, cv,
-                                COL_TASK_ID + " = ?", new String[]{taskId});
-                            Log.w(TAG, "Startup check: mark " + taskId + " failed (meta missing)");
-                        }
-
-                        // 检查图片文件数量
-                        File[] imageFiles = chapterDir.listFiles(
-                            (dir, name) -> !name.equals("meta.json") && !name.endsWith(".tmp"));
-                        int fileCount = imageFiles != null ? imageFiles.length : 0;
-                        if (fileCount < total) {
-                            ContentValues cv = new ContentValues();
-                            cv.put(COL_STATUS, "failed");
-                            cv.put(COL_ERROR, "Missing images: " + fileCount + "/" + total);
+                            cv.put(COL_DOWNLOADED_PAGES,
+                                validation.getFailedProgressCount());
+                            cv.put(COL_ERROR, validation.getFailureMessage(0));
                             db.update(TABLE_TASKS, cv,
                                 COL_TASK_ID + " = ?", new String[]{taskId});
                             Log.w(TAG, "Startup check: mark " + taskId
-                                + " failed (images " + fileCount + "/" + total + ")");
+                                + " failed (valid images " + validation.getValidCount()
+                                + "/" + validation.getExpectedCount() + ")");
                         }
                     }
                 } finally {
@@ -398,6 +380,23 @@ public class DownloadStore extends SQLiteOpenHelper {
     }
 
     // ========== 辅助 ==========
+
+    private static List<String> getImageFilenames(SQLiteDatabase db, String taskId) {
+        List<String> filenames = new ArrayList<>();
+        Cursor cursor = db.query(TABLE_IMAGES, new String[]{COL_FILENAME},
+            COL_TASK_ID + " = ?", new String[]{taskId}, null, null,
+            COL_SORT_ORDER + " ASC");
+        if (cursor != null) {
+            try {
+                while (cursor.moveToNext()) {
+                    filenames.add(cursor.getString(0));
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return filenames;
+    }
 
     private void normalizeFullyDownloadedFailures() {
         SQLiteDatabase db = getWritableDatabase();

--- a/android/app/src/main/java/io/github/jukomu/data/FileStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/FileStore.java
@@ -4,9 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.media.MediaScannerConnection;
 import android.os.Environment;
-import android.system.Os;
 import android.util.Log;
-import io.github.jukomu.jmcomic.api.model.JmImage;
 import org.json.JSONObject;
 
 import java.io.*;
@@ -40,69 +38,6 @@ public class FileStore {
      */
     public interface RelocationListener {
         void onProgress(int current, int total, String phase, String currentFile);
-    }
-
-    public static final class DownloadValidationResult {
-        private final int expectedCount;
-        private final int validCount;
-        private final int invalidContentCount;
-        private final int missingCount;
-        private final int cleanupFailureCount;
-
-        DownloadValidationResult(int expectedCount, int validCount,
-                                 int invalidContentCount, int missingCount,
-                                 int cleanupFailureCount) {
-            this.expectedCount = expectedCount;
-            this.validCount = validCount;
-            this.invalidContentCount = invalidContentCount;
-            this.missingCount = missingCount;
-            this.cleanupFailureCount = cleanupFailureCount;
-        }
-
-        public int getExpectedCount() {
-            return expectedCount;
-        }
-
-        public int getValidCount() {
-            return validCount;
-        }
-
-        public int getInvalidContentCount() {
-            return invalidContentCount;
-        }
-
-        public int getMissingCount() {
-            return missingCount;
-        }
-
-        public int getCleanupFailureCount() {
-            return cleanupFailureCount;
-        }
-
-        public boolean isComplete() {
-            return validCount == expectedCount
-                && invalidContentCount == 0
-                && missingCount == 0
-                && cleanupFailureCount == 0;
-        }
-
-        public String getFailureMessage() {
-            int failedCount = Math.max(0, expectedCount - validCount);
-            StringBuilder detail = new StringBuilder();
-            if (invalidContentCount > 0) {
-                detail.append("损坏 ").append(invalidContentCount).append(" 张");
-            }
-            if (missingCount > 0) {
-                if (detail.length() > 0) detail.append("，");
-                detail.append("缺失 ").append(missingCount).append(" 张");
-            }
-            if (cleanupFailureCount > 0) {
-                if (detail.length() > 0) detail.append("，");
-                detail.append("无法清理 ").append(cleanupFailureCount).append(" 张");
-            }
-            return failedCount + "/" + expectedCount
-                + " 张图片下载失败（文件校验未通过：" + detail + "）";
-        }
     }
 
     private static FileStore instance;
@@ -249,12 +184,7 @@ public class FileStore {
     }
 
     private static File resolveImagePath(File chapterDir, String filename) throws IOException {
-        if (new File(filename).isAbsolute()) return null;
-        File canonicalChapterDir = chapterDir.getCanonicalFile();
-        File canonicalImageFile = new File(canonicalChapterDir, filename).getCanonicalFile();
-        String chapterPrefix = canonicalChapterDir.getPath() + File.separator;
-        if (!canonicalImageFile.getPath().startsWith(chapterPrefix)) return null;
-        return canonicalImageFile;
+        return ImageValidator.resolveMappedImage(chapterDir, filename);
     }
 
     public byte[] getImageBytesByPhotoId(String photoId, int sortOrder) {
@@ -270,97 +200,6 @@ public class FileStore {
         String albumId = chapterIdToAlbumId.get(photoId);
         if (albumId == null) return null;
         return getImageFile(albumId, photoId, sortOrder);
-    }
-
-    /**
-     * 将已恢复的图片写入同目录临时文件，再通过 POSIX rename 原子替换目标文件。
-     *
-     * @return false 表示当前下载索引中没有该图片映射
-     */
-    public boolean replaceImageBytesByPhotoId(String photoId, int sortOrder, byte[] data)
-        throws IOException {
-        if (data == null || data.length == 0) {
-            throw new IOException("替换图片数据为空");
-        }
-        String albumId = chapterIdToAlbumId.get(photoId);
-        if (albumId == null) return false;
-        File target = getImagePath(albumId, photoId, sortOrder);
-        if (target == null) return false;
-
-        File parent = target.getParentFile();
-        if (parent == null || (!parent.isDirectory() && !parent.mkdirs())) {
-            throw new IOException("无法创建图片目录: " + target.getPath());
-        }
-
-        File temporary = new File(parent,
-            target.getName() + ".repair." + Thread.currentThread().getId() + ".tmp");
-        try {
-            try (FileOutputStream output = new FileOutputStream(temporary)) {
-                output.write(data);
-                output.flush();
-                output.getFD().sync();
-            }
-            try {
-                Os.rename(temporary.getAbsolutePath(), target.getAbsolutePath());
-            } catch (Exception e) {
-                throw new IOException("原子替换图片失败: " + target.getPath(), e);
-            }
-            return true;
-        } finally {
-            if (temporary.exists() && !temporary.delete()) {
-                Log.w(TAG, "Failed to delete repair temp file: " + temporary.getPath());
-            }
-        }
-    }
-
-    /**
-     * 校验下载任务预期的所有图片，并删除会被底层下载器误判为可跳过的损坏文件。
-     */
-    public DownloadValidationResult validateDownloadedImages(
-        String albumId, String chapterId, List<JmImage> images) {
-        return validateDownloadedImages(getChapterDir(albumId, chapterId), images);
-    }
-
-    static DownloadValidationResult validateDownloadedImages(
-        File chapterDir, List<JmImage> images) {
-        int expectedCount = images == null ? 0 : images.size();
-        int validCount = 0;
-        int invalidContentCount = 0;
-        int missingCount = 0;
-        int cleanupFailureCount = 0;
-
-        if (images == null) {
-            return new DownloadValidationResult(0, 0, 0, 0, 0);
-        }
-
-        for (JmImage image : images) {
-            File imageFile;
-            try {
-                imageFile = image == null
-                    ? null : resolveImagePath(chapterDir, image.getFilename());
-            } catch (IOException | RuntimeException e) {
-                imageFile = null;
-            }
-
-            if (imageFile == null || !imageFile.isFile()) {
-                missingCount++;
-                continue;
-            }
-            if (ImageCache.isDecodableImage(imageFile)) {
-                validCount++;
-                continue;
-            }
-
-            invalidContentCount++;
-            if (!imageFile.delete()) {
-                cleanupFailureCount++;
-                Log.w(TAG, "Failed to delete invalid downloaded image: "
-                    + imageFile.getPath());
-            }
-        }
-
-        return new DownloadValidationResult(expectedCount, validCount,
-            invalidContentCount, missingCount, cleanupFailureCount);
     }
 
     public byte[] readImageBytes(File imageFile) throws IOException {
@@ -417,16 +256,19 @@ public class FileStore {
         if (dir.isDirectory()) {
             deleteRecursive(dir);
         }
-        // 清理内存索引
-        chapterIdToAlbumId.remove(chapterId);
-        String prefix = albumId + "_" + chapterId + "_";
-        sortOrderToFilename.keySet().removeIf(k -> k.startsWith(prefix));
+        removeMappings(albumId, chapterId);
         // 清理父目录（如果为空）
         File parentDir = new File(baseDir, albumId);
         String[] remaining = parentDir.list();
         if (remaining != null && remaining.length == 0) {
             parentDir.delete();
         }
+    }
+
+    public void removeMappings(String albumId, String chapterId) {
+        chapterIdToAlbumId.remove(chapterId);
+        String prefix = albumId + "_" + chapterId + "_";
+        sortOrderToFilename.keySet().removeIf(k -> k.startsWith(prefix));
     }
 
     public long getTotalUsedBytes() {

--- a/android/app/src/main/java/io/github/jukomu/data/FileStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/FileStore.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.media.MediaScannerConnection;
 import android.os.Environment;
+import android.system.Os;
 import android.util.Log;
 import org.json.JSONObject;
 
@@ -160,26 +161,36 @@ public class FileStore {
         }
     }
 
-    private File getImageFile(String albumId, String chapterId, int sortOrder) {
+    private File getImagePath(String albumId, String chapterId, int sortOrder) {
         String key = makeSortKey(albumId, chapterId, sortOrder);
         String filename = sortOrderToFilename.get(key);
         if (filename == null) return null;
 
         try {
-            return resolveImageFile(getChapterDir(albumId, chapterId), filename);
+            return resolveImagePath(getChapterDir(albumId, chapterId), filename);
         } catch (IOException e) {
             Log.w(TAG, "图片路径校验失败", e);
             return null;
         }
     }
 
+    private File getImageFile(String albumId, String chapterId, int sortOrder) {
+        File imagePath = getImagePath(albumId, chapterId, sortOrder);
+        return imagePath != null && imagePath.isFile() ? imagePath : null;
+    }
+
     static File resolveImageFile(File chapterDir, String filename) throws IOException {
+        File imagePath = resolveImagePath(chapterDir, filename);
+        return imagePath != null && imagePath.isFile() ? imagePath : null;
+    }
+
+    private static File resolveImagePath(File chapterDir, String filename) throws IOException {
         if (new File(filename).isAbsolute()) return null;
         File canonicalChapterDir = chapterDir.getCanonicalFile();
         File canonicalImageFile = new File(canonicalChapterDir, filename).getCanonicalFile();
         String chapterPrefix = canonicalChapterDir.getPath() + File.separator;
         if (!canonicalImageFile.getPath().startsWith(chapterPrefix)) return null;
-        return canonicalImageFile.isFile() ? canonicalImageFile : null;
+        return canonicalImageFile;
     }
 
     public byte[] getImageBytesByPhotoId(String photoId, int sortOrder) {
@@ -195,6 +206,47 @@ public class FileStore {
         String albumId = chapterIdToAlbumId.get(photoId);
         if (albumId == null) return null;
         return getImageFile(albumId, photoId, sortOrder);
+    }
+
+    /**
+     * 将已恢复的图片写入同目录临时文件，再通过 POSIX rename 原子替换目标文件。
+     *
+     * @return false 表示当前下载索引中没有该图片映射
+     */
+    public boolean replaceImageBytesByPhotoId(String photoId, int sortOrder, byte[] data)
+        throws IOException {
+        if (data == null || data.length == 0) {
+            throw new IOException("替换图片数据为空");
+        }
+        String albumId = chapterIdToAlbumId.get(photoId);
+        if (albumId == null) return false;
+        File target = getImagePath(albumId, photoId, sortOrder);
+        if (target == null) return false;
+
+        File parent = target.getParentFile();
+        if (parent == null || (!parent.isDirectory() && !parent.mkdirs())) {
+            throw new IOException("无法创建图片目录: " + target.getPath());
+        }
+
+        File temporary = new File(parent,
+            target.getName() + ".repair." + Thread.currentThread().getId() + ".tmp");
+        try {
+            try (FileOutputStream output = new FileOutputStream(temporary)) {
+                output.write(data);
+                output.flush();
+                output.getFD().sync();
+            }
+            try {
+                Os.rename(temporary.getAbsolutePath(), target.getAbsolutePath());
+            } catch (Exception e) {
+                throw new IOException("原子替换图片失败: " + target.getPath(), e);
+            }
+            return true;
+        } finally {
+            if (temporary.exists() && !temporary.delete()) {
+                Log.w(TAG, "Failed to delete repair temp file: " + temporary.getPath());
+            }
+        }
     }
 
     public byte[] readImageBytes(File imageFile) throws IOException {

--- a/android/app/src/main/java/io/github/jukomu/data/FileStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/FileStore.java
@@ -6,6 +6,7 @@ import android.media.MediaScannerConnection;
 import android.os.Environment;
 import android.system.Os;
 import android.util.Log;
+import io.github.jukomu.jmcomic.api.model.JmImage;
 import org.json.JSONObject;
 
 import java.io.*;
@@ -39,6 +40,69 @@ public class FileStore {
      */
     public interface RelocationListener {
         void onProgress(int current, int total, String phase, String currentFile);
+    }
+
+    public static final class DownloadValidationResult {
+        private final int expectedCount;
+        private final int validCount;
+        private final int invalidContentCount;
+        private final int missingCount;
+        private final int cleanupFailureCount;
+
+        DownloadValidationResult(int expectedCount, int validCount,
+                                 int invalidContentCount, int missingCount,
+                                 int cleanupFailureCount) {
+            this.expectedCount = expectedCount;
+            this.validCount = validCount;
+            this.invalidContentCount = invalidContentCount;
+            this.missingCount = missingCount;
+            this.cleanupFailureCount = cleanupFailureCount;
+        }
+
+        public int getExpectedCount() {
+            return expectedCount;
+        }
+
+        public int getValidCount() {
+            return validCount;
+        }
+
+        public int getInvalidContentCount() {
+            return invalidContentCount;
+        }
+
+        public int getMissingCount() {
+            return missingCount;
+        }
+
+        public int getCleanupFailureCount() {
+            return cleanupFailureCount;
+        }
+
+        public boolean isComplete() {
+            return validCount == expectedCount
+                && invalidContentCount == 0
+                && missingCount == 0
+                && cleanupFailureCount == 0;
+        }
+
+        public String getFailureMessage() {
+            int failedCount = Math.max(0, expectedCount - validCount);
+            StringBuilder detail = new StringBuilder();
+            if (invalidContentCount > 0) {
+                detail.append("损坏 ").append(invalidContentCount).append(" 张");
+            }
+            if (missingCount > 0) {
+                if (detail.length() > 0) detail.append("，");
+                detail.append("缺失 ").append(missingCount).append(" 张");
+            }
+            if (cleanupFailureCount > 0) {
+                if (detail.length() > 0) detail.append("，");
+                detail.append("无法清理 ").append(cleanupFailureCount).append(" 张");
+            }
+            return failedCount + "/" + expectedCount
+                + " 张图片下载失败（文件校验未通过：" + detail + "）";
+        }
     }
 
     private static FileStore instance;
@@ -247,6 +311,56 @@ public class FileStore {
                 Log.w(TAG, "Failed to delete repair temp file: " + temporary.getPath());
             }
         }
+    }
+
+    /**
+     * 校验下载任务预期的所有图片，并删除会被底层下载器误判为可跳过的损坏文件。
+     */
+    public DownloadValidationResult validateDownloadedImages(
+        String albumId, String chapterId, List<JmImage> images) {
+        return validateDownloadedImages(getChapterDir(albumId, chapterId), images);
+    }
+
+    static DownloadValidationResult validateDownloadedImages(
+        File chapterDir, List<JmImage> images) {
+        int expectedCount = images == null ? 0 : images.size();
+        int validCount = 0;
+        int invalidContentCount = 0;
+        int missingCount = 0;
+        int cleanupFailureCount = 0;
+
+        if (images == null) {
+            return new DownloadValidationResult(0, 0, 0, 0, 0);
+        }
+
+        for (JmImage image : images) {
+            File imageFile;
+            try {
+                imageFile = image == null
+                    ? null : resolveImagePath(chapterDir, image.getFilename());
+            } catch (IOException | RuntimeException e) {
+                imageFile = null;
+            }
+
+            if (imageFile == null || !imageFile.isFile()) {
+                missingCount++;
+                continue;
+            }
+            if (ImageCache.isDecodableImage(imageFile)) {
+                validCount++;
+                continue;
+            }
+
+            invalidContentCount++;
+            if (!imageFile.delete()) {
+                cleanupFailureCount++;
+                Log.w(TAG, "Failed to delete invalid downloaded image: "
+                    + imageFile.getPath());
+            }
+        }
+
+        return new DownloadValidationResult(expectedCount, validCount,
+            invalidContentCount, missingCount, cleanupFailureCount);
     }
 
     public byte[] readImageBytes(File imageFile) throws IOException {

--- a/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
+++ b/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
@@ -20,6 +20,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class ImageCache {
 
     static final String VIRTUAL_HOST = "jqviewer.local";
+    private static final int VALIDATION_MAX_DIMENSION = 256;
     private static final int THUMBNAIL_MAX_WIDTH = 300;
     private static final int THUMBNAIL_JPEG_QUALITY = 70;
 
@@ -190,6 +191,19 @@ public class ImageCache {
         writeLock.lock();
         try {
             return cache.get(key);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void remove(String key) {
+        if (key == null) return;
+        writeLock.lock();
+        try {
+            ImageEntry removed = cache.remove(key);
+            if (removed != null) {
+                currentSize -= removed.data.length;
+            }
         } finally {
             writeLock.unlock();
         }
@@ -452,6 +466,49 @@ public class ImageCache {
         if (b0 == 0x47 && b1 == 0x49 && b2 == 0x46) return "gif";
         if (b0 == 0x52 && b1 == 0x49 && b2 == 0x46) return "webp"; // RIFF....WEBP
         return "jpeg";
+    }
+
+    /** 使用低分辨率实际解码，避免仅有合法头部的截断图片通过校验。 */
+    public static boolean isDecodableImage(byte[] data) {
+        if (data == null || data.length == 0) return false;
+        try {
+            if (!hasCompleteWebpContainer(data)) return false;
+
+            BitmapFactory.Options bounds = new BitmapFactory.Options();
+            bounds.inJustDecodeBounds = true;
+            BitmapFactory.decodeByteArray(data, 0, data.length, bounds);
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return false;
+
+            int sampleSize = 1;
+            int maxDimension = Math.max(bounds.outWidth, bounds.outHeight);
+            while (maxDimension / sampleSize > VALIDATION_MAX_DIMENSION
+                && sampleSize <= Integer.MAX_VALUE / 2) {
+                sampleSize *= 2;
+            }
+
+            BitmapFactory.Options decode = new BitmapFactory.Options();
+            decode.inSampleSize = sampleSize;
+            decode.inPreferredConfig = Bitmap.Config.RGB_565;
+            Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, decode);
+            if (bitmap == null) return false;
+            bitmap.recycle();
+            return true;
+        } catch (RuntimeException | OutOfMemoryError e) {
+            return false;
+        }
+    }
+
+    private static boolean hasCompleteWebpContainer(byte[] data) {
+        if (data.length < 12
+            || data[0] != 'R' || data[1] != 'I' || data[2] != 'F' || data[3] != 'F'
+            || data[8] != 'W' || data[9] != 'E' || data[10] != 'B' || data[11] != 'P') {
+            return true;
+        }
+        long riffSize = (data[4] & 0xffL)
+            | ((data[5] & 0xffL) << 8)
+            | ((data[6] & 0xffL) << 16)
+            | ((data[7] & 0xffL) << 24);
+        return riffSize + 8L == data.length;
     }
 
     /**

--- a/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
+++ b/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
@@ -3,6 +3,7 @@ package io.github.jukomu.data;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.util.Log;
 import android.webkit.WebResourceResponse;
 
 import java.io.*;
@@ -20,6 +21,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class ImageCache {
 
+    private static final String TAG = "ImageCache";
     static final String VIRTUAL_HOST = "jqviewer.local";
     private static final int VALIDATION_MAX_DIMENSION = 256;
     private static final int THUMBNAIL_MAX_WIDTH = 300;
@@ -396,7 +398,7 @@ public class ImageCache {
                 }
 
                 // 2b. 查 FileStore（从本地原图生成缩略图）
-                File imageFile = FileStore.getInstance().getImageFileByPhotoId(photoId, sortOrder);
+                File imageFile = getValidatedStoredImageFile(photoId, sortOrder);
                 if (imageFile != null) {
                     try (IncomingReservation reservation = getInstance()
                         .prepareForIncomingBytes(imageFile.length())) {
@@ -410,7 +412,7 @@ public class ImageCache {
                     }
                 }
             } else {
-                File imageFile = FileStore.getInstance().getImageFileByPhotoId(photoId, sortOrder);
+                File imageFile = getValidatedStoredImageFile(photoId, sortOrder);
                 if (imageFile != null) {
                     try (IncomingReservation reservation = getInstance()
                         .prepareForIncomingBytes(imageFile.length())) {
@@ -428,6 +430,19 @@ public class ImageCache {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private static File getValidatedStoredImageFile(String photoId, int sortOrder) {
+        return validatedStoredImageFile(
+            FileStore.getInstance().getImageFileByPhotoId(photoId, sortOrder));
+    }
+
+    static File validatedStoredImageFile(File imageFile) {
+        if (imageFile == null || isDecodableImage(imageFile)) return imageFile;
+        if (imageFile.exists() && !imageFile.delete()) {
+            Log.w(TAG, "Failed to delete invalid stored image: " + imageFile.getPath());
+        }
+        return null;
     }
 
     static WebResourceResponse createFileResponse(File imageFile) throws IOException {

--- a/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
+++ b/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
@@ -3,7 +3,6 @@ package io.github.jukomu.data;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
-import android.util.Log;
 import android.webkit.WebResourceResponse;
 
 import java.io.*;
@@ -21,9 +20,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class ImageCache {
 
-    private static final String TAG = "ImageCache";
     static final String VIRTUAL_HOST = "jqviewer.local";
-    private static final int VALIDATION_MAX_DIMENSION = 256;
     private static final int THUMBNAIL_MAX_WIDTH = 300;
     private static final int THUMBNAIL_JPEG_QUALITY = 70;
     private static final Map<String, String> NO_CACHE_RESPONSE_HEADERS;
@@ -438,10 +435,8 @@ public class ImageCache {
     }
 
     static File validatedStoredImageFile(File imageFile) {
-        if (imageFile == null || isDecodableImage(imageFile)) return imageFile;
-        if (imageFile.exists() && !imageFile.delete()) {
-            Log.w(TAG, "Failed to delete invalid stored image: " + imageFile.getPath());
-        }
+        if (imageFile == null || ImageValidator.validate(imageFile).isValid()) return imageFile;
+        imageFile.delete();
         return null;
     }
 
@@ -483,159 +478,6 @@ public class ImageCache {
         if (b0 == 0x47 && b1 == 0x49 && b2 == 0x46) return "gif";
         if (b0 == 0x52 && b1 == 0x49 && b2 == 0x46) return "webp"; // RIFF....WEBP
         return "jpeg";
-    }
-
-    /** 使用低分辨率实际解码，避免仅有合法头部的截断图片通过校验。 */
-    public static boolean isDecodableImage(byte[] data) {
-        if (data == null || data.length == 0) return false;
-        try {
-            if (!hasCompleteImageContainer(data)) return false;
-
-            BitmapFactory.Options bounds = new BitmapFactory.Options();
-            bounds.inJustDecodeBounds = true;
-            BitmapFactory.decodeByteArray(data, 0, data.length, bounds);
-            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return false;
-
-            int sampleSize = 1;
-            int maxDimension = Math.max(bounds.outWidth, bounds.outHeight);
-            while (maxDimension / sampleSize > VALIDATION_MAX_DIMENSION
-                && sampleSize <= Integer.MAX_VALUE / 2) {
-                sampleSize *= 2;
-            }
-
-            BitmapFactory.Options decode = new BitmapFactory.Options();
-            decode.inSampleSize = sampleSize;
-            decode.inPreferredConfig = Bitmap.Config.RGB_565;
-            Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, decode);
-            if (bitmap == null) return false;
-            bitmap.recycle();
-            return true;
-        } catch (RuntimeException | OutOfMemoryError e) {
-            return false;
-        }
-    }
-
-    /** 文件版校验避免为了下载完成检查而把整张图片再次读入 Java 堆。 */
-    public static boolean isDecodableImage(File imageFile) {
-        if (imageFile == null || !imageFile.isFile() || imageFile.length() <= 0L) return false;
-        try {
-            if (!hasCompleteImageContainer(imageFile)) return false;
-
-            BitmapFactory.Options bounds = new BitmapFactory.Options();
-            bounds.inJustDecodeBounds = true;
-            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), bounds);
-            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return false;
-
-            BitmapFactory.Options decode = new BitmapFactory.Options();
-            decode.inSampleSize = calculateValidationSampleSize(bounds.outWidth, bounds.outHeight);
-            decode.inPreferredConfig = Bitmap.Config.RGB_565;
-            Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath(), decode);
-            if (bitmap == null) return false;
-            bitmap.recycle();
-            return true;
-        } catch (IOException | RuntimeException | OutOfMemoryError e) {
-            return false;
-        }
-    }
-
-    private static int calculateValidationSampleSize(int width, int height) {
-        int sampleSize = 1;
-        int maxDimension = Math.max(width, height);
-        while (maxDimension / sampleSize > VALIDATION_MAX_DIMENSION
-            && sampleSize <= Integer.MAX_VALUE / 2) {
-            sampleSize *= 2;
-        }
-        return sampleSize;
-    }
-
-    private static boolean hasCompleteImageContainer(byte[] data) {
-        if (isJpeg(data)) {
-            return data.length >= 4
-                && data[data.length - 2] == (byte) 0xff
-                && data[data.length - 1] == (byte) 0xd9;
-        }
-        if (isPng(data)) {
-            return hasPngEndMarker(data, data.length - 12);
-        }
-        if (isGif(data)) {
-            return data.length >= 7 && data[data.length - 1] == 0x3b;
-        }
-        if (!isWebp(data)) return true;
-
-        long riffSize = (data[4] & 0xffL)
-            | ((data[5] & 0xffL) << 8)
-            | ((data[6] & 0xffL) << 16)
-            | ((data[7] & 0xffL) << 24);
-        return riffSize + 8L == data.length;
-    }
-
-    private static boolean hasCompleteImageContainer(File imageFile) throws IOException {
-        try (RandomAccessFile input = new RandomAccessFile(imageFile, "r")) {
-            long length = input.length();
-            if (length <= 0L) return false;
-
-            byte[] header = new byte[(int) Math.min(12L, length)];
-            input.readFully(header);
-            if (isJpeg(header)) {
-                if (length < 4L) return false;
-                input.seek(length - 2L);
-                return input.readUnsignedByte() == 0xff && input.readUnsignedByte() == 0xd9;
-            }
-            if (isPng(header)) {
-                if (length < 12L) return false;
-                byte[] footer = new byte[12];
-                input.seek(length - footer.length);
-                input.readFully(footer);
-                return hasPngEndMarker(footer, 0);
-            }
-            if (isGif(header)) {
-                if (length < 7L) return false;
-                input.seek(length - 1L);
-                return input.readUnsignedByte() == 0x3b;
-            }
-            if (!isWebp(header)) return true;
-
-            long riffSize = (header[4] & 0xffL)
-                | ((header[5] & 0xffL) << 8)
-                | ((header[6] & 0xffL) << 16)
-                | ((header[7] & 0xffL) << 24);
-            return riffSize + 8L == length;
-        }
-    }
-
-    private static boolean isJpeg(byte[] data) {
-        return data.length >= 2
-            && data[0] == (byte) 0xff && data[1] == (byte) 0xd8;
-    }
-
-    private static boolean isPng(byte[] data) {
-        return data.length >= 8
-            && data[0] == (byte) 0x89 && data[1] == 0x50
-            && data[2] == 0x4e && data[3] == 0x47
-            && data[4] == 0x0d && data[5] == 0x0a
-            && data[6] == 0x1a && data[7] == 0x0a;
-    }
-
-    private static boolean isGif(byte[] data) {
-        return data.length >= 6
-            && data[0] == 'G' && data[1] == 'I' && data[2] == 'F'
-            && data[3] == '8' && (data[4] == '7' || data[4] == '9') && data[5] == 'a';
-    }
-
-    private static boolean isWebp(byte[] data) {
-        return data.length >= 12
-            && data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F'
-            && data[8] == 'W' && data[9] == 'E' && data[10] == 'B' && data[11] == 'P';
-    }
-
-    private static boolean hasPngEndMarker(byte[] data, int offset) {
-        return offset >= 0 && data.length - offset >= 12
-            && data[offset] == 0 && data[offset + 1] == 0
-            && data[offset + 2] == 0 && data[offset + 3] == 0
-            && data[offset + 4] == 'I' && data[offset + 5] == 'E'
-            && data[offset + 6] == 'N' && data[offset + 7] == 'D'
-            && data[offset + 8] == (byte) 0xae && data[offset + 9] == 0x42
-            && data[offset + 10] == 0x60 && data[offset + 11] == (byte) 0x82;
     }
 
     private static WebResourceResponse createImageResponse(String mimeType, InputStream data) {

--- a/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
+++ b/android/app/src/main/java/io/github/jukomu/data/ImageCache.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.webkit.WebResourceResponse;
 
 import java.io.*;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,15 @@ public class ImageCache {
     private static final int VALIDATION_MAX_DIMENSION = 256;
     private static final int THUMBNAIL_MAX_WIDTH = 300;
     private static final int THUMBNAIL_JPEG_QUALITY = 70;
+    private static final Map<String, String> NO_CACHE_RESPONSE_HEADERS;
+
+    static {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+        headers.put("Pragma", "no-cache");
+        headers.put("Expires", "0");
+        NO_CACHE_RESPONSE_HEADERS = Collections.unmodifiableMap(headers);
+    }
 
     private static volatile ImageCache instance;
 
@@ -370,11 +380,8 @@ public class ImageCache {
             // 1. 查内存缓存
             ImageEntry entry = getInstance().get(cacheKey);
             if (entry != null) {
-                return new WebResourceResponse(
-                    entry.mimeType,
-                    "UTF-8",
-                    new ByteArrayInputStream(entry.data)
-                );
+                return createImageResponse(entry.mimeType,
+                    new ByteArrayInputStream(entry.data));
             }
 
             // 2. 缓存 miss → 依次：原图内存缓存 → FileStore
@@ -384,7 +391,7 @@ public class ImageCache {
                 if (original != null) {
                     byte[] thumbData = createThumbnail(original.data);
                     getInstance().put(cacheKey, thumbData, "image/jpeg");
-                    return new WebResourceResponse("image/jpeg", "UTF-8",
+                    return createImageResponse("image/jpeg",
                         new ByteArrayInputStream(thumbData));
                 }
 
@@ -398,7 +405,7 @@ public class ImageCache {
                         byte[] thumbData = createThumbnail(originalData);
                         reservation.close();
                         getInstance().put(cacheKey, thumbData, "image/jpeg");
-                        return new WebResourceResponse("image/jpeg", "UTF-8",
+                        return createImageResponse("image/jpeg",
                             new ByteArrayInputStream(thumbData));
                     }
                 }
@@ -411,8 +418,7 @@ public class ImageCache {
                         byte[] data = FileStore.getInstance().readImageBytes(imageFile);
                         String mime = "image/" + guessFormatName(data);
                         getInstance().put(cacheKey, data, mime, reservation);
-                        return new WebResourceResponse(mime, "UTF-8",
-                            new ByteArrayInputStream(data));
+                        return createImageResponse(mime, new ByteArrayInputStream(data));
                     }
                 }
             }
@@ -438,11 +444,7 @@ public class ImageCache {
                 offset += count;
             }
             input.getChannel().position(0L);
-            return new WebResourceResponse(
-                "image/" + guessFormatName(header),
-                null,
-                input
-            );
+            return createImageResponse("image/" + guessFormatName(header), input);
         } catch (IOException | RuntimeException e) {
             try {
                 input.close();
@@ -472,7 +474,7 @@ public class ImageCache {
     public static boolean isDecodableImage(byte[] data) {
         if (data == null || data.length == 0) return false;
         try {
-            if (!hasCompleteWebpContainer(data)) return false;
+            if (!hasCompleteImageContainer(data)) return false;
 
             BitmapFactory.Options bounds = new BitmapFactory.Options();
             bounds.inJustDecodeBounds = true;
@@ -498,17 +500,133 @@ public class ImageCache {
         }
     }
 
-    private static boolean hasCompleteWebpContainer(byte[] data) {
-        if (data.length < 12
-            || data[0] != 'R' || data[1] != 'I' || data[2] != 'F' || data[3] != 'F'
-            || data[8] != 'W' || data[9] != 'E' || data[10] != 'B' || data[11] != 'P') {
+    /** 文件版校验避免为了下载完成检查而把整张图片再次读入 Java 堆。 */
+    public static boolean isDecodableImage(File imageFile) {
+        if (imageFile == null || !imageFile.isFile() || imageFile.length() <= 0L) return false;
+        try {
+            if (!hasCompleteImageContainer(imageFile)) return false;
+
+            BitmapFactory.Options bounds = new BitmapFactory.Options();
+            bounds.inJustDecodeBounds = true;
+            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), bounds);
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return false;
+
+            BitmapFactory.Options decode = new BitmapFactory.Options();
+            decode.inSampleSize = calculateValidationSampleSize(bounds.outWidth, bounds.outHeight);
+            decode.inPreferredConfig = Bitmap.Config.RGB_565;
+            Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath(), decode);
+            if (bitmap == null) return false;
+            bitmap.recycle();
             return true;
+        } catch (IOException | RuntimeException | OutOfMemoryError e) {
+            return false;
         }
+    }
+
+    private static int calculateValidationSampleSize(int width, int height) {
+        int sampleSize = 1;
+        int maxDimension = Math.max(width, height);
+        while (maxDimension / sampleSize > VALIDATION_MAX_DIMENSION
+            && sampleSize <= Integer.MAX_VALUE / 2) {
+            sampleSize *= 2;
+        }
+        return sampleSize;
+    }
+
+    private static boolean hasCompleteImageContainer(byte[] data) {
+        if (isJpeg(data)) {
+            return data.length >= 4
+                && data[data.length - 2] == (byte) 0xff
+                && data[data.length - 1] == (byte) 0xd9;
+        }
+        if (isPng(data)) {
+            return hasPngEndMarker(data, data.length - 12);
+        }
+        if (isGif(data)) {
+            return data.length >= 7 && data[data.length - 1] == 0x3b;
+        }
+        if (!isWebp(data)) return true;
+
         long riffSize = (data[4] & 0xffL)
             | ((data[5] & 0xffL) << 8)
             | ((data[6] & 0xffL) << 16)
             | ((data[7] & 0xffL) << 24);
         return riffSize + 8L == data.length;
+    }
+
+    private static boolean hasCompleteImageContainer(File imageFile) throws IOException {
+        try (RandomAccessFile input = new RandomAccessFile(imageFile, "r")) {
+            long length = input.length();
+            if (length <= 0L) return false;
+
+            byte[] header = new byte[(int) Math.min(12L, length)];
+            input.readFully(header);
+            if (isJpeg(header)) {
+                if (length < 4L) return false;
+                input.seek(length - 2L);
+                return input.readUnsignedByte() == 0xff && input.readUnsignedByte() == 0xd9;
+            }
+            if (isPng(header)) {
+                if (length < 12L) return false;
+                byte[] footer = new byte[12];
+                input.seek(length - footer.length);
+                input.readFully(footer);
+                return hasPngEndMarker(footer, 0);
+            }
+            if (isGif(header)) {
+                if (length < 7L) return false;
+                input.seek(length - 1L);
+                return input.readUnsignedByte() == 0x3b;
+            }
+            if (!isWebp(header)) return true;
+
+            long riffSize = (header[4] & 0xffL)
+                | ((header[5] & 0xffL) << 8)
+                | ((header[6] & 0xffL) << 16)
+                | ((header[7] & 0xffL) << 24);
+            return riffSize + 8L == length;
+        }
+    }
+
+    private static boolean isJpeg(byte[] data) {
+        return data.length >= 2
+            && data[0] == (byte) 0xff && data[1] == (byte) 0xd8;
+    }
+
+    private static boolean isPng(byte[] data) {
+        return data.length >= 8
+            && data[0] == (byte) 0x89 && data[1] == 0x50
+            && data[2] == 0x4e && data[3] == 0x47
+            && data[4] == 0x0d && data[5] == 0x0a
+            && data[6] == 0x1a && data[7] == 0x0a;
+    }
+
+    private static boolean isGif(byte[] data) {
+        return data.length >= 6
+            && data[0] == 'G' && data[1] == 'I' && data[2] == 'F'
+            && data[3] == '8' && (data[4] == '7' || data[4] == '9') && data[5] == 'a';
+    }
+
+    private static boolean isWebp(byte[] data) {
+        return data.length >= 12
+            && data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F'
+            && data[8] == 'W' && data[9] == 'E' && data[10] == 'B' && data[11] == 'P';
+    }
+
+    private static boolean hasPngEndMarker(byte[] data, int offset) {
+        return offset >= 0 && data.length - offset >= 12
+            && data[offset] == 0 && data[offset + 1] == 0
+            && data[offset + 2] == 0 && data[offset + 3] == 0
+            && data[offset + 4] == 'I' && data[offset + 5] == 'E'
+            && data[offset + 6] == 'N' && data[offset + 7] == 'D'
+            && data[offset + 8] == (byte) 0xae && data[offset + 9] == 0x42
+            && data[offset + 10] == 0x60 && data[offset + 11] == (byte) 0x82;
+    }
+
+    private static WebResourceResponse createImageResponse(String mimeType, InputStream data) {
+        WebResourceResponse response = new WebResourceResponse(mimeType, null, data);
+        response.setResponseHeaders(NO_CACHE_RESPONSE_HEADERS);
+        return response;
     }
 
     /**

--- a/android/app/src/main/java/io/github/jukomu/data/ImageValidator.java
+++ b/android/app/src/main/java/io/github/jukomu/data/ImageValidator.java
@@ -1,0 +1,321 @@
+package io.github.jukomu.data;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 图片内容校验的统一入口。该类只读取输入并返回结果，不修改文件或缓存。
+ */
+public final class ImageValidator {
+
+    private static final int VALIDATION_MAX_DIMENSION = 256;
+
+    public enum Status {
+        VALID,
+        MISSING,
+        EMPTY,
+        INCOMPLETE,
+        UNDECODABLE;
+
+        public boolean isValid() {
+            return this == VALID;
+        }
+    }
+
+    public static final class DownloadValidationResult {
+        private final int expectedCount;
+        private final int mappedCount;
+        private final int validCount;
+        private final int invalidContentCount;
+        private final int missingCount;
+        private final List<File> invalidFiles;
+
+        DownloadValidationResult(int expectedCount, int mappedCount, int validCount,
+                                 int invalidContentCount, int missingCount,
+                                 List<File> invalidFiles) {
+            this.expectedCount = expectedCount;
+            this.mappedCount = mappedCount;
+            this.validCount = validCount;
+            this.invalidContentCount = invalidContentCount;
+            this.missingCount = missingCount;
+            this.invalidFiles = Collections.unmodifiableList(
+                new ArrayList<>(invalidFiles));
+        }
+
+        public int getExpectedCount() {
+            return expectedCount;
+        }
+
+        public int getValidCount() {
+            return validCount;
+        }
+
+        public int getMappedCount() {
+            return mappedCount;
+        }
+
+        public int getInvalidContentCount() {
+            return invalidContentCount;
+        }
+
+        public int getMissingCount() {
+            return missingCount;
+        }
+
+        public List<File> getInvalidFiles() {
+            return invalidFiles;
+        }
+
+        public boolean isComplete() {
+            return mappedCount == expectedCount
+                && validCount == expectedCount
+                && invalidContentCount == 0
+                && missingCount == 0;
+        }
+
+        /** 防止失败任务因进度等于总页数而被 DownloadStore 重新归一化为完成。 */
+        public int getFailedProgressCount() {
+            return Math.min(validCount, Math.max(0, expectedCount - 1));
+        }
+
+        public String getFailureMessage(int cleanupFailureCount) {
+            int failedCount = Math.max(0,
+                expectedCount - Math.min(validCount, expectedCount));
+            StringBuilder detail = new StringBuilder();
+            if (invalidContentCount > 0) {
+                detail.append("损坏 ").append(invalidContentCount).append(" 张");
+            }
+            if (missingCount > 0) {
+                if (detail.length() > 0) detail.append("，");
+                detail.append("缺失 ").append(missingCount).append(" 张");
+            }
+            if (cleanupFailureCount > 0) {
+                if (detail.length() > 0) detail.append("，");
+                detail.append("无法清理 ").append(cleanupFailureCount).append(" 张");
+            }
+            if (mappedCount != expectedCount) {
+                if (detail.length() > 0) detail.append("，");
+                detail.append("页映射 ").append(mappedCount).append("/")
+                    .append(expectedCount);
+            }
+            if (failedCount == 0) {
+                return "下载图片校验失败（" + detail + "）";
+            }
+            return failedCount + "/" + expectedCount
+                + " 张图片下载失败（文件校验未通过：" + detail + "）";
+        }
+    }
+
+    private ImageValidator() {
+    }
+
+    public static Status validate(byte[] data) {
+        if (data == null) return Status.MISSING;
+        if (data.length == 0) return Status.EMPTY;
+        try {
+            if (!hasCompleteImageContainer(data)) return Status.INCOMPLETE;
+
+            BitmapFactory.Options bounds = new BitmapFactory.Options();
+            bounds.inJustDecodeBounds = true;
+            BitmapFactory.decodeByteArray(data, 0, data.length, bounds);
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) {
+                return Status.UNDECODABLE;
+            }
+
+            BitmapFactory.Options decode = new BitmapFactory.Options();
+            decode.inSampleSize = calculateValidationSampleSize(
+                bounds.outWidth, bounds.outHeight);
+            decode.inPreferredConfig = Bitmap.Config.RGB_565;
+            Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, decode);
+            if (bitmap == null) return Status.UNDECODABLE;
+            bitmap.recycle();
+            return Status.VALID;
+        } catch (RuntimeException | OutOfMemoryError e) {
+            return Status.UNDECODABLE;
+        }
+    }
+
+    public static Status validate(File imageFile) {
+        if (imageFile == null || !imageFile.isFile()) return Status.MISSING;
+        if (imageFile.length() <= 0L) return Status.EMPTY;
+        try {
+            if (!hasCompleteImageContainer(imageFile)) return Status.INCOMPLETE;
+
+            BitmapFactory.Options bounds = new BitmapFactory.Options();
+            bounds.inJustDecodeBounds = true;
+            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), bounds);
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) {
+                return Status.UNDECODABLE;
+            }
+
+            BitmapFactory.Options decode = new BitmapFactory.Options();
+            decode.inSampleSize = calculateValidationSampleSize(
+                bounds.outWidth, bounds.outHeight);
+            decode.inPreferredConfig = Bitmap.Config.RGB_565;
+            Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath(), decode);
+            if (bitmap == null) return Status.UNDECODABLE;
+            bitmap.recycle();
+            return Status.VALID;
+        } catch (IOException e) {
+            return Status.INCOMPLETE;
+        } catch (RuntimeException | OutOfMemoryError e) {
+            return Status.UNDECODABLE;
+        }
+    }
+
+    public static DownloadValidationResult validateDownloadedImages(
+        File chapterDir, int expectedCount, List<String> filenames) {
+        List<String> safeFilenames = filenames == null
+            ? Collections.emptyList() : filenames;
+        int normalizedExpectedCount = Math.max(0, expectedCount);
+        int validCount = 0;
+        int invalidContentCount = 0;
+        int missingCount = Math.max(0,
+            normalizedExpectedCount - safeFilenames.size());
+        List<File> invalidFiles = new ArrayList<>();
+
+        for (String filename : safeFilenames) {
+            File imageFile;
+            try {
+                imageFile = resolveMappedImage(chapterDir, filename);
+            } catch (IOException | RuntimeException e) {
+                imageFile = null;
+            }
+
+            Status status = validate(imageFile);
+            if (status == Status.VALID) {
+                validCount++;
+            } else if (status == Status.MISSING) {
+                missingCount++;
+            } else {
+                invalidContentCount++;
+                invalidFiles.add(imageFile);
+            }
+        }
+
+        return new DownloadValidationResult(normalizedExpectedCount,
+            safeFilenames.size(), validCount, invalidContentCount, missingCount,
+            invalidFiles);
+    }
+
+    static File resolveMappedImage(File chapterDir, String filename) throws IOException {
+        if (chapterDir == null || filename == null || filename.isEmpty()
+            || new File(filename).isAbsolute()) {
+            return null;
+        }
+        File canonicalChapterDir = chapterDir.getCanonicalFile();
+        File canonicalImageFile = new File(canonicalChapterDir, filename).getCanonicalFile();
+        String chapterPrefix = canonicalChapterDir.getPath() + File.separator;
+        if (!canonicalImageFile.getPath().startsWith(chapterPrefix)) return null;
+        return canonicalImageFile;
+    }
+
+    private static int calculateValidationSampleSize(int width, int height) {
+        int sampleSize = 1;
+        int maxDimension = Math.max(width, height);
+        while (maxDimension / sampleSize > VALIDATION_MAX_DIMENSION
+            && sampleSize <= Integer.MAX_VALUE / 2) {
+            sampleSize *= 2;
+        }
+        return sampleSize;
+    }
+
+    private static boolean hasCompleteImageContainer(byte[] data) {
+        if (isJpeg(data)) {
+            return data.length >= 4
+                && data[data.length - 2] == (byte) 0xff
+                && data[data.length - 1] == (byte) 0xd9;
+        }
+        if (isPng(data)) {
+            return hasPngEndMarker(data, data.length - 12);
+        }
+        if (isGif(data)) {
+            return data.length >= 7 && data[data.length - 1] == 0x3b;
+        }
+        if (!isWebp(data)) return true;
+
+        long riffSize = (data[4] & 0xffL)
+            | ((data[5] & 0xffL) << 8)
+            | ((data[6] & 0xffL) << 16)
+            | ((data[7] & 0xffL) << 24);
+        return riffSize + 8L == data.length;
+    }
+
+    private static boolean hasCompleteImageContainer(File imageFile) throws IOException {
+        try (RandomAccessFile input = new RandomAccessFile(imageFile, "r")) {
+            long length = input.length();
+            if (length <= 0L) return false;
+
+            byte[] header = new byte[(int) Math.min(12L, length)];
+            input.readFully(header);
+            if (isJpeg(header)) {
+                if (length < 4L) return false;
+                input.seek(length - 2L);
+                return input.readUnsignedByte() == 0xff
+                    && input.readUnsignedByte() == 0xd9;
+            }
+            if (isPng(header)) {
+                if (length < 12L) return false;
+                byte[] footer = new byte[12];
+                input.seek(length - footer.length);
+                input.readFully(footer);
+                return hasPngEndMarker(footer, 0);
+            }
+            if (isGif(header)) {
+                if (length < 7L) return false;
+                input.seek(length - 1L);
+                return input.readUnsignedByte() == 0x3b;
+            }
+            if (!isWebp(header)) return true;
+
+            long riffSize = (header[4] & 0xffL)
+                | ((header[5] & 0xffL) << 8)
+                | ((header[6] & 0xffL) << 16)
+                | ((header[7] & 0xffL) << 24);
+            return riffSize + 8L == length;
+        }
+    }
+
+    private static boolean isJpeg(byte[] data) {
+        return data.length >= 2
+            && data[0] == (byte) 0xff && data[1] == (byte) 0xd8;
+    }
+
+    private static boolean isPng(byte[] data) {
+        return data.length >= 8
+            && data[0] == (byte) 0x89 && data[1] == 0x50
+            && data[2] == 0x4e && data[3] == 0x47
+            && data[4] == 0x0d && data[5] == 0x0a
+            && data[6] == 0x1a && data[7] == 0x0a;
+    }
+
+    private static boolean isGif(byte[] data) {
+        return data.length >= 6
+            && data[0] == 'G' && data[1] == 'I' && data[2] == 'F'
+            && data[3] == '8' && (data[4] == '7' || data[4] == '9')
+            && data[5] == 'a';
+    }
+
+    private static boolean isWebp(byte[] data) {
+        return data.length >= 12
+            && data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F'
+            && data[8] == 'W' && data[9] == 'E' && data[10] == 'B' && data[11] == 'P';
+    }
+
+    private static boolean hasPngEndMarker(byte[] data, int offset) {
+        return offset >= 0 && data.length - offset >= 12
+            && data[offset] == 0 && data[offset + 1] == 0
+            && data[offset + 2] == 0 && data[offset + 3] == 0
+            && data[offset + 4] == 'I' && data[offset + 5] == 'E'
+            && data[offset + 6] == 'N' && data[offset + 7] == 'D'
+            && data[offset + 8] == (byte) 0xae && data[offset + 9] == 0x42
+            && data[offset + 10] == 0x60 && data[offset + 11] == (byte) 0x82;
+    }
+}

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadObserver.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadObserver.java
@@ -8,7 +8,10 @@ import io.github.jukomu.jmcomic.api.download.DownloadResult;
 import io.github.jukomu.jmcomic.api.download.enums.TaskState;
 import io.github.jukomu.jmcomic.api.download.task.BaseDownloadTask;
 import io.github.jukomu.jmcomic.api.download.task.TaskObserver;
+import io.github.jukomu.jmcomic.api.model.JmImage;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -19,6 +22,7 @@ class DownloadObserver implements TaskObserver {
     private final String ourTaskId;
     private final String albumId;
     private final String chapterId;
+    private final List<JmImage> images;
     private final int totalImages;
     private final DownloadStore downloadDb;
     private final FileStore fileStore;
@@ -27,13 +31,15 @@ class DownloadObserver implements TaskObserver {
     private long lastBytes = 0;
     private long lastTimestamp = 0;
 
-    DownloadObserver(String ourTaskId, String albumId, String chapterId, int totalImages,
+    DownloadObserver(String ourTaskId, String albumId, String chapterId,
+                     List<JmImage> images,
                      DownloadStore downloadDb, FileStore fileStore,
                      DownloadService service) {
         this.ourTaskId = ourTaskId;
         this.albumId = albumId;
         this.chapterId = chapterId;
-        this.totalImages = totalImages;
+        this.images = images == null ? new ArrayList<>() : new ArrayList<>(images);
+        this.totalImages = this.images.size();
         this.downloadDb = downloadDb;
         this.fileStore = fileStore;
         this.service = service;
@@ -50,22 +56,10 @@ class DownloadObserver implements TaskObserver {
         if (newState.isTerminal() && !markFinalized()) return;
 
         if (newState == TaskState.COMPLETED) {
-            Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
-            downloadDb.updateCompleted(ourTaskId, totalImages,
-                firstSO != null ? firstSO : 1);
-            long totalSize = service.calcChapterFileSize(albumId, chapterId);
-            downloadDb.updateSize(ourTaskId, totalSize);
-            notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
-                null, 0, totalSize);
-            service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
-                DownloadService.STATUS_COMPLETED, null);
-            service.cleanupTaskMapping(ourTaskId);
+            completeDownloadIfValid();
         } else if (newState == TaskState.FAILED) {
-            downloadDb.updateFailed(ourTaskId, 0, "下载失败");
-            notifyProgress(0, totalImages, DownloadService.STATUS_FAILED, "下载失败");
-            service.updateDownloadNotification(ourTaskId, 0, totalImages,
-                DownloadService.STATUS_FAILED, "下载失败");
-            service.cleanupTaskMapping(ourTaskId);
+            FileStore.DownloadValidationResult validation = validateDownloadedImages();
+            failDownload(validation.getValidCount(), "下载失败");
         } else if (newState == TaskState.CANCELLED) {
             if (downloadDb.getTask(ourTaskId) == null) return;
             fileStore.deleteChapter(albumId, chapterId);
@@ -86,39 +80,20 @@ class DownloadObserver implements TaskObserver {
             DownloadResult result = task.getCurrentDownloadResult();
             int failed = result.getFailedTasks().size();
             if (failed == 0) {
-                Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
-                downloadDb.updateCompleted(ourTaskId, totalImages,
-                    firstSO != null ? firstSO : 1);
-                long totalSize = service.calcChapterFileSize(albumId, chapterId);
-                downloadDb.updateSize(ourTaskId, totalSize);
-                notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
-                    null, 0, totalSize);
-                service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
-                    DownloadService.STATUS_COMPLETED, null);
-                service.cleanupTaskMapping(ourTaskId);
+                completeDownloadIfValid();
                 return;
             }
-            int succeeded = totalImages - failed;
-            String error = failed + "/" + totalImages + " 张图片下载失败";
-            downloadDb.updateFailed(ourTaskId, succeeded, error);
-            long totalSize = service.calcChapterFileSize(albumId, chapterId);
-            downloadDb.updateSize(ourTaskId, totalSize);
-            notifyProgress(succeeded, totalImages, DownloadService.STATUS_FAILED,
-                error, 0, totalSize);
-            service.updateDownloadNotification(ourTaskId, succeeded, totalImages,
-                DownloadService.STATUS_FAILED, error);
-            service.cleanupTaskMapping(ourTaskId);
+            FileStore.DownloadValidationResult validation = validateDownloadedImages();
+            int succeeded = Math.min(totalImages - failed, validation.getValidCount());
+            int effectiveFailed = totalImages - succeeded;
+            String error = effectiveFailed + "/" + totalImages + " 张图片下载失败";
+            if (validation.getInvalidContentCount() > 0) {
+                error += "（含 " + validation.getInvalidContentCount()
+                    + " 张文件校验失败）";
+            }
+            failDownload(succeeded, error);
         } else if (newState == TaskState.SKIPPED) {
-            Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
-            downloadDb.updateCompleted(ourTaskId, totalImages,
-                firstSO != null ? firstSO : 1);
-            long totalSize = service.calcChapterFileSize(albumId, chapterId);
-            downloadDb.updateSize(ourTaskId, totalSize);
-            notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
-                null, 0, totalSize);
-            service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
-                DownloadService.STATUS_COMPLETED, null);
-            service.cleanupTaskMapping(ourTaskId);
+            completeDownloadIfValid();
         }
     }
 
@@ -154,10 +129,43 @@ class DownloadObserver implements TaskObserver {
     public void onError(BaseDownloadTask task, Exception e) {
         if (service.isCancelled(ourTaskId)) return;
         if (!markFinalized()) return;
-        downloadDb.updateFailed(ourTaskId, 0, e.getMessage());
-        notifyProgress(0, totalImages, DownloadService.STATUS_FAILED, e.getMessage());
-        service.updateDownloadNotification(ourTaskId, 0, totalImages,
-            DownloadService.STATUS_FAILED, e.getMessage());
+        FileStore.DownloadValidationResult validation = validateDownloadedImages();
+        failDownload(validation.getValidCount(), e.getMessage());
+    }
+
+    private FileStore.DownloadValidationResult validateDownloadedImages() {
+        return fileStore.validateDownloadedImages(albumId, chapterId, images);
+    }
+
+    private void completeDownloadIfValid() {
+        FileStore.DownloadValidationResult validation = validateDownloadedImages();
+        if (!validation.isComplete()) {
+            failDownload(validation.getValidCount(), validation.getFailureMessage());
+            return;
+        }
+
+        Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
+        downloadDb.updateCompleted(ourTaskId, totalImages,
+            firstSO != null ? firstSO : 1);
+        long totalSize = service.calcChapterFileSize(albumId, chapterId);
+        downloadDb.updateSize(ourTaskId, totalSize);
+        notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
+            null, 0, totalSize);
+        service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
+            DownloadService.STATUS_COMPLETED, null);
+        service.cleanupTaskMapping(ourTaskId);
+    }
+
+    private void failDownload(int succeeded, String error) {
+        int safeSucceeded = Math.max(0, Math.min(succeeded, totalImages));
+        String safeError = error == null || error.isEmpty() ? "下载失败" : error;
+        downloadDb.updateFailed(ourTaskId, safeSucceeded, safeError);
+        long totalSize = service.calcChapterFileSize(albumId, chapterId);
+        downloadDb.updateSize(ourTaskId, totalSize);
+        notifyProgress(safeSucceeded, totalImages, DownloadService.STATUS_FAILED,
+            safeError, 0, totalSize);
+        service.updateDownloadNotification(ourTaskId, safeSucceeded, totalImages,
+            DownloadService.STATUS_FAILED, safeError);
         service.cleanupTaskMapping(ourTaskId);
     }
 

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadObserver.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadObserver.java
@@ -3,6 +3,7 @@ package io.github.jukomu.service;
 import android.annotation.SuppressLint;
 import io.github.jukomu.data.DownloadStore;
 import io.github.jukomu.data.FileStore;
+import io.github.jukomu.data.ImageValidator;
 import io.github.jukomu.jmcomic.api.download.DownloadProgress;
 import io.github.jukomu.jmcomic.api.download.DownloadResult;
 import io.github.jukomu.jmcomic.api.download.enums.TaskState;
@@ -58,8 +59,9 @@ class DownloadObserver implements TaskObserver {
         if (newState == TaskState.COMPLETED) {
             completeDownloadIfValid();
         } else if (newState == TaskState.FAILED) {
-            FileStore.DownloadValidationResult validation = validateDownloadedImages();
-            failDownload(validation.getValidCount(), "下载失败");
+            ImageValidator.DownloadValidationResult validation = validateDownloadedImages();
+            service.cleanupInvalidDownloadedImages(validation);
+            failDownload(progressForFailure(validation), "下载失败");
         } else if (newState == TaskState.CANCELLED) {
             if (downloadDb.getTask(ourTaskId) == null) return;
             fileStore.deleteChapter(albumId, chapterId);
@@ -83,7 +85,8 @@ class DownloadObserver implements TaskObserver {
                 completeDownloadIfValid();
                 return;
             }
-            FileStore.DownloadValidationResult validation = validateDownloadedImages();
+            ImageValidator.DownloadValidationResult validation = validateDownloadedImages();
+            service.cleanupInvalidDownloadedImages(validation);
             int succeeded = Math.min(totalImages - failed, validation.getValidCount());
             int effectiveFailed = totalImages - succeeded;
             String error = effectiveFailed + "/" + totalImages + " 张图片下载失败";
@@ -129,18 +132,21 @@ class DownloadObserver implements TaskObserver {
     public void onError(BaseDownloadTask task, Exception e) {
         if (service.isCancelled(ourTaskId)) return;
         if (!markFinalized()) return;
-        FileStore.DownloadValidationResult validation = validateDownloadedImages();
-        failDownload(validation.getValidCount(), e.getMessage());
+        ImageValidator.DownloadValidationResult validation = validateDownloadedImages();
+        service.cleanupInvalidDownloadedImages(validation);
+        failDownload(progressForFailure(validation), e.getMessage());
     }
 
-    private FileStore.DownloadValidationResult validateDownloadedImages() {
-        return fileStore.validateDownloadedImages(albumId, chapterId, images);
+    private ImageValidator.DownloadValidationResult validateDownloadedImages() {
+        return service.validateDownloadedImages(albumId, chapterId, images);
     }
 
     private void completeDownloadIfValid() {
-        FileStore.DownloadValidationResult validation = validateDownloadedImages();
+        ImageValidator.DownloadValidationResult validation = validateDownloadedImages();
         if (!validation.isComplete()) {
-            failDownload(validation.getValidCount(), validation.getFailureMessage());
+            int cleanupFailures = service.cleanupInvalidDownloadedImages(validation);
+            failDownload(validation.getFailedProgressCount(),
+                validation.getFailureMessage(cleanupFailures));
             return;
         }
 
@@ -160,6 +166,9 @@ class DownloadObserver implements TaskObserver {
         int safeSucceeded = Math.max(0, Math.min(succeeded, totalImages));
         String safeError = error == null || error.isEmpty() ? "下载失败" : error;
         downloadDb.updateFailed(ourTaskId, safeSucceeded, safeError);
+        if (totalImages == 0 || safeSucceeded < totalImages) {
+            fileStore.removeMappings(albumId, chapterId);
+        }
         long totalSize = service.calcChapterFileSize(albumId, chapterId);
         downloadDb.updateSize(ourTaskId, totalSize);
         notifyProgress(safeSucceeded, totalImages, DownloadService.STATUS_FAILED,
@@ -167,6 +176,11 @@ class DownloadObserver implements TaskObserver {
         service.updateDownloadNotification(ourTaskId, safeSucceeded, totalImages,
             DownloadService.STATUS_FAILED, safeError);
         service.cleanupTaskMapping(ourTaskId);
+    }
+
+    private int progressForFailure(ImageValidator.DownloadValidationResult validation) {
+        return validation.isComplete()
+            ? validation.getValidCount() : validation.getFailedProgressCount();
     }
 
     private void notifyProgress(int downloadedPages, int totalPages,

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
@@ -15,6 +15,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,15 @@ public class DownloadService {
 
                 File chapterDir = fileStore.ensureChapterDir(albumId, chapterId);
                 fileStore.refreshMappings(albumId, chapterId, downloadDb);
+                FileStore.DownloadValidationResult existingFiles =
+                    fileStore.validateDownloadedImages(albumId, chapterId, images);
+                if (existingFiles.getInvalidContentCount() > 0) {
+                    Log.w(TAG, "Discarded " + existingFiles.getInvalidContentCount()
+                        + " invalid existing images before retrying " + taskId);
+                }
+                if (existingFiles.getCleanupFailureCount() > 0) {
+                    throw new IOException("无法清理损坏的已下载图片");
+                }
 
                 JSONObject metaJson = new JSONObject();
                 metaJson.put("albumId", albumId);
@@ -151,7 +161,7 @@ public class DownloadService {
                 }
 
                 task.addObserver(new DownloadObserver(taskId, albumId, chapterId,
-                    images.size(), downloadDb, fileStore, this));
+                    images, downloadDb, fileStore, this));
 
                 downloadDb.updateStatus(taskId, STATUS_DOWNLOADING);
                 showDownloadNotification(taskId, albumTitle, chapterId, chapterTitle,

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
@@ -349,13 +349,12 @@ public class DownloadService {
             throw new IllegalStateException("Task is not completed");
 
         List<JSONObject> images = downloadDb.getImages(taskId);
-        ImageValidator.DownloadValidationResult validation =
-            validateDownloadedImages(albumId, chapterId,
-                task.optInt("totalPages", images.size()), filenamesFromRecords(images));
-        if (!validation.isComplete()) {
-            int cleanupFailures = cleanupInvalidDownloadedImages(validation);
-            String error = validation.getFailureMessage(cleanupFailures);
-            downloadDb.updateFailed(taskId, validation.getFailedProgressCount(), error);
+        int totalPages = task.optInt("totalPages", images.size());
+        if (images.size() != totalPages) {
+            int failedProgress = Math.min(images.size(), Math.max(0, totalPages - 1));
+            String error = "下载图片校验失败（页映射 "
+                + images.size() + "/" + totalPages + "）";
+            downloadDb.updateFailed(taskId, failedProgress, error);
             downloadDb.updateSize(taskId, calcChapterFileSize(albumId, chapterId));
             fileStore.removeMappings(albumId, chapterId);
             throw new InvalidDownloadedContentException(error);
@@ -396,7 +395,8 @@ public class DownloadService {
                 filenames.add(image == null ? null : image.getFilename());
             }
         }
-        return validateDownloadedImages(albumId, chapterId,
+        return ImageValidator.validateDownloadedImages(
+            fileStore.getChapterDir(albumId, chapterId),
             images == null ? 0 : images.size(), filenames);
     }
 
@@ -411,20 +411,6 @@ public class DownloadService {
             }
         }
         return cleanupFailures;
-    }
-
-    private ImageValidator.DownloadValidationResult validateDownloadedImages(
-        String albumId, String chapterId, int expectedCount, List<String> filenames) {
-        return ImageValidator.validateDownloadedImages(
-            fileStore.getChapterDir(albumId, chapterId), expectedCount, filenames);
-    }
-
-    private static List<String> filenamesFromRecords(List<JSONObject> images) {
-        List<String> filenames = new ArrayList<>();
-        for (JSONObject image : images) {
-            filenames.add(image == null ? null : image.optString("filename", null));
-        }
-        return filenames;
     }
 
     // ---- 内部工具（DownloadObserver 通过 package-private 访问） ----

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import io.github.jukomu.data.DownloadStore;
 import io.github.jukomu.data.FileStore;
+import io.github.jukomu.data.ImageValidator;
 import io.github.jukomu.jmcomic.api.download.task.BaseDownloadTask;
 import io.github.jukomu.jmcomic.api.model.JmImage;
 import io.github.jukomu.jmcomic.api.model.JmPhoto;
@@ -17,6 +18,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +39,14 @@ public class DownloadService {
     static final String STATUS_PAUSED = "paused";
     static final String STATUS_COMPLETED = "completed";
     static final String STATUS_FAILED = "failed";
+    public static final String INVALID_DOWNLOAD_CODE = "DOWNLOAD_FILES_INVALID";
+
+    public static final class InvalidDownloadedContentException
+        extends IllegalStateException {
+        InvalidDownloadedContentException(String message) {
+            super(message);
+        }
+    }
 
     private final DownloadStore downloadDb;
     private final FileStore fileStore;
@@ -120,13 +130,14 @@ public class DownloadService {
 
                 File chapterDir = fileStore.ensureChapterDir(albumId, chapterId);
                 fileStore.refreshMappings(albumId, chapterId, downloadDb);
-                FileStore.DownloadValidationResult existingFiles =
-                    fileStore.validateDownloadedImages(albumId, chapterId, images);
+                ImageValidator.DownloadValidationResult existingFiles =
+                    validateDownloadedImages(albumId, chapterId, images);
+                int cleanupFailures = cleanupInvalidDownloadedImages(existingFiles);
                 if (existingFiles.getInvalidContentCount() > 0) {
                     Log.w(TAG, "Discarded " + existingFiles.getInvalidContentCount()
                         + " invalid existing images before retrying " + taskId);
                 }
-                if (existingFiles.getCleanupFailureCount() > 0) {
+                if (cleanupFailures > 0) {
                     throw new IOException("无法清理损坏的已下载图片");
                 }
 
@@ -185,6 +196,7 @@ public class DownloadService {
                 }
             } catch (Exception e) {
                 downloadDb.updateFailed(taskId, 0, e.getMessage());
+                fileStore.removeMappings(albumId, chapterId);
                 showFailedNotification(taskId, albumTitle, chapterId, chapterTitle,
                     coverUrl, e.getMessage());
                 notifyProgress(taskId, albumId, chapterId, 0, 0,
@@ -337,6 +349,18 @@ public class DownloadService {
             throw new IllegalStateException("Task is not completed");
 
         List<JSONObject> images = downloadDb.getImages(taskId);
+        ImageValidator.DownloadValidationResult validation =
+            validateDownloadedImages(albumId, chapterId,
+                task.optInt("totalPages", images.size()), filenamesFromRecords(images));
+        if (!validation.isComplete()) {
+            int cleanupFailures = cleanupInvalidDownloadedImages(validation);
+            String error = validation.getFailureMessage(cleanupFailures);
+            downloadDb.updateFailed(taskId, validation.getFailedProgressCount(), error);
+            downloadDb.updateSize(taskId, calcChapterFileSize(albumId, chapterId));
+            fileStore.removeMappings(albumId, chapterId);
+            throw new InvalidDownloadedContentException(error);
+        }
+
         JSONObject ret = new JSONObject();
         try {
             ret.put("id", chapterId);
@@ -362,6 +386,45 @@ public class DownloadService {
             Log.w(TAG, "构建已下载章节信息失败", e);
         }
         return ret;
+    }
+
+    ImageValidator.DownloadValidationResult validateDownloadedImages(
+        String albumId, String chapterId, List<JmImage> images) {
+        List<String> filenames = new ArrayList<>();
+        if (images != null) {
+            for (JmImage image : images) {
+                filenames.add(image == null ? null : image.getFilename());
+            }
+        }
+        return validateDownloadedImages(albumId, chapterId,
+            images == null ? 0 : images.size(), filenames);
+    }
+
+    int cleanupInvalidDownloadedImages(
+        ImageValidator.DownloadValidationResult validation) {
+        int cleanupFailures = 0;
+        for (File invalidFile : validation.getInvalidFiles()) {
+            if (invalidFile.exists() && !invalidFile.delete()) {
+                cleanupFailures++;
+                Log.w(TAG, "Failed to delete invalid downloaded image: "
+                    + invalidFile.getPath());
+            }
+        }
+        return cleanupFailures;
+    }
+
+    private ImageValidator.DownloadValidationResult validateDownloadedImages(
+        String albumId, String chapterId, int expectedCount, List<String> filenames) {
+        return ImageValidator.validateDownloadedImages(
+            fileStore.getChapterDir(albumId, chapterId), expectedCount, filenames);
+    }
+
+    private static List<String> filenamesFromRecords(List<JSONObject> images) {
+        List<String> filenames = new ArrayList<>();
+        for (JSONObject image : images) {
+            filenames.add(image == null ? null : image.optString("filename", null));
+        }
+        return filenames;
     }
 
     // ---- 内部工具（DownloadObserver 通过 package-private 访问） ----

--- a/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
@@ -273,6 +273,7 @@ public class PreloadService {
         if (callback == null) throw new IllegalArgumentException("callback is required");
         try {
             networkExecutor.submit(() -> {
+                NetworkLoadGate.Permit permit = null;
                 try {
                     if (photoId == null || photoId.isEmpty()) {
                         throw new IllegalArgumentException("photoId is required");
@@ -289,6 +290,11 @@ public class PreloadService {
                         throw new IllegalStateException("图片获取器未初始化");
                     }
 
+                    permit = networkLoadGate.acquire(null);
+                    if (permit == null) {
+                        throw new IOException("当前内存压力过高，暂时无法修复图片");
+                    }
+
                     String scrambleId = imageObject.optString("scrambleId");
                     String filename = imageObject.optString("filename");
                     String url = imageObject.optString("url");
@@ -299,6 +305,9 @@ public class PreloadService {
                     if (!ImageCache.isDecodableImage(repairedBytes)) {
                         throw new IOException("重新获取的图片无法解码");
                     }
+                    if (networkLoadGate.isCompletePressure()) {
+                        throw new IOException("当前内存压力过高，已丢弃修复结果");
+                    }
 
                     boolean persisted = false;
                     try {
@@ -306,6 +315,10 @@ public class PreloadService {
                             photoId, sortOrder, repairedBytes);
                     } catch (IOException e) {
                         Log.w(TAG, "恢复图片已获取，但无法写回下载文件", e);
+                    }
+
+                    if (networkLoadGate.isCompletePressure()) {
+                        throw new IOException("当前内存压力过高，已跳过图片缓存写入");
                     }
 
                     String formatName = JmImageTool.getFormatName(filename);
@@ -318,7 +331,10 @@ public class PreloadService {
                     }
                     callback.onSuccess(persisted);
                 } catch (Exception e) {
+                    if (e instanceof InterruptedException) Thread.currentThread().interrupt();
                     callback.onError(e);
+                } finally {
+                    if (permit != null) permit.close();
                 }
             });
         } catch (RuntimeException e) {

--- a/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import io.github.jukomu.data.CacheCapacityPolicy;
 import io.github.jukomu.data.FileStore;
 import io.github.jukomu.data.ImageCache;
+import io.github.jukomu.data.ImageValidator;
 import io.github.jukomu.data.SettingsStore;
 import io.github.jukomu.jmcomic.api.model.JmImage;
 import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
@@ -32,8 +33,8 @@ public class PreloadService {
         byte[] fetch(JmImage image) throws Exception;
     }
 
-    public interface ImageRepairCallback {
-        void onSuccess(boolean persisted);
+    public interface ImageRetryCallback {
+        void onSuccess();
 
         void onError(Exception error);
     }
@@ -265,11 +266,8 @@ public class PreloadService {
         return ret;
     }
 
-    /**
-     * 绕过内存缓存和已下载文件重新获取单页。返回前会确认新字节可解码，并尽量
-     * 原子覆盖已下载文件；即使持久化失败，仍会刷新内存缓存供当前阅读会话使用。
-     */
-    public void repairImage(String photoId, JSONObject imageObject, ImageRepairCallback callback) {
+    /** 绕过现有缓存重新获取单页，验证后仅刷新当前阅读会话的内存缓存。 */
+    public void retryImage(String photoId, JSONObject imageObject, ImageRetryCallback callback) {
         if (callback == null) throw new IllegalArgumentException("callback is required");
         try {
             networkExecutor.submit(() -> {
@@ -292,7 +290,7 @@ public class PreloadService {
 
                     permit = networkLoadGate.acquire(null);
                     if (permit == null) {
-                        throw new IOException("当前内存压力过高，暂时无法修复图片");
+                        throw new IOException("当前内存压力过高，暂时无法重试图片");
                     }
 
                     String scrambleId = imageObject.optString("scrambleId");
@@ -301,35 +299,23 @@ public class PreloadService {
                     String queryParams = imageObject.optString("queryParams", "");
                     JmImage jmImage = new JmImage(
                         photoId, scrambleId, filename, url, queryParams, sortOrder);
-                    byte[] repairedBytes = imageFetcher.fetch(jmImage);
-                    if (!ImageCache.isDecodableImage(repairedBytes)) {
+                    byte[] fetchedBytes = imageFetcher.fetch(jmImage);
+                    if (!ImageValidator.validate(fetchedBytes).isValid()) {
                         throw new IOException("重新获取的图片无法解码");
                     }
                     if (networkLoadGate.isCompletePressure()) {
-                        throw new IOException("当前内存压力过高，已丢弃修复结果");
-                    }
-
-                    boolean persisted = false;
-                    try {
-                        persisted = fileStore.replaceImageBytesByPhotoId(
-                            photoId, sortOrder, repairedBytes);
-                    } catch (IOException e) {
-                        Log.w(TAG, "恢复图片已获取，但无法写回下载文件", e);
-                    }
-
-                    if (networkLoadGate.isCompletePressure()) {
-                        throw new IOException("当前内存压力过高，已跳过图片缓存写入");
+                        throw new IOException("当前内存压力过高，已丢弃重试结果");
                     }
 
                     String formatName = JmImageTool.getFormatName(filename);
                     String cacheKey = photoId + "/" + sortOrder;
                     imageCache.remove(cacheKey);
-                    boolean cached = imageCache.put(cacheKey, repairedBytes,
+                    boolean cached = imageCache.put(cacheKey, fetchedBytes,
                         "image/" + formatName);
-                    if (!persisted && !cached) {
-                        throw new IOException("恢复图片无法写入下载文件或内存缓存");
+                    if (!cached) {
+                        throw new IOException("重试图片无法写入内存缓存");
                     }
-                    callback.onSuccess(persisted);
+                    callback.onSuccess();
                 } catch (Exception e) {
                     if (e instanceof InterruptedException) Thread.currentThread().interrupt();
                     callback.onError(e);

--- a/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
@@ -309,7 +309,6 @@ public class PreloadService {
 
                     String formatName = JmImageTool.getFormatName(filename);
                     String cacheKey = photoId + "/" + sortOrder;
-                    imageCache.remove(cacheKey);
                     boolean cached = imageCache.put(cacheKey, fetchedBytes,
                         "image/" + formatName);
                     if (!cached) {

--- a/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/PreloadService.java
@@ -14,6 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +30,12 @@ public class PreloadService {
     @FunctionalInterface
     interface ImageFetcher {
         byte[] fetch(JmImage image) throws Exception;
+    }
+
+    public interface ImageRepairCallback {
+        void onSuccess(boolean persisted);
+
+        void onError(Exception error);
     }
 
     private static final String TAG = "PreloadService";
@@ -256,6 +263,67 @@ public class PreloadService {
             Log.d(TAG, "构建待处理列表失败", e);
         }
         return ret;
+    }
+
+    /**
+     * 绕过内存缓存和已下载文件重新获取单页。返回前会确认新字节可解码，并尽量
+     * 原子覆盖已下载文件；即使持久化失败，仍会刷新内存缓存供当前阅读会话使用。
+     */
+    public void repairImage(String photoId, JSONObject imageObject, ImageRepairCallback callback) {
+        if (callback == null) throw new IllegalArgumentException("callback is required");
+        try {
+            networkExecutor.submit(() -> {
+                try {
+                    if (photoId == null || photoId.isEmpty()) {
+                        throw new IllegalArgumentException("photoId is required");
+                    }
+                    if (imageObject == null) {
+                        throw new IllegalArgumentException("image is required");
+                    }
+
+                    int sortOrder = imageObject.optInt("sortOrder");
+                    if (sortOrder <= 0) {
+                        throw new IllegalArgumentException("sortOrder must be positive");
+                    }
+                    if (imageFetcher == null) {
+                        throw new IllegalStateException("图片获取器未初始化");
+                    }
+
+                    String scrambleId = imageObject.optString("scrambleId");
+                    String filename = imageObject.optString("filename");
+                    String url = imageObject.optString("url");
+                    String queryParams = imageObject.optString("queryParams", "");
+                    JmImage jmImage = new JmImage(
+                        photoId, scrambleId, filename, url, queryParams, sortOrder);
+                    byte[] repairedBytes = imageFetcher.fetch(jmImage);
+                    if (!ImageCache.isDecodableImage(repairedBytes)) {
+                        throw new IOException("重新获取的图片无法解码");
+                    }
+
+                    boolean persisted = false;
+                    try {
+                        persisted = fileStore.replaceImageBytesByPhotoId(
+                            photoId, sortOrder, repairedBytes);
+                    } catch (IOException e) {
+                        Log.w(TAG, "恢复图片已获取，但无法写回下载文件", e);
+                    }
+
+                    String formatName = JmImageTool.getFormatName(filename);
+                    String cacheKey = photoId + "/" + sortOrder;
+                    imageCache.remove(cacheKey);
+                    boolean cached = imageCache.put(cacheKey, repairedBytes,
+                        "image/" + formatName);
+                    if (!persisted && !cached) {
+                        throw new IOException("恢复图片无法写入下载文件或内存缓存");
+                    }
+                    callback.onSuccess(persisted);
+                } catch (Exception e) {
+                    callback.onError(e);
+                }
+            });
+        } catch (RuntimeException e) {
+            callback.onError(e);
+        }
     }
 
     private boolean isStale(String scopeKey, long generation) {

--- a/src/components/reader/HorizontalPageView.vue
+++ b/src/components/reader/HorizontalPageView.vue
@@ -9,16 +9,16 @@
               <button
                 type="button"
                 class="image-retry-button"
-                :disabled="repairingSortOrders.has(idx + 1)"
+                :disabled="retryingSortOrders.has(idx + 1)"
                 @touchstart.stop
                 @touchend.stop
                 @click.stop="emit('retry-image', idx + 1)"
               >
                 <IonIcon
                   :icon="refreshOutline"
-                  :class="{ spinning: repairingSortOrders.has(idx + 1) }"
+                  :class="{ spinning: retryingSortOrders.has(idx + 1) }"
                 />
-                <span>{{ repairingSortOrders.has(idx + 1) ? '修复中' : '重试' }}</span>
+                <span>{{ retryingSortOrders.has(idx + 1) ? '重试中' : '重试' }}</span>
               </button>
             </div>
           </template>
@@ -50,13 +50,13 @@ const props = withDefaults(
   defineProps<{
     imageMap: Map<number, string>
     failedSortOrders?: Set<number>
-    repairingSortOrders?: Set<number>
+    retryingSortOrders?: Set<number>
     totalCount: number
     currentIndex: number
   }>(),
   {
     failedSortOrders: () => new Set<number>(),
-    repairingSortOrders: () => new Set<number>(),
+    retryingSortOrders: () => new Set<number>(),
   },
 )
 

--- a/src/components/reader/HorizontalPageView.vue
+++ b/src/components/reader/HorizontalPageView.vue
@@ -3,8 +3,32 @@
     <div class="strip" :style="stripStyle">
       <div v-for="idx in visibleIndices" :key="idx" class="page-slot" :style="slotStyle(idx)">
         <div class="page-content" :style="idx === displayIndex ? contentStyle : undefined">
-          <template v-if="imageMap.get(idx + 1)">
-            <img :src="imageMap.get(idx + 1)!" class="page-image" alt="" />
+          <template v-if="failedSortOrders.has(idx + 1)">
+            <div class="image-error-state">
+              <span>图片加载失败</span>
+              <button
+                type="button"
+                class="image-retry-button"
+                :disabled="repairingSortOrders.has(idx + 1)"
+                @touchstart.stop
+                @touchend.stop
+                @click.stop="emit('retry-image', idx + 1)"
+              >
+                <IonIcon
+                  :icon="refreshOutline"
+                  :class="{ spinning: repairingSortOrders.has(idx + 1) }"
+                />
+                <span>{{ repairingSortOrders.has(idx + 1) ? '修复中' : '重试' }}</span>
+              </button>
+            </div>
+          </template>
+          <template v-else-if="imageMap.get(idx + 1)">
+            <img
+              :src="imageMap.get(idx + 1)!"
+              class="page-image"
+              alt=""
+              @error="emit('image-error', idx + 1)"
+            />
           </template>
           <template v-else>
             <div class="skeleton-page" />
@@ -16,20 +40,32 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { IonIcon } from '@ionic/vue'
+import { refreshOutline } from 'ionicons/icons'
+
 defineOptions({ name: 'HorizontalPageView' })
 
-const props = defineProps<{
-  imageMap: Map<number, string>
-  totalCount: number
-  currentIndex: number
-}>()
+const props = withDefaults(
+  defineProps<{
+    imageMap: Map<number, string>
+    failedSortOrders?: Set<number>
+    repairingSortOrders?: Set<number>
+    totalCount: number
+    currentIndex: number
+  }>(),
+  {
+    failedSortOrders: () => new Set<number>(),
+    repairingSortOrders: () => new Set<number>(),
+  },
+)
 
 const emit = defineEmits<{
   'update:currentIndex': [index: number]
   'toggle-toolbar': []
+  'image-error': [sortOrder: number]
+  'retry-image': [sortOrder: number]
 }>()
-
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const SWIPE_THRESHOLD = 60
 const ZOOM_MAX = 4
@@ -441,6 +477,53 @@ defineExpose({ scrollToIndex })
   background: linear-gradient(90deg, #222 25%, #3a3a3a 50%, #222 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.image-error-state {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #aaa;
+  font-size: 14px;
+  background: #111;
+}
+
+.image-retry-button {
+  min-width: 96px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: #eee;
+  background: #222;
+  font: inherit;
+}
+
+.image-retry-button:disabled {
+  color: #888;
+  border-color: #444;
+}
+
+.image-retry-button ion-icon {
+  font-size: 18px;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes shimmer {

--- a/src/components/reader/VerticalScrollView.vue
+++ b/src/components/reader/VerticalScrollView.vue
@@ -22,16 +22,16 @@
               <button
                 type="button"
                 class="image-retry-button"
-                :disabled="repairingSortOrders.has(item.index + 1)"
+                :disabled="retryingSortOrders.has(item.index + 1)"
                 @touchstart.stop
                 @touchend.stop
                 @click.stop="emit('retry-image', item.index + 1)"
               >
                 <IonIcon
                   :icon="refreshOutline"
-                  :class="{ spinning: repairingSortOrders.has(item.index + 1) }"
+                  :class="{ spinning: retryingSortOrders.has(item.index + 1) }"
                 />
-                <span>{{ repairingSortOrders.has(item.index + 1) ? '修复中' : '重试' }}</span>
+                <span>{{ retryingSortOrders.has(item.index + 1) ? '重试中' : '重试' }}</span>
               </button>
             </div>
           </template>
@@ -71,13 +71,13 @@ const props = withDefaults(
   defineProps<{
     imageMap: Map<number, string>
     failedSortOrders?: Set<number>
-    repairingSortOrders?: Set<number>
+    retryingSortOrders?: Set<number>
     totalCount: number
     currentIndex: number
   }>(),
   {
     failedSortOrders: () => new Set<number>(),
-    repairingSortOrders: () => new Set<number>(),
+    retryingSortOrders: () => new Set<number>(),
   },
 )
 

--- a/src/components/reader/VerticalScrollView.vue
+++ b/src/components/reader/VerticalScrollView.vue
@@ -16,12 +16,32 @@
           :style="item.style"
           :data-index="item.index"
         >
-          <template v-if="item.dataUrl">
+          <template v-if="failedSortOrders.has(item.index + 1)">
+            <div class="image-error-state">
+              <span>图片加载失败</span>
+              <button
+                type="button"
+                class="image-retry-button"
+                :disabled="repairingSortOrders.has(item.index + 1)"
+                @touchstart.stop
+                @touchend.stop
+                @click.stop="emit('retry-image', item.index + 1)"
+              >
+                <IonIcon
+                  :icon="refreshOutline"
+                  :class="{ spinning: repairingSortOrders.has(item.index + 1) }"
+                />
+                <span>{{ repairingSortOrders.has(item.index + 1) ? '修复中' : '重试' }}</span>
+              </button>
+            </div>
+          </template>
+          <template v-else-if="item.dataUrl">
             <img
               :src="item.dataUrl"
               class="reader-image"
               alt=""
               @load="onImageLoad(item.index, $event)"
+              @error="emit('image-error', item.index + 1)"
             />
           </template>
           <template v-else>
@@ -42,19 +62,31 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { IonIcon } from '@ionic/vue'
+import { refreshOutline } from 'ionicons/icons'
 
 defineOptions({ name: 'VerticalScrollView' })
 
-const props = defineProps<{
-  imageMap: Map<number, string>
-  totalCount: number
-  currentIndex: number
-}>()
+const props = withDefaults(
+  defineProps<{
+    imageMap: Map<number, string>
+    failedSortOrders?: Set<number>
+    repairingSortOrders?: Set<number>
+    totalCount: number
+    currentIndex: number
+  }>(),
+  {
+    failedSortOrders: () => new Set<number>(),
+    repairingSortOrders: () => new Set<number>(),
+  },
+)
 
 const emit = defineEmits<{
   'update:currentIndex': [index: number]
   requestRange: [range: { start: number; end: number; center: number }]
   'reached-bottom': []
+  'image-error': [sortOrder: number]
+  'retry-image': [sortOrder: number]
 }>()
 
 interface VisibleItem {
@@ -685,6 +717,55 @@ defineExpose({ scrollToIndex, containerRef, isAtBottom })
   background: linear-gradient(90deg, #222 25%, #3a3a3a 50%, #222 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.image-error-state {
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #aaa;
+  font-size: 14px;
+  line-height: normal;
+  background: #111;
+}
+
+.image-retry-button {
+  min-width: 96px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: #eee;
+  background: #222;
+  font: inherit;
+}
+
+.image-retry-button:disabled {
+  color: #888;
+  border-color: #444;
+}
+
+.image-retry-button ion-icon {
+  font-size: 18px;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes shimmer {

--- a/src/services/jmcomic/JmcomicClient.ts
+++ b/src/services/jmcomic/JmcomicClient.ts
@@ -72,10 +72,10 @@ export interface JmcomicClient {
     replacePending?: boolean
   }): Promise<PreloadResult>
 
-  repairImage(options: {
+  retryImage(options: {
     photoId: string
     image: ImageInfo
-  }): Promise<{ success: boolean; persisted: boolean }>
+  }): Promise<{ success: boolean }>
 
   setCacheCapacity(options: { mb: number }): Promise<CacheCapacityInfo & { success: boolean }>
 

--- a/src/services/jmcomic/JmcomicClient.ts
+++ b/src/services/jmcomic/JmcomicClient.ts
@@ -72,6 +72,11 @@ export interface JmcomicClient {
     replacePending?: boolean
   }): Promise<PreloadResult>
 
+  repairImage(options: {
+    photoId: string
+    image: ImageInfo
+  }): Promise<{ success: boolean; persisted: boolean }>
+
   setCacheCapacity(options: { mb: number }): Promise<CacheCapacityInfo & { success: boolean }>
 
   getCacheCapacityInfo(): Promise<CacheCapacityInfo>

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -133,6 +133,11 @@ export const JmcomicService = {
     return native.preloadImages({ photoId, images, type, replacePending: options.replacePending })
   },
 
+  /** 绕过缓存重新获取单页，并尽量修复对应的已下载文件。 */
+  repairImage(photoId: string, image: ImageInfo) {
+    return native.repairImage({ photoId, image })
+  },
+
   /** 设置图片缓存容量（MB），供设置页调用 */
   setCacheCapacity(mb: number) {
     return native.setCacheCapacity({ mb })

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -133,9 +133,9 @@ export const JmcomicService = {
     return native.preloadImages({ photoId, images, type, replacePending: options.replacePending })
   },
 
-  /** 绕过缓存重新获取单页，并尽量修复对应的已下载文件。 */
-  repairImage(photoId: string, image: ImageInfo) {
-    return native.repairImage({ photoId, image })
+  /** 绕过缓存重新获取单页，仅刷新当前阅读会话。 */
+  retryImage(photoId: string, image: ImageInfo) {
+    return native.retryImage({ photoId, image })
   },
 
   /** 设置图片缓存容量（MB），供设置页调用 */

--- a/src/views/ReaderPage.vue
+++ b/src/views/ReaderPage.vue
@@ -11,20 +11,28 @@
         v-if="isVertical"
         ref="verticalViewRef"
         :image-map="imageMap"
+        :failed-sort-orders="failedSortOrders"
+        :repairing-sort-orders="repairingSortOrders"
         :total-count="totalCount"
         :current-index="currentIndex"
         @update:current-index="onPageChange"
         @request-range="onVerticalRequestRange"
         @reached-bottom="scheduleToolbarAtReaderEnd"
+        @image-error="onImageError"
+        @retry-image="retryImage"
       />
       <HorizontalPageView
         v-else
         ref="horizontalViewRef"
         :image-map="imageMap"
+        :failed-sort-orders="failedSortOrders"
+        :repairing-sort-orders="repairingSortOrders"
         :total-count="totalCount"
         :current-index="currentIndex"
         @update:current-index="onPageChange"
         @toggle-toolbar="toggleToolbar"
+        @image-error="onImageError"
+        @retry-image="retryImage"
       />
 
       <!-- 底部工具栏 -->
@@ -111,6 +119,8 @@ const isVertical = ref(SettingsStore.getReaderDisplayMode() === 'vertical')
 const currentIndex = ref(0)
 const totalCount = ref(0)
 const imageMap = shallowRef<Map<number, string>>(new Map())
+const failedSortOrders = shallowRef<Set<number>>(new Set())
+const repairingSortOrders = shallowRef<Set<number>>(new Set())
 const chapters = ref<PhotoMeta[]>([])
 const toolbarVisible = ref(true)
 const isDragProgress = ref(false)
@@ -134,6 +144,8 @@ let readerRuntimeActive = false
 let loadedSortOrders = new Set<number>()
 let requestedSortOrders = new Set<number>()
 let sortOrderToImage = new Map<number, ImageInfo>()
+let autoRepairAttempts = new Set<number>()
+let repairUrlRevision = 0
 let lastWindowCenter = -1
 const triggerRafId = 0
 let expandDirection: 'forward' | 'backward' | null = null
@@ -382,6 +394,80 @@ const applyImageMap = () => {
   imageMap.value = new Map(imageMap.value)
 }
 
+const setFailedSortOrder = (sortOrder: number, failed: boolean) => {
+  const next = new Set(failedSortOrders.value)
+  if (failed) next.add(sortOrder)
+  else next.delete(sortOrder)
+  failedSortOrders.value = next
+}
+
+const setRepairingSortOrder = (sortOrder: number, repairing: boolean) => {
+  const next = new Set(repairingSortOrders.value)
+  if (repairing) next.add(sortOrder)
+  else next.delete(sortOrder)
+  repairingSortOrders.value = next
+}
+
+const isCurrentRepair = (version: number, photoId: string) =>
+  version === chapterLoadVersion && photoDetail?.id === photoId
+
+const repairImage = async (sortOrder: number) => {
+  const pd = photoDetail
+  const image = sortOrderToImage.get(sortOrder)
+  if (!pd || !image || repairingSortOrders.value.has(sortOrder)) return
+
+  const version = chapterLoadVersion
+  const targetPhotoId = pd.id
+  setFailedSortOrder(sortOrder, true)
+  setRepairingSortOrder(sortOrder, true)
+  imageMap.value.delete(sortOrder)
+  loadedSortOrders.delete(sortOrder)
+  applyImageMap()
+
+  try {
+    const result = await JmcomicService.repairImage(targetPhotoId, image)
+    if (!isCurrentRepair(version, targetPhotoId)) return
+
+    repairUrlRevision++
+    imageMap.value.set(
+      sortOrder,
+      `${getImageUrl(targetPhotoId, sortOrder, 'image')}?repair=${repairUrlRevision}`,
+    )
+    loadedSortOrders.add(sortOrder)
+    setFailedSortOrder(sortOrder, false)
+    applyImageMap()
+    if (isOffline.value && !result.persisted) {
+      showToast('图片已临时恢复，但无法写回下载文件', 'medium')
+    }
+  } catch {
+    if (!isCurrentRepair(version, targetPhotoId)) return
+    setFailedSortOrder(sortOrder, true)
+    showToast('图片修复失败，请检查网络后重试', 'danger')
+  } finally {
+    if (isCurrentRepair(version, targetPhotoId)) {
+      setRepairingSortOrder(sortOrder, false)
+    }
+  }
+}
+
+const onImageError = (sortOrder: number) => {
+  if (!photoDetail || sortOrder < 1 || sortOrder > totalCount.value) return
+
+  imageMap.value.delete(sortOrder)
+  loadedSortOrders.delete(sortOrder)
+  setFailedSortOrder(sortOrder, true)
+  applyImageMap()
+
+  if (repairingSortOrders.value.has(sortOrder) || autoRepairAttempts.has(sortOrder)) return
+  autoRepairAttempts.add(sortOrder)
+  void repairImage(sortOrder)
+}
+
+const retryImage = (sortOrder: number) => {
+  if (repairingSortOrders.value.has(sortOrder)) return
+  void repairImage(sortOrder)
+}
+
 const clampIndex = (index: number) => {
   if (totalCount.value <= 0) return 0
   return Math.min(totalCount.value - 1, Math.max(0, index))
@@ -410,7 +496,11 @@ const updateWindow = (center: number, replacePending = false) => {
 
   if (isOffline.value) {
     for (const so of windowOrders) {
-      if (!loadedSortOrders.has(so)) {
+      if (
+        !loadedSortOrders.has(so) &&
+        !failedSortOrders.value.has(so) &&
+        !repairingSortOrders.value.has(so)
+      ) {
         imageMap.value.set(so, getImageUrl(photoDetail.id, so, 'image'))
         loadedSortOrders.add(so)
       }
@@ -418,7 +508,12 @@ const updateWindow = (center: number, replacePending = false) => {
   } else {
     const toLoad: ImageInfo[] = []
     for (const so of windowOrders) {
-      if (loadedSortOrders.has(so)) continue
+      if (
+        loadedSortOrders.has(so) ||
+        failedSortOrders.value.has(so) ||
+        repairingSortOrders.value.has(so)
+      )
+        continue
       const img = sortOrderToImage.get(so)
       if (!img) continue
       toLoad.push(img)
@@ -432,6 +527,12 @@ const updateWindow = (center: number, replacePending = false) => {
         .then((result: PreloadResult) => {
           if (photoDetail?.id !== requestedPhotoId) return
           for (const so of result.cached) {
+            if (
+              loadedSortOrders.has(so) ||
+              failedSortOrders.value.has(so) ||
+              repairingSortOrders.value.has(so)
+            )
+              continue
             imageMap.value.set(so, getImageUrl(requestedPhotoId, so, 'image'))
             loadedSortOrders.add(so)
           }
@@ -467,7 +568,14 @@ const loadDragPreviewImage = (center: number) => {
   if (!photoDetail) return
   const requestedPhotoId = photoDetail.id
   const so = center + 1
-  if (so < 1 || so > totalCount.value || loadedSortOrders.has(so) || requestedSortOrders.has(so))
+  if (
+    so < 1 ||
+    so > totalCount.value ||
+    loadedSortOrders.has(so) ||
+    requestedSortOrders.has(so) ||
+    failedSortOrders.value.has(so) ||
+    repairingSortOrders.value.has(so)
+  )
     return
 
   if (isOffline.value) {
@@ -484,6 +592,12 @@ const loadDragPreviewImage = (center: number) => {
     .then((result: PreloadResult) => {
       if (photoDetail?.id !== requestedPhotoId) return
       for (const cachedSo of result.cached) {
+        if (
+          loadedSortOrders.has(cachedSo) ||
+          failedSortOrders.value.has(cachedSo) ||
+          repairingSortOrders.value.has(cachedSo)
+        )
+          continue
         imageMap.value.set(cachedSo, getImageUrl(requestedPhotoId, cachedSo, 'image'))
         loadedSortOrders.add(cachedSo)
       }
@@ -615,6 +729,12 @@ const setupImageReadyListener = async () => {
   const targetChapterId = chapterId.value
   const handle = await JmcomicService.addImageReadyListener(targetChapterId, (sortOrder) => {
     if (chapterId.value !== targetChapterId) return
+    if (
+      loadedSortOrders.has(sortOrder) ||
+      failedSortOrders.value.has(sortOrder) ||
+      repairingSortOrders.value.has(sortOrder)
+    )
+      return
     imageMap.value.set(sortOrder, getImageUrl(targetChapterId, sortOrder, 'image'))
     loadedSortOrders.add(sortOrder)
     applyImageMap()
@@ -728,6 +848,7 @@ const loadDownloadedChapter = async (
     if (!isCurrentChapterLoad(version, targetAlbumId, targetChapterId)) return 'stale'
     isOffline.value = true
     applyPhotoBaseState(pd)
+    sortOrderToImage = new Map(pd.images.map((image) => [image.sortOrder, image]))
 
     const initOrders = calcWindow(currentIndex.value)
     const priorityInitOrders = prioritizeSortOrders(initOrders, currentIndex.value)
@@ -823,12 +944,16 @@ const resetChapterState = () => {
   currentIndex.value = 0
   totalCount.value = 0
   imageMap.value = new Map()
+  failedSortOrders.value = new Set()
+  repairingSortOrders.value = new Set()
   isOffline.value = route.query.source === 'download'
   isDragProgress.value = false
   settingsPanelVisible.value = false
   loadedSortOrders = new Set()
   requestedSortOrders = new Set()
   sortOrderToImage = new Map()
+  autoRepairAttempts = new Set()
+  repairUrlRevision = 0
   lastWindowCenter = -1
   activeRenderRange = null
   pendingSeekIndex = null

--- a/src/views/ReaderPage.vue
+++ b/src/views/ReaderPage.vue
@@ -414,7 +414,11 @@ const isCurrentRepair = (version: number, photoId: string) =>
 const repairImage = async (sortOrder: number) => {
   const pd = photoDetail
   const image = sortOrderToImage.get(sortOrder)
-  if (!pd || !image || repairingSortOrders.value.has(sortOrder)) return
+  if (!pd || repairingSortOrders.value.has(sortOrder)) return
+  if (!image) {
+    showToast('缺少图片信息，无法修复', 'danger')
+    return
+  }
 
   const version = chapterLoadVersion
   const targetPhotoId = pd.id

--- a/src/views/ReaderPage.vue
+++ b/src/views/ReaderPage.vue
@@ -12,7 +12,7 @@
         ref="verticalViewRef"
         :image-map="imageMap"
         :failed-sort-orders="failedSortOrders"
-        :repairing-sort-orders="repairingSortOrders"
+        :retrying-sort-orders="retryingSortOrders"
         :total-count="totalCount"
         :current-index="currentIndex"
         @update:current-index="onPageChange"
@@ -26,7 +26,7 @@
         ref="horizontalViewRef"
         :image-map="imageMap"
         :failed-sort-orders="failedSortOrders"
-        :repairing-sort-orders="repairingSortOrders"
+        :retrying-sort-orders="retryingSortOrders"
         :total-count="totalCount"
         :current-index="currentIndex"
         @update:current-index="onPageChange"
@@ -120,7 +120,7 @@ const currentIndex = ref(0)
 const totalCount = ref(0)
 const imageMap = shallowRef<Map<number, string>>(new Map())
 const failedSortOrders = shallowRef<Set<number>>(new Set())
-const repairingSortOrders = shallowRef<Set<number>>(new Set())
+const retryingSortOrders = shallowRef<Set<number>>(new Set())
 const chapters = ref<PhotoMeta[]>([])
 const toolbarVisible = ref(true)
 const isDragProgress = ref(false)
@@ -144,8 +144,7 @@ let readerRuntimeActive = false
 let loadedSortOrders = new Set<number>()
 let requestedSortOrders = new Set<number>()
 let sortOrderToImage = new Map<number, ImageInfo>()
-let autoRepairAttempts = new Set<number>()
-let repairUrlRevision = 0
+let retryUrlRevision = 0
 let lastWindowCenter = -1
 const triggerRafId = 0
 let expandDirection: 'forward' | 'backward' | null = null
@@ -401,55 +400,52 @@ const setFailedSortOrder = (sortOrder: number, failed: boolean) => {
   failedSortOrders.value = next
 }
 
-const setRepairingSortOrder = (sortOrder: number, repairing: boolean) => {
-  const next = new Set(repairingSortOrders.value)
-  if (repairing) next.add(sortOrder)
+const setRetryingSortOrder = (sortOrder: number, retrying: boolean) => {
+  const next = new Set(retryingSortOrders.value)
+  if (retrying) next.add(sortOrder)
   else next.delete(sortOrder)
-  repairingSortOrders.value = next
+  retryingSortOrders.value = next
 }
 
-const isCurrentRepair = (version: number, photoId: string) =>
+const isCurrentRetry = (version: number, photoId: string) =>
   version === chapterLoadVersion && photoDetail?.id === photoId
 
-const repairImage = async (sortOrder: number) => {
+const retryImage = async (sortOrder: number) => {
   const pd = photoDetail
   const image = sortOrderToImage.get(sortOrder)
-  if (!pd || repairingSortOrders.value.has(sortOrder)) return
+  if (!pd || retryingSortOrders.value.has(sortOrder)) return
   if (!image) {
-    showToast('缺少图片信息，无法修复', 'danger')
+    showToast('缺少图片信息，无法重试', 'danger')
     return
   }
 
   const version = chapterLoadVersion
   const targetPhotoId = pd.id
   setFailedSortOrder(sortOrder, true)
-  setRepairingSortOrder(sortOrder, true)
+  setRetryingSortOrder(sortOrder, true)
   imageMap.value.delete(sortOrder)
   loadedSortOrders.delete(sortOrder)
   applyImageMap()
 
   try {
-    const result = await JmcomicService.repairImage(targetPhotoId, image)
-    if (!isCurrentRepair(version, targetPhotoId)) return
+    await JmcomicService.retryImage(targetPhotoId, image)
+    if (!isCurrentRetry(version, targetPhotoId)) return
 
-    repairUrlRevision++
+    retryUrlRevision++
     imageMap.value.set(
       sortOrder,
-      `${getImageUrl(targetPhotoId, sortOrder, 'image')}?repair=${repairUrlRevision}`,
+      `${getImageUrl(targetPhotoId, sortOrder, 'image')}?retry=${retryUrlRevision}`,
     )
     loadedSortOrders.add(sortOrder)
     setFailedSortOrder(sortOrder, false)
     applyImageMap()
-    if (isOffline.value && !result.persisted) {
-      showToast('图片已临时恢复，但无法写回下载文件', 'medium')
-    }
   } catch {
-    if (!isCurrentRepair(version, targetPhotoId)) return
+    if (!isCurrentRetry(version, targetPhotoId)) return
     setFailedSortOrder(sortOrder, true)
-    showToast('图片修复失败，请检查网络后重试', 'danger')
+    showToast('图片重试失败，请检查网络后重试', 'danger')
   } finally {
-    if (isCurrentRepair(version, targetPhotoId)) {
-      setRepairingSortOrder(sortOrder, false)
+    if (isCurrentRetry(version, targetPhotoId)) {
+      setRetryingSortOrder(sortOrder, false)
     }
   }
 }
@@ -461,15 +457,6 @@ const onImageError = (sortOrder: number) => {
   loadedSortOrders.delete(sortOrder)
   setFailedSortOrder(sortOrder, true)
   applyImageMap()
-
-  if (repairingSortOrders.value.has(sortOrder) || autoRepairAttempts.has(sortOrder)) return
-  autoRepairAttempts.add(sortOrder)
-  void repairImage(sortOrder)
-}
-
-const retryImage = (sortOrder: number) => {
-  if (repairingSortOrders.value.has(sortOrder)) return
-  void repairImage(sortOrder)
 }
 
 const clampIndex = (index: number) => {
@@ -503,7 +490,7 @@ const updateWindow = (center: number, replacePending = false) => {
       if (
         !loadedSortOrders.has(so) &&
         !failedSortOrders.value.has(so) &&
-        !repairingSortOrders.value.has(so)
+        !retryingSortOrders.value.has(so)
       ) {
         imageMap.value.set(so, getImageUrl(photoDetail.id, so, 'image'))
         loadedSortOrders.add(so)
@@ -515,7 +502,7 @@ const updateWindow = (center: number, replacePending = false) => {
       if (
         loadedSortOrders.has(so) ||
         failedSortOrders.value.has(so) ||
-        repairingSortOrders.value.has(so)
+        retryingSortOrders.value.has(so)
       )
         continue
       const img = sortOrderToImage.get(so)
@@ -534,7 +521,7 @@ const updateWindow = (center: number, replacePending = false) => {
             if (
               loadedSortOrders.has(so) ||
               failedSortOrders.value.has(so) ||
-              repairingSortOrders.value.has(so)
+              retryingSortOrders.value.has(so)
             )
               continue
             imageMap.value.set(so, getImageUrl(requestedPhotoId, so, 'image'))
@@ -578,7 +565,7 @@ const loadDragPreviewImage = (center: number) => {
     loadedSortOrders.has(so) ||
     requestedSortOrders.has(so) ||
     failedSortOrders.value.has(so) ||
-    repairingSortOrders.value.has(so)
+    retryingSortOrders.value.has(so)
   )
     return
 
@@ -599,7 +586,7 @@ const loadDragPreviewImage = (center: number) => {
         if (
           loadedSortOrders.has(cachedSo) ||
           failedSortOrders.value.has(cachedSo) ||
-          repairingSortOrders.value.has(cachedSo)
+          retryingSortOrders.value.has(cachedSo)
         )
           continue
         imageMap.value.set(cachedSo, getImageUrl(requestedPhotoId, cachedSo, 'image'))
@@ -736,7 +723,7 @@ const setupImageReadyListener = async () => {
     if (
       loadedSortOrders.has(sortOrder) ||
       failedSortOrders.value.has(sortOrder) ||
-      repairingSortOrders.value.has(sortOrder)
+      retryingSortOrders.value.has(sortOrder)
     )
       return
     imageMap.value.set(sortOrder, getImageUrl(targetChapterId, sortOrder, 'image'))
@@ -846,7 +833,7 @@ const loadDownloadedChapter = async (
   targetAlbumId: string,
   targetChapterId: string,
   version: number,
-): Promise<'loaded' | 'missing' | 'stale'> => {
+): Promise<'loaded' | 'missing' | 'invalid' | 'stale'> => {
   try {
     const pd = await JmcomicService.getDownloadedPhoto(targetAlbumId, targetChapterId)
     if (!isCurrentChapterLoad(version, targetAlbumId, targetChapterId)) return 'stale'
@@ -866,9 +853,12 @@ const loadDownloadedChapter = async (
     scrollToInitialIndex()
     recordBrowseHistory()
     return 'loaded'
-  } catch {
+  } catch (error) {
     if (!isCurrentChapterLoad(version, targetAlbumId, targetChapterId)) return 'stale'
     isOffline.value = false
+    if ((error as { code?: unknown })?.code === 'DOWNLOAD_FILES_INVALID') {
+      return 'invalid'
+    }
     return 'missing'
   }
 }
@@ -930,9 +920,11 @@ const loadChapter = async () => {
   const requestedDownload = route.query.source === 'download'
   const version = chapterLoadVersion
   const downloadResult = await loadDownloadedChapter(targetAlbumId, targetChapterId, version)
-  if (downloadResult !== 'missing') return
+  if (downloadResult === 'loaded' || downloadResult === 'stale') return
 
-  if (requestedDownload) {
+  if (downloadResult === 'invalid') {
+    showToast('下载文件异常，请在下载管理中重新下载', 'danger')
+  } else if (requestedDownload) {
     showToast('离线章节加载失败', 'danger')
   }
   await loadOnlineChapter(targetAlbumId, targetChapterId, version)
@@ -949,15 +941,14 @@ const resetChapterState = () => {
   totalCount.value = 0
   imageMap.value = new Map()
   failedSortOrders.value = new Set()
-  repairingSortOrders.value = new Set()
+  retryingSortOrders.value = new Set()
   isOffline.value = route.query.source === 'download'
   isDragProgress.value = false
   settingsPanelVisible.value = false
   loadedSortOrders = new Set()
   requestedSortOrders = new Set()
   sortOrderToImage = new Map()
-  autoRepairAttempts = new Set()
-  repairUrlRevision = 0
+  retryUrlRevision = 0
   lastWindowCenter = -1
   activeRenderRange = null
   pendingSeekIndex = null

--- a/tests/unit/HorizontalPageView.test.ts
+++ b/tests/unit/HorizontalPageView.test.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+import HorizontalPageView from '@/components/reader/HorizontalPageView.vue'
+
+describe('HorizontalPageView', () => {
+  test('上报图片加载失败并提供重试操作', async () => {
+    const wrapper = mount(HorizontalPageView, {
+      props: {
+        imageMap: new Map<number, string>([[1, 'https://jqviewer.local/image/photo/1']]),
+        failedSortOrders: new Set<number>(),
+        repairingSortOrders: new Set<number>(),
+        totalCount: 1,
+        currentIndex: 0,
+      },
+    })
+
+    await wrapper.get('.page-image').trigger('error')
+    expect(wrapper.emitted('image-error')).toEqual([[1]])
+
+    await wrapper.setProps({ failedSortOrders: new Set([1]) })
+    const retry = wrapper.get('.image-retry-button')
+    expect(retry.text()).toContain('重试')
+    await retry.trigger('click')
+    expect(wrapper.emitted('retry-image')).toEqual([[1]])
+
+    await wrapper.setProps({ repairingSortOrders: new Set([1]) })
+    expect(wrapper.get('.image-retry-button').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('.image-retry-button').text()).toContain('修复中')
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/HorizontalPageView.test.ts
+++ b/tests/unit/HorizontalPageView.test.ts
@@ -8,7 +8,7 @@ describe('HorizontalPageView', () => {
       props: {
         imageMap: new Map<number, string>([[1, 'https://jqviewer.local/image/photo/1']]),
         failedSortOrders: new Set<number>(),
-        repairingSortOrders: new Set<number>(),
+        retryingSortOrders: new Set<number>(),
         totalCount: 1,
         currentIndex: 0,
       },
@@ -23,9 +23,9 @@ describe('HorizontalPageView', () => {
     await retry.trigger('click')
     expect(wrapper.emitted('retry-image')).toEqual([[1]])
 
-    await wrapper.setProps({ repairingSortOrders: new Set([1]) })
+    await wrapper.setProps({ retryingSortOrders: new Set([1]) })
     expect(wrapper.get('.image-retry-button').attributes('disabled')).toBeDefined()
-    expect(wrapper.get('.image-retry-button').text()).toContain('修复中')
+    expect(wrapper.get('.image-retry-button').text()).toContain('重试中')
     wrapper.unmount()
   })
 })

--- a/tests/unit/ReaderPageRepair.test.ts
+++ b/tests/unit/ReaderPageRepair.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   showToast: vi.fn(() => Promise.resolve()),
   getDownloadedPhoto: vi.fn(),
   getPhoto: vi.fn(),
-  repairImage: vi.fn(),
+  retryImage: vi.fn(),
   router: {
     back: vi.fn(),
     push: vi.fn(() => Promise.resolve()),
@@ -31,7 +31,7 @@ vi.mock('@/services/JmcomicService', () => ({
     getPhoto: mocks.getPhoto,
     getAlbum: vi.fn(() => new Promise(() => {})),
     preloadImages: vi.fn(() => Promise.resolve({ cached: [], pending: [] })),
-    repairImage: mocks.repairImage,
+    retryImage: mocks.retryImage,
     setReaderFullscreen: vi.fn(() => Promise.resolve()),
     setReaderState: vi.fn(() => Promise.resolve()),
     setReaderScreenOrientation: vi.fn(() => Promise.resolve()),
@@ -66,7 +66,7 @@ vi.mock('@/services/ReadingProgressService', () => ({
 
 import ReaderPage from '@/views/ReaderPage.vue'
 
-describe('ReaderPage 图片修复', () => {
+describe('ReaderPage 图片重试', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.getDownloadedPhoto.mockRejectedValue(new Error('not downloaded'))
@@ -106,8 +106,70 @@ describe('ReaderPage 图片修复', () => {
     horizontalView.vm.$emit('retry-image', 1)
     await nextTick()
 
-    expect(mocks.showToast).toHaveBeenCalledWith('缺少图片信息，无法修复', 'danger')
-    expect(mocks.repairImage).not.toHaveBeenCalled()
+    expect(mocks.showToast).toHaveBeenCalledWith('缺少图片信息，无法重试', 'danger')
+    expect(mocks.retryImage).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('图片加载失败不会自动发起网络重试', async () => {
+    mocks.getPhoto.mockResolvedValue({
+      id: 'chapter',
+      title: 'Chapter',
+      albumId: 'album',
+      sortOrder: 1,
+      author: '',
+      tags: [],
+      images: [
+        {
+          photoId: 'chapter',
+          scrambleId: 'scramble',
+          filename: 'page-1.png',
+          url: 'https://example.invalid/page-1.png',
+          queryParams: '',
+          sortOrder: 1,
+        },
+      ],
+    })
+    mocks.retryImage.mockResolvedValue({ success: true })
+    const wrapper = shallowMount(ReaderPage, {
+      global: {
+        stubs: {
+          IonPage: { template: '<div><slot /></div>' },
+        },
+      },
+    })
+    await flushPromises()
+
+    const horizontalView = wrapper.findComponent({ name: 'HorizontalPageView' })
+    horizontalView.vm.$emit('image-error', 1)
+    await nextTick()
+    expect(mocks.retryImage).not.toHaveBeenCalled()
+
+    horizontalView.vm.$emit('retry-image', 1)
+    await flushPromises()
+    expect(mocks.retryImage).toHaveBeenCalledWith(
+      'chapter',
+      expect.objectContaining({ sortOrder: 1 }),
+    )
+    wrapper.unmount()
+  })
+
+  test('原生确认下载文件异常时提示重新下载并回退在线加载', async () => {
+    mocks.getDownloadedPhoto.mockRejectedValue({ code: 'DOWNLOAD_FILES_INVALID' })
+    const wrapper = shallowMount(ReaderPage, {
+      global: {
+        stubs: {
+          IonPage: { template: '<div><slot /></div>' },
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      '下载文件异常，请在下载管理中重新下载',
+      'danger',
+    )
+    expect(mocks.getPhoto).toHaveBeenCalledWith('chapter')
     wrapper.unmount()
   })
 })

--- a/tests/unit/ReaderPageRepair.test.ts
+++ b/tests/unit/ReaderPageRepair.test.ts
@@ -1,0 +1,113 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  showToast: vi.fn(() => Promise.resolve()),
+  getDownloadedPhoto: vi.fn(),
+  getPhoto: vi.fn(),
+  repairImage: vi.fn(),
+  router: {
+    back: vi.fn(),
+    push: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    name: 'ReaderPage',
+    params: { albumId: 'album', chapterId: 'chapter' },
+    query: {},
+  }),
+  useRouter: () => mocks.router,
+}))
+
+vi.mock('@/services/JmcomicService', () => ({
+  getImageUrl: (photoId: string, sortOrder: number, type: string) =>
+    `https://jqviewer.local/${type}/${photoId}/${sortOrder}`,
+  showToast: mocks.showToast,
+  JmcomicService: {
+    getDownloadedPhoto: mocks.getDownloadedPhoto,
+    getPhoto: mocks.getPhoto,
+    getAlbum: vi.fn(() => new Promise(() => {})),
+    preloadImages: vi.fn(() => Promise.resolve({ cached: [], pending: [] })),
+    repairImage: mocks.repairImage,
+    setReaderFullscreen: vi.fn(() => Promise.resolve()),
+    setReaderState: vi.fn(() => Promise.resolve()),
+    setReaderScreenOrientation: vi.fn(() => Promise.resolve()),
+    setReaderBrightness: vi.fn(() => Promise.resolve()),
+    setReaderKeepScreenOn: vi.fn(() => Promise.resolve()),
+    addVolumeKeyListener: vi.fn(() => Promise.resolve({ remove: vi.fn() })),
+    addImageReadyListener: vi.fn(() => Promise.resolve({ remove: vi.fn() })),
+  },
+}))
+
+vi.mock('@/services/SettingsService', () => ({
+  SettingsStore: {
+    getReaderPreloadPages: () => 1,
+    getReaderDisplayMode: () => 'horizontal',
+    getReaderAutoShowToolbarAtEnd: () => false,
+    getReaderScreenOrientation: () => 'auto',
+    getReaderBrightness: () => -1,
+    getReaderKeepScreenOn: () => false,
+  },
+}))
+
+vi.mock('@/services/HistoryService', () => ({
+  HistoryService: { recordBrowse: vi.fn() },
+}))
+
+vi.mock('@/services/ReadingProgressService', () => ({
+  ReadingProgressService: {
+    getInitialPage: () => 1,
+    record: vi.fn(),
+  },
+}))
+
+import ReaderPage from '@/views/ReaderPage.vue'
+
+describe('ReaderPage 图片修复', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getDownloadedPhoto.mockRejectedValue(new Error('not downloaded'))
+    mocks.getPhoto.mockResolvedValue({
+      id: 'chapter',
+      title: 'Chapter',
+      albumId: 'album',
+      sortOrder: 1,
+      author: '',
+      tags: [],
+      images: [
+        {
+          photoId: 'chapter',
+          scrambleId: 'scramble',
+          filename: 'page-2.png',
+          url: 'https://example.invalid/page-2.png',
+          queryParams: '',
+          sortOrder: 2,
+        },
+      ],
+    })
+  })
+
+  test('缺少目标图片映射时提示错误而不是静默返回', async () => {
+    const wrapper = shallowMount(ReaderPage, {
+      global: {
+        stubs: {
+          IonPage: { template: '<div><slot /></div>' },
+        },
+      },
+    })
+    await flushPromises()
+
+    const horizontalView = wrapper.findComponent({ name: 'HorizontalPageView' })
+    expect(horizontalView.exists()).toBe(true)
+
+    horizontalView.vm.$emit('retry-image', 1)
+    await nextTick()
+
+    expect(mocks.showToast).toHaveBeenCalledWith('缺少图片信息，无法修复', 'danger')
+    expect(mocks.repairImage).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/VerticalScrollView.test.ts
+++ b/tests/unit/VerticalScrollView.test.ts
@@ -1,13 +1,11 @@
-import {mount} from '@vue/test-utils'
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import VerticalScrollView from '@/components/reader/VerticalScrollView.vue'
 
 class ResizeObserverMock {
-  observe() {
-  }
+  observe() {}
 
-  disconnect() {
-  }
+  disconnect() {}
 }
 
 let frameId = 0
@@ -20,8 +18,7 @@ beforeEach(() => {
     Promise.resolve().then(() => callback(performance.now()))
     return id
   })
-  vi.stubGlobal('cancelAnimationFrame', () => {
-  })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
 })
 
 afterEach(() => {
@@ -35,6 +32,33 @@ async function flushAnimationFrames() {
 }
 
 describe('VerticalScrollView', () => {
+  test('上报图片加载失败并提供重试操作', async () => {
+    const wrapper = mount(VerticalScrollView, {
+      props: {
+        imageMap: new Map<number, string>([[1, 'https://jqviewer.local/image/photo/1']]),
+        failedSortOrders: new Set<number>(),
+        repairingSortOrders: new Set<number>(),
+        totalCount: 1,
+        currentIndex: 0,
+      },
+    })
+    await flushAnimationFrames()
+
+    await wrapper.get('.reader-image').trigger('error')
+    expect(wrapper.emitted('image-error')).toEqual([[1]])
+
+    await wrapper.setProps({ failedSortOrders: new Set([1]) })
+    const retry = wrapper.get('.image-retry-button')
+    expect(retry.text()).toContain('重试')
+    await retry.trigger('click')
+    expect(wrapper.emitted('retry-image')).toEqual([[1]])
+
+    await wrapper.setProps({ repairingSortOrders: new Set([1]) })
+    expect(wrapper.get('.image-retry-button').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('.image-retry-button').text()).toContain('修复中')
+    wrapper.unmount()
+  })
+
   test('每次进入章节底部时只触发一次 reached-bottom', async () => {
     const wrapper = mount(VerticalScrollView, {
       props: {
@@ -47,10 +71,10 @@ describe('VerticalScrollView', () => {
 
     const container = wrapper.get('.vertical-container')
     Object.defineProperties(container.element, {
-      scrollHeight: {configurable: true, value: 1000},
-      clientHeight: {configurable: true, value: 400},
-      clientWidth: {configurable: true, value: 300},
-      scrollTop: {configurable: true, value: 500, writable: true},
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 400 },
+      clientWidth: { configurable: true, value: 300 },
+      scrollTop: { configurable: true, value: 500, writable: true },
     })
 
     await container.trigger('scroll')

--- a/tests/unit/VerticalScrollView.test.ts
+++ b/tests/unit/VerticalScrollView.test.ts
@@ -37,7 +37,7 @@ describe('VerticalScrollView', () => {
       props: {
         imageMap: new Map<number, string>([[1, 'https://jqviewer.local/image/photo/1']]),
         failedSortOrders: new Set<number>(),
-        repairingSortOrders: new Set<number>(),
+        retryingSortOrders: new Set<number>(),
         totalCount: 1,
         currentIndex: 0,
       },
@@ -53,9 +53,9 @@ describe('VerticalScrollView', () => {
     await retry.trigger('click')
     expect(wrapper.emitted('retry-image')).toEqual([[1]])
 
-    await wrapper.setProps({ repairingSortOrders: new Set([1]) })
+    await wrapper.setProps({ retryingSortOrders: new Set([1]) })
     expect(wrapper.get('.image-retry-button').attributes('disabled')).toBeDefined()
-    expect(wrapper.get('.image-retry-button').text()).toContain('修复中')
+    expect(wrapper.get('.image-retry-button').text()).toContain('重试中')
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## 概要

本 PR 修复 #19 中“已下载图片损坏后阅读页空白”的问题，并落实维护者关联的 #27 下载校验要求。

- 横向与纵向阅读器在图片解码失败后显示明确的修复状态，并自动尝试一次单页恢复
- 修复请求绕过内存缓存和本地下载文件，重新获取并验证图片内容
- 使用同目录临时文件和原子重命名替换损坏下载，同时清除旧缓存
- 自动恢复失败后保留手动重试入口；无法持久化时提示仅当前会话恢复

## 下载校验与审核整改

- 下载启动前校验预期落盘文件；发现损坏文件时先删除，再进入下载流程，避免底层下载器因文件已存在而跳过
- 下载终态执行容器完整性和实际解码校验；无效内容不会标记为完成，也不会进入持久化缓存
- 对历史已完成下载，在 `ImageCache` 从 `FileStore` 读取并进入缩略图、内存缓存或流式响应前再次校验；损坏文件会被清理并按缓存未命中处理
- `PreloadService.repairImage` 统一通过 `NetworkLoadGate` 获取 permit，执行完整压力检查，并在 `finally` 释放；压力状态下不写入 `FileStore` 或 `ImageCache`
- `ImageCache` 返回的 `WebResourceResponse` 添加 no-cache 响应头，修复成功后同时更新图片 URL 版本，避免 WebView 复用旧失败响应
- `ReaderPage.vue` 在缺少图片映射时使用现有 toast 错误提示，不再静默结束重试
- 补充 persisted 回调、fetch 异常、不可解码字节、下载有效/失败路径、压力门控、缓存响应头及历史损坏文件清理测试

相关提交：`ac31626`、`b3cf335`。

## 根因

下载完成判定此前主要依赖文件存在和大小，非空但损坏的文件仍可能被当作有效下载并由本地图片 URL 直接返回；历史已完成下载还可能绕过下载服务，直接由 `ImageCache` 读取。阅读器也未完整处理图片解码失败和 WebView 旧失败响应复用，因此用户最终看到空白区域。

## 修复前

<img width="1080" height="2400" alt="Issue #19 修复前：损坏图片导致阅读页空白" src="https://github.com/user-attachments/assets/2ad6dbd7-39e5-42b5-b1ba-dad1fac1e629" />

## 修复后

<img width="1080" height="2400" alt="Issue #19 修复后：自动恢复后冷启动仍正常显示" src="https://github.com/user-attachments/assets/e6f0facb-0be3-4440-9ae0-83b8210305b3" />

## 验证

- `npm run test:unit`：19 个测试文件、93 项测试通过
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run check-version`
- `./gradlew :app:testDebugUnitTest :app:lintDebug`
- Android API 36 目标仪器回归：13/13 通过；追加 `ImageCache` 历史文件回归：4/4 通过
- Android API 36 完整仪器测试：37 项通过，2 项依赖样本的实验测试按设计跳过
- `npm run build:android`
- 本次涉及文件通过格式与 diff 检查；未扩散全仓库既有格式问题

Closes #19
Closes #27
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 阅读器新增图片加载失败提示与手动重试功能，重试期间显示状态并禁用操作。
  * 支持在线重新获取异常图片，成功后自动刷新显示内容。
  * 离线章节检测到损坏或不完整图片时，提示用户重新下载。

* **问题修复**
  * 增强图片完整性与可解码性校验，自动清理无效缓存和下载文件。
  * 优化缓存响应，减少过期或损坏图片被重复使用。
  * 改善下载失败状态、进度统计及重新下载流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->