### PR TITLE
refactor(reader): 统一在线与离线图片加载链路

### DIFF
--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -192,13 +192,15 @@ export const JmcomicService = {
    * 注册图片就绪监听。
    * @param photoId 当前章节 ID，仅接收此章节的事件
    * @param handler 每张图片下载完成时调用
+   * @param options 可选图片类型过滤；不传时保持兼容，接收该章节的全部图片事件
    */
   addImageReadyListener(
     photoId: string,
     handler: (sortOrder: number) => void,
+    options: { type?: 'image' | 'thumb' } = {},
   ): Promise<JmcomicListenerHandle> {
     return native.addListener('imageReady', (data: ImageReadyEvent) => {
-      if (data.photoId === photoId) {
+      if (data.photoId === photoId && (!options.type || data.type === options.type)) {
         handler(data.sortOrder)
       }
     })

--- a/src/views/ReaderPage.vue
+++ b/src/views/ReaderPage.vue
@@ -128,12 +128,15 @@ let chapterLoadVersion = 0
 let chapterStateKey = ''
 let chapterStateAlbumId = ''
 let imageReadyListenerHandle: PluginListenerHandle | null = null
+let imageReadyListenerSetupPromise: Promise<void> | null = null
 let imageReadyListenerSetupId = 0
 let volumeKeyListenerHandle: PluginListenerHandle | null = null
 let readerRuntimeActive = false
 let loadedSortOrders = new Set<number>()
 let requestedSortOrders = new Set<number>()
 let sortOrderToImage = new Map<number, ImageInfo>()
+let activeAllowedSortOrders = new Set<number>()
+let activeDragPreviewSortOrder: number | null = null
 let lastWindowCenter = -1
 const triggerRafId = 0
 let expandDirection: 'forward' | 'backward' | null = null
@@ -382,6 +385,97 @@ const applyImageMap = () => {
   imageMap.value = new Map(imageMap.value)
 }
 
+interface ImageExposureContext {
+  version: number
+  albumId: string
+  chapterId: string
+  photoId: string
+}
+
+const createImageExposureContext = (): ImageExposureContext | null => {
+  if (!photoDetail) return null
+  return {
+    version: chapterLoadVersion,
+    albumId: albumId.value,
+    chapterId: chapterId.value,
+    photoId: photoDetail.id,
+  }
+}
+
+const isCurrentImageExposureContext = (context: ImageExposureContext) =>
+  context.version === chapterLoadVersion &&
+  context.albumId === albumId.value &&
+  context.chapterId === chapterId.value &&
+  context.photoId === photoDetail?.id
+
+const exposeImageIfAllowed = (
+  context: ImageExposureContext,
+  sortOrder: number,
+  type: 'image' | 'thumb',
+) => {
+  if (
+    type !== 'image' ||
+    !isCurrentImageExposureContext(context) ||
+    !activeAllowedSortOrders.has(sortOrder)
+  )
+    return false
+
+  imageMap.value.set(sortOrder, getImageUrl(context.photoId, sortOrder, 'image'))
+  loadedSortOrders.add(sortOrder)
+  return true
+}
+
+const exposeImagesIfAllowed = (
+  context: ImageExposureContext,
+  sortOrders: number[],
+  type: 'image' | 'thumb',
+) => {
+  let changed = false
+  for (const sortOrder of sortOrders) {
+    changed = exposeImageIfAllowed(context, sortOrder, type) || changed
+  }
+  if (changed) applyImageMap()
+}
+
+const setActiveAllowedSortOrders = (
+  sortOrders: Iterable<number>,
+  dragPreviewSortOrder: number | null,
+) => {
+  activeAllowedSortOrders = new Set(sortOrders)
+  if (dragPreviewSortOrder !== null) activeAllowedSortOrders.add(dragPreviewSortOrder)
+}
+
+const cleanupRequestedSortOrdersOutsideAllowed = () => {
+  for (const sortOrder of requestedSortOrders) {
+    if (!activeAllowedSortOrders.has(sortOrder) && !loadedSortOrders.has(sortOrder)) {
+      requestedSortOrders.delete(sortOrder)
+    }
+  }
+}
+
+const preloadSortOrders = (sortOrders: number[], replacePending = false) => {
+  const context = createImageExposureContext()
+  if (!context || !readerRuntimeActive || !imageReadyListenerHandle) return
+
+  const images: ImageInfo[] = []
+  for (const sortOrder of new Set(sortOrders)) {
+    if (!activeAllowedSortOrders.has(sortOrder) || loadedSortOrders.has(sortOrder)) continue
+    if (!replacePending && requestedSortOrders.has(sortOrder)) continue
+
+    const image = sortOrderToImage.get(sortOrder)
+    if (!image) continue
+    images.push(image)
+    requestedSortOrders.add(sortOrder)
+  }
+
+  if (images.length === 0) return
+  JmcomicService.preloadImages(context.photoId, images, 'image', { replacePending })
+    .then((result: PreloadResult) => {
+      exposeImagesIfAllowed(context, result.cached, 'image')
+    })
+    .catch(() => {})
+}
+
 const clampIndex = (index: number) => {
   if (totalCount.value <= 0) return 0
   return Math.min(totalCount.value - 1, Math.max(0, index))
@@ -405,42 +499,7 @@ const hasPendingInRange = (center: number, dir: 'forward' | 'backward'): boolean
 
 const updateWindow = (center: number, replacePending = false) => {
   if (!photoDetail) return
-  const requestedPhotoId = photoDetail.id
   const windowOrders = calcPriorityWindow(center)
-
-  if (isOffline.value) {
-    for (const so of windowOrders) {
-      if (!loadedSortOrders.has(so)) {
-        imageMap.value.set(so, getImageUrl(photoDetail.id, so, 'image'))
-        loadedSortOrders.add(so)
-      }
-    }
-  } else {
-    const toLoad: ImageInfo[] = []
-    for (const so of windowOrders) {
-      if (loadedSortOrders.has(so)) continue
-      const img = sortOrderToImage.get(so)
-      if (!img) continue
-      toLoad.push(img)
-      if (!requestedSortOrders.has(so)) {
-        requestedSortOrders.add(so)
-      }
-    }
-
-    if (toLoad.length > 0) {
-      JmcomicService.preloadImages(requestedPhotoId, toLoad, 'image', { replacePending })
-        .then((result: PreloadResult) => {
-          if (photoDetail?.id !== requestedPhotoId) return
-          for (const so of result.cached) {
-            imageMap.value.set(so, getImageUrl(requestedPhotoId, so, 'image'))
-            loadedSortOrders.add(so)
-          }
-          applyImageMap()
-        })
-        .catch(() => {})
-    }
-  }
-
   const cleanBackward = expandDirection === 'backward' ? N_FAST : Math.floor(M / 2)
   const cleanForward = expandDirection === 'forward' ? N_FAST : Math.floor(M / 2)
   const cacheMin = Math.max(0, center - cleanBackward)
@@ -454,42 +513,29 @@ const updateWindow = (center: number, replacePending = false) => {
   }
   for (const so of calcWindow(currentIndex.value)) cacheSet.add(so)
 
+  setActiveAllowedSortOrders(cacheSet, activeDragPreviewSortOrder)
+
   for (const so of loadedSortOrders) {
-    if (!cacheSet.has(so)) {
+    if (!activeAllowedSortOrders.has(so)) {
       imageMap.value.delete(so)
       loadedSortOrders.delete(so)
     }
   }
+  cleanupRequestedSortOrdersOutsideAllowed()
   applyImageMap()
+  preloadSortOrders(windowOrders, replacePending)
 }
 
 const loadDragPreviewImage = (center: number) => {
   if (!photoDetail) return
-  const requestedPhotoId = photoDetail.id
   const so = center + 1
-  if (so < 1 || so > totalCount.value || loadedSortOrders.has(so) || requestedSortOrders.has(so))
-    return
+  if (so < 1 || so > totalCount.value) return
 
-  if (isOffline.value) {
-    imageMap.value.set(so, getImageUrl(photoDetail.id, so, 'image'))
-    loadedSortOrders.add(so)
-    applyImageMap()
-    return
-  }
-
-  const img = sortOrderToImage.get(so)
-  if (!img) return
-  requestedSortOrders.add(so)
-  JmcomicService.preloadImages(requestedPhotoId, [img], 'image', { replacePending: true })
-    .then((result: PreloadResult) => {
-      if (photoDetail?.id !== requestedPhotoId) return
-      for (const cachedSo of result.cached) {
-        imageMap.value.set(cachedSo, getImageUrl(requestedPhotoId, cachedSo, 'image'))
-        loadedSortOrders.add(cachedSo)
-      }
-      applyImageMap()
-    })
-    .catch(() => {})
+  activeDragPreviewSortOrder = so
+  setActiveAllowedSortOrders(calcPriorityWindow(currentIndex.value), activeDragPreviewSortOrder)
+  cleanupRequestedSortOrdersOutsideAllowed()
+  if (loadedSortOrders.has(so)) return
+  preloadSortOrders([so], true)
 }
 
 const scheduleDragPreviewLoad = (index: number) => {
@@ -567,6 +613,7 @@ const goToIndex = (index: number, source: PageChangeSource) => {
     return
   }
 
+  activeDragPreviewSortOrder = null
   pendingSeekIndex = null
   if (dragPreviewTimer) {
     clearTimeout(dragPreviewTimer)
@@ -611,40 +658,53 @@ const onProgressInput = (page1Based: number) => {
 // ---- 图片就绪监听 ----
 const setupImageReadyListener = async () => {
   if (imageReadyListenerHandle) return
+  if (imageReadyListenerSetupPromise) return imageReadyListenerSetupPromise
+  const context = createImageExposureContext()
+  if (!readerRuntimeActive || !context) return
+
   const setupId = ++imageReadyListenerSetupId
-  const targetChapterId = chapterId.value
-  const handle = await JmcomicService.addImageReadyListener(targetChapterId, (sortOrder) => {
-    if (chapterId.value !== targetChapterId) return
-    imageMap.value.set(sortOrder, getImageUrl(targetChapterId, sortOrder, 'image'))
-    loadedSortOrders.add(sortOrder)
-    applyImageMap()
-  })
-  if (
-    setupId !== imageReadyListenerSetupId ||
-    !readerRuntimeActive ||
-    chapterId.value !== targetChapterId
-  ) {
-    handle.remove()
-    return
+  const setupPromise = (async () => {
+    const handle = await JmcomicService.addImageReadyListener(
+      context.photoId,
+      (sortOrder) => exposeImagesIfAllowed(context, [sortOrder], 'image'),
+      { type: 'image' },
+    )
+    if (
+      setupId !== imageReadyListenerSetupId ||
+      !readerRuntimeActive ||
+      !isCurrentImageExposureContext(context)
+    ) {
+      handle.remove()
+      return
+    }
+    imageReadyListenerHandle = handle
+  })()
+  imageReadyListenerSetupPromise = setupPromise
+  try {
+    await setupPromise
+  } finally {
+    if (imageReadyListenerSetupPromise === setupPromise) {
+      imageReadyListenerSetupPromise = null
+    }
   }
-  imageReadyListenerHandle = handle
 }
 
-const activateReaderRuntime = () => {
-  if (readerRuntimeActive) return
-  readerRuntimeActive = true
-  applyReaderSettings()
-  JmcomicService.setReaderState(true, isVertical.value).catch(() => {})
-  setupVolumeKeyListener().catch(() => {})
-  if (!isOffline.value && photoDetail) {
-    setupImageReadyListener().catch(() => {})
+const activateReaderRuntime = (): Promise<void> => {
+  if (!readerRuntimeActive) {
+    readerRuntimeActive = true
+    applyReaderSettings()
+    JmcomicService.setReaderState(true, isVertical.value).catch(() => {})
+    setupVolumeKeyListener().catch(() => {})
   }
+  if (!photoDetail) return Promise.resolve()
+  return setupImageReadyListener().catch(() => {})
 }
 
 const deactivateReaderRuntime = () => {
   if (!readerRuntimeActive) return
   readerRuntimeActive = false
   imageReadyListenerSetupId++
+  imageReadyListenerSetupPromise = null
   clearToolbarTapTimer()
   imageReadyListenerHandle?.remove()
   imageReadyListenerHandle = null
@@ -728,16 +788,20 @@ const loadDownloadedChapter = async (
     if (!isCurrentChapterLoad(version, targetAlbumId, targetChapterId)) return 'stale'
     isOffline.value = true
     applyPhotoBaseState(pd)
+    sortOrderToImage = new Map(pd.images.map((i) => [i.sortOrder, i]))
 
-    const initOrders = calcWindow(currentIndex.value)
-    const priorityInitOrders = prioritizeSortOrders(initOrders, currentIndex.value)
-    for (const so of priorityInitOrders) {
-      if (!loadedSortOrders.has(so)) {
-        imageMap.value.set(so, getImageUrl(pd.id, so, 'image'))
-        loadedSortOrders.add(so)
-      }
+    if (readerRuntimeActive) {
+      await setupImageReadyListener().catch(() => {})
     }
-    applyImageMap()
+    if (!isCurrentChapterLoad(version, targetAlbumId, targetChapterId) || photoDetail?.id !== pd.id)
+      return 'stale'
+
+    const priorityInitOrders = prioritizeSortOrders(
+      calcWindow(currentIndex.value),
+      currentIndex.value,
+    )
+    setActiveAllowedSortOrders(priorityInitOrders, null)
+    preloadSortOrders(priorityInitOrders)
     scrollToInitialIndex()
     recordBrowseHistory()
     return 'loaded'
@@ -761,33 +825,14 @@ const loadOnlineChapter = async (
     sortOrderToImage = new Map(pd.images.map((i) => [i.sortOrder, i]))
 
     if (readerRuntimeActive) {
-      setupImageReadyListener().catch(() => {})
+      await setupImageReadyListener().catch(() => {})
     }
+    if (!isCurrentChapterLoad(version, targetAlbumId, targetChapterId) || photoDetail?.id !== pd.id)
+      return
 
     const initOrders = prioritizeSortOrders(calcWindow(currentIndex.value), currentIndex.value)
-    const initOrderSet = new Set(initOrders)
-    const initImages = initOrders
-      .map((so) => sortOrderToImage.get(so))
-      .filter((i): i is ImageInfo => Boolean(i))
-    for (const so of initOrderSet) {
-      requestedSortOrders.add(so)
-    }
-    if (initImages.length > 0) {
-      JmcomicService.preloadImages(pd.id, initImages, 'image')
-        .then((result) => {
-          if (
-            !isCurrentChapterLoad(version, targetAlbumId, targetChapterId) ||
-            photoDetail?.id !== pd.id
-          )
-            return
-          for (const so of result.cached) {
-            imageMap.value.set(so, getImageUrl(pd.id, so, 'image'))
-            loadedSortOrders.add(so)
-          }
-          applyImageMap()
-        })
-        .catch(() => {})
-    }
+    setActiveAllowedSortOrders(initOrders, null)
+    preloadSortOrders(initOrders)
 
     scrollToInitialIndex()
     recordBrowseHistory()
@@ -816,6 +861,7 @@ const loadChapter = async () => {
 const resetChapterState = () => {
   chapterLoadVersion++
   imageReadyListenerSetupId++
+  imageReadyListenerSetupPromise = null
   clearAutoShowToolbarTimer()
   imageReadyListenerHandle?.remove()
   imageReadyListenerHandle = null
@@ -829,6 +875,8 @@ const resetChapterState = () => {
   loadedSortOrders = new Set()
   requestedSortOrders = new Set()
   sortOrderToImage = new Map()
+  activeAllowedSortOrders = new Set()
+  activeDragPreviewSortOrder = null
   lastWindowCenter = -1
   activeRenderRange = null
   pendingSeekIndex = null
@@ -860,7 +908,7 @@ onMounted(() => {
   chapterStateKey = `${albumId.value}:${chapterId.value}`
   chapterStateAlbumId = albumId.value
   resetChapterState()
-  activateReaderRuntime()
+  void activateReaderRuntime()
   void loadChapter()
 })
 
@@ -881,9 +929,10 @@ watch([albumId, chapterId], ([newAlbumId, newChapterId]) => {
 })
 
 onActivated(() => {
-  activateReaderRuntime()
-  nextTick(() => {
-    goToIndex(currentIndex.value, 'route')
+  void activateReaderRuntime().then(() => {
+    nextTick(() => {
+      goToIndex(currentIndex.value, 'route')
+    })
   })
 })
 

--- a/src/views/ReaderPage.vue
+++ b/src/views/ReaderPage.vue
@@ -133,7 +133,8 @@ let imageReadyListenerSetupId = 0
 let volumeKeyListenerHandle: PluginListenerHandle | null = null
 let readerRuntimeActive = false
 let loadedSortOrders = new Set<number>()
-let requestedSortOrders = new Set<number>()
+let requestedSortOrders = new Map<number, number>()
+let preloadRequestSequence = 0
 let sortOrderToImage = new Map<number, ImageInfo>()
 let activeAllowedSortOrders = new Set<number>()
 let activeDragPreviewSortOrder: number | null = null
@@ -446,7 +447,7 @@ const setActiveAllowedSortOrders = (
 }
 
 const cleanupRequestedSortOrdersOutsideAllowed = () => {
-  for (const sortOrder of requestedSortOrders) {
+  for (const sortOrder of requestedSortOrders.keys()) {
     if (!activeAllowedSortOrders.has(sortOrder) && !loadedSortOrders.has(sortOrder)) {
       requestedSortOrders.delete(sortOrder)
     }
@@ -465,14 +466,33 @@ const preloadSortOrders = (sortOrders: number[], replacePending = false) => {
     const image = sortOrderToImage.get(sortOrder)
     if (!image) continue
     images.push(image)
-    requestedSortOrders.add(sortOrder)
   }
 
   if (images.length === 0) return
-  JmcomicService.preloadImages(context.photoId, images, 'image', { replacePending })
-    .then((result: PreloadResult) => {
-      exposeImagesIfAllowed(context, result.cached, 'image')
-    })
+  const requestRegistry = requestedSortOrders
+  const requestBatchId = ++preloadRequestSequence
+  const submittedSortOrders = images.map((image) => image.sortOrder)
+  for (const sortOrder of submittedSortOrders) {
+    requestRegistry.set(sortOrder, requestBatchId)
+  }
+
+  void JmcomicService.preloadImages(context.photoId, images, 'image', { replacePending })
+    .then(
+      (result: PreloadResult) => {
+        exposeImagesIfAllowed(context, result.cached, 'image')
+      },
+      () => {
+        if (!isCurrentImageExposureContext(context)) return
+        for (const sortOrder of submittedSortOrders) {
+          if (
+            !loadedSortOrders.has(sortOrder) &&
+            requestRegistry.get(sortOrder) === requestBatchId
+          ) {
+            requestRegistry.delete(sortOrder)
+          }
+        }
+      },
+    )
     .catch(() => {})
 }
 
@@ -656,6 +676,11 @@ const onProgressInput = (page1Based: number) => {
 }
 
 // ---- 图片就绪监听 ----
+const removeListenerSafely = (handle: PluginListenerHandle | null) => {
+  if (!handle) return
+  void handle.remove().catch(() => {})
+}
+
 const setupImageReadyListener = async () => {
   if (imageReadyListenerHandle) return
   if (imageReadyListenerSetupPromise) return imageReadyListenerSetupPromise
@@ -674,7 +699,7 @@ const setupImageReadyListener = async () => {
       !readerRuntimeActive ||
       !isCurrentImageExposureContext(context)
     ) {
-      handle.remove()
+      removeListenerSafely(handle)
       return
     }
     imageReadyListenerHandle = handle
@@ -706,9 +731,9 @@ const deactivateReaderRuntime = () => {
   imageReadyListenerSetupId++
   imageReadyListenerSetupPromise = null
   clearToolbarTapTimer()
-  imageReadyListenerHandle?.remove()
+  removeListenerSafely(imageReadyListenerHandle)
   imageReadyListenerHandle = null
-  volumeKeyListenerHandle?.remove()
+  removeListenerSafely(volumeKeyListenerHandle)
   volumeKeyListenerHandle = null
   restoreSystemState()
 }
@@ -863,7 +888,7 @@ const resetChapterState = () => {
   imageReadyListenerSetupId++
   imageReadyListenerSetupPromise = null
   clearAutoShowToolbarTimer()
-  imageReadyListenerHandle?.remove()
+  removeListenerSafely(imageReadyListenerHandle)
   imageReadyListenerHandle = null
   photoDetail = null
   currentIndex.value = 0
@@ -873,7 +898,7 @@ const resetChapterState = () => {
   isDragProgress.value = false
   settingsPanelVisible.value = false
   loadedSortOrders = new Set()
-  requestedSortOrders = new Set()
+  requestedSortOrders = new Map()
   sortOrderToImage = new Map()
   activeAllowedSortOrders = new Set()
   activeDragPreviewSortOrder = null

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  addListener: vi.fn(),
+}))
+
+vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
+  jmcomicNativeClient: {
+    addListener: mocks.addListener,
+  },
+}))
+
+import type { ImageReadyEvent } from '@/services/jmcomic/JmcomicClient'
+import { JmcomicService } from '@/services/jmcomic/JmcomicServiceFacade'
+
+describe('JmcomicService.addImageReadyListener', () => {
+  let imageReadyHandler: ((event: ImageReadyEvent) => void) | null
+
+  beforeEach(() => {
+    imageReadyHandler = null
+    mocks.addListener.mockReset()
+    mocks.addListener.mockImplementation(
+      (_event: string, handler: (event: ImageReadyEvent) => void) => {
+        imageReadyHandler = handler
+        return Promise.resolve({ remove: vi.fn(() => Promise.resolve()) })
+      },
+    )
+  })
+
+  test('可按图片类型过滤事件', async () => {
+    const handler = vi.fn()
+    await JmcomicService.addImageReadyListener('chapter-1', handler, { type: 'image' })
+
+    imageReadyHandler?.({ photoId: 'chapter-1', sortOrder: 1, type: 'thumb' })
+    imageReadyHandler?.({ photoId: 'chapter-2', sortOrder: 2, type: 'image' })
+    imageReadyHandler?.({ photoId: 'chapter-1', sortOrder: 3, type: 'image' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(3)
+  })
+
+  test('未传类型时保持原有兼容行为', async () => {
+    const handler = vi.fn()
+    await JmcomicService.addImageReadyListener('chapter-1', handler)
+
+    imageReadyHandler?.({ photoId: 'chapter-1', sortOrder: 1, type: 'thumb' })
+    imageReadyHandler?.({ photoId: 'chapter-1', sortOrder: 2, type: 'image' })
+
+    expect(handler.mock.calls).toEqual([[1], [2]])
+  })
+})

--- a/tests/unit/ReaderPage.test.ts
+++ b/tests/unit/ReaderPage.test.ts
@@ -1,0 +1,346 @@
+/* eslint-disable vue/one-component-per-file -- test-only reader component fixtures */
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, type PropType } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { ImageInfo, PhotoDetail, PreloadResult } from '@/services/JmcomicTypes'
+
+const mocks = vi.hoisted(() => ({
+  setRouteSource: undefined as undefined | ((source?: string) => void),
+  router: {
+    back: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+  },
+  getDownloadedPhoto: vi.fn(),
+  getPhoto: vi.fn(),
+  getAlbum: vi.fn(),
+  preloadImages: vi.fn(),
+  addImageReadyListener: vi.fn(),
+  addVolumeKeyListener: vi.fn(),
+  imageReadyHandler: null as null | ((sortOrder: number) => void),
+  listenerRemove: vi.fn(() => Promise.resolve()),
+  getImageUrl: vi.fn(
+    (photoId: string, sortOrder: number, type: string) =>
+      `jqviewer.local/${photoId}/${type}/${sortOrder}`,
+  ),
+}))
+
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue')
+  const route = reactive({
+    name: 'ReaderPage',
+    params: { albumId: 'album-1', chapterId: 'chapter-1' },
+    query: {} as Record<string, string>,
+  })
+  mocks.setRouteSource = (source) => {
+    route.query = source ? { source } : {}
+  }
+  return {
+    useRoute: () => route,
+    useRouter: () => mocks.router,
+  }
+})
+
+vi.mock('@ionic/vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    IonPage: defineComponent({
+      name: 'IonPage',
+      setup(_, { slots }) {
+        return () => h('div', slots.default?.())
+      },
+    }),
+  }
+})
+
+vi.mock('@/services/JmcomicService', () => ({
+  getImageUrl: mocks.getImageUrl,
+  showToast: vi.fn(() => Promise.resolve()),
+  JmcomicService: {
+    getDownloadedPhoto: mocks.getDownloadedPhoto,
+    getPhoto: mocks.getPhoto,
+    getAlbum: mocks.getAlbum,
+    preloadImages: mocks.preloadImages,
+    addImageReadyListener: mocks.addImageReadyListener,
+    addVolumeKeyListener: mocks.addVolumeKeyListener,
+    setReaderBrightness: vi.fn(() => Promise.resolve()),
+    setReaderScreenOrientation: vi.fn(() => Promise.resolve()),
+    setReaderKeepScreenOn: vi.fn(() => Promise.resolve()),
+    setReaderFullscreen: vi.fn(() => Promise.resolve()),
+    setReaderState: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock('@/services/SettingsService', () => ({
+  SettingsStore: {
+    getReaderPreloadPages: () => 1,
+    getReaderDisplayMode: () => 'vertical',
+    getReaderScreenOrientation: () => 'auto',
+    getReaderBrightness: () => -1,
+    getReaderKeepScreenOn: () => false,
+    getReaderAutoShowToolbarAtEnd: () => false,
+  },
+}))
+
+vi.mock('@/services/HistoryService', () => ({
+  HistoryService: { recordBrowse: vi.fn() },
+}))
+
+vi.mock('@/services/ReadingProgressService', () => ({
+  ReadingProgressService: {
+    getInitialPage: () => 1,
+    record: vi.fn(),
+  },
+}))
+
+import ReaderPage from '@/views/ReaderPage.vue'
+
+const VerticalScrollViewStub = defineComponent({
+  name: 'VerticalScrollView',
+  props: {
+    imageMap: { type: Object as PropType<Map<number, string>>, required: true },
+    totalCount: { type: Number, required: true },
+    currentIndex: { type: Number, required: true },
+  },
+  emits: ['update:current-index', 'request-range', 'reached-bottom'],
+  setup(_, { expose }) {
+    expose({
+      scrollToIndex: vi.fn(),
+      isAtBottom: () => false,
+    })
+    return () => h('div', { class: 'vertical-reader-stub' })
+  },
+})
+
+const HorizontalPageViewStub = defineComponent({
+  name: 'HorizontalPageView',
+  props: {
+    imageMap: { type: Object as PropType<Map<number, string>>, required: true },
+    totalCount: { type: Number, required: true },
+    currentIndex: { type: Number, required: true },
+  },
+  emits: ['update:current-index', 'toggle-toolbar'],
+  setup(_, { expose }) {
+    expose({ scrollToIndex: vi.fn() })
+    return () => h('div')
+  },
+})
+
+const ReaderBottomToolbarStub = defineComponent({
+  name: 'ReaderBottomToolbar',
+  props: {
+    current: { type: Number, required: true },
+    total: { type: Number, required: true },
+    chapters: { type: Array, required: true },
+    currentChapterId: { type: String, required: true },
+  },
+  emits: [
+    'open-settings',
+    'select-chapter',
+    'update:current',
+    'update:current-input',
+    'progress-drag-start',
+    'progress-drag-end',
+  ],
+  setup() {
+    return () => h('div', { class: 'reader-bottom-toolbar-stub' })
+  },
+})
+
+const EmptyStub = defineComponent({
+  setup() {
+    return () => h('div')
+  },
+})
+
+const makePhoto = (count = 100): PhotoDetail => ({
+  id: 'chapter-1',
+  title: '章节 1',
+  albumId: 'album-1',
+  sortOrder: 1,
+  author: 'author',
+  tags: [],
+  images: Array.from({ length: count }, (_, index): ImageInfo => {
+    const sortOrder = index + 1
+    return {
+      photoId: 'chapter-1',
+      scrambleId: '0',
+      filename: `${sortOrder}.jpg`,
+      url: `https://example.com/${sortOrder}.jpg`,
+      queryParams: '',
+      sortOrder,
+    }
+  }),
+})
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+const mountReader = () =>
+  mount(ReaderPage, {
+    global: {
+      stubs: {
+        ReaderTopToolbar: EmptyStub,
+        ReaderBottomToolbar: ReaderBottomToolbarStub,
+        VerticalScrollView: VerticalScrollViewStub,
+        HorizontalPageView: HorizontalPageViewStub,
+        ReaderSettingsPanel: EmptyStub,
+      },
+    },
+  })
+
+const settle = async () => {
+  await flushPromises()
+  await nextTick()
+}
+
+const currentImageMap = (wrapper: ReturnType<typeof mountReader>) =>
+  wrapper.findComponent(VerticalScrollViewStub).props('imageMap') as Map<number, string>
+
+describe('ReaderPage 在线/离线统一图片加载', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    mocks.setRouteSource?.('download')
+    mocks.imageReadyHandler = null
+    mocks.getDownloadedPhoto.mockResolvedValue(makePhoto())
+    mocks.getPhoto.mockResolvedValue(makePhoto())
+    mocks.getAlbum.mockRejectedValue(new Error('skip history metadata'))
+    mocks.preloadImages.mockResolvedValue({ cached: [], pending: [] } satisfies PreloadResult)
+    mocks.addImageReadyListener.mockImplementation(
+      (_photoId: string, handler: (sortOrder: number) => void) => {
+        mocks.imageReadyHandler = handler
+        return Promise.resolve({ remove: mocks.listenerRemove })
+      },
+    )
+    mocks.addVolumeKeyListener.mockResolvedValue({ remove: vi.fn(() => Promise.resolve()) })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('离线章节等待 imageReady 监听注册后再预加载，并通过 cached 暴露图片', async () => {
+    const listener = deferred<{ remove: () => Promise<void> }>()
+    mocks.addImageReadyListener.mockImplementationOnce(
+      (_photoId: string, handler: (sortOrder: number) => void) => {
+        mocks.imageReadyHandler = handler
+        return listener.promise
+      },
+    )
+    mocks.preloadImages.mockResolvedValue({ cached: [1], pending: [2] } satisfies PreloadResult)
+
+    const wrapper = mountReader()
+    await nextTick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mocks.addImageReadyListener).toHaveBeenCalledWith('chapter-1', expect.any(Function), {
+      type: 'image',
+    })
+    expect(mocks.preloadImages).not.toHaveBeenCalled()
+    expect(currentImageMap(wrapper).size).toBe(0)
+
+    listener.resolve({ remove: mocks.listenerRemove })
+    await settle()
+
+    expect(mocks.preloadImages).toHaveBeenCalledWith(
+      'chapter-1',
+      expect.arrayContaining([
+        expect.objectContaining({ sortOrder: 1 }),
+        expect.objectContaining({ sortOrder: 2 }),
+      ]),
+      'image',
+      { replacePending: false },
+    )
+    expect(currentImageMap(wrapper).get(1)).toBe('jqviewer.local/chapter-1/image/1')
+
+    wrapper.unmount()
+  })
+
+  test('在线回退路径仍通过统一预加载入口显示图片', async () => {
+    mocks.setRouteSource?.()
+    mocks.getDownloadedPhoto.mockRejectedValue(new Error('not downloaded'))
+    mocks.preloadImages.mockResolvedValue({ cached: [1], pending: [] } satisfies PreloadResult)
+
+    const wrapper = mountReader()
+    await settle()
+
+    expect(mocks.getPhoto).toHaveBeenCalledWith('chapter-1')
+    expect(mocks.preloadImages).toHaveBeenCalledWith('chapter-1', expect.any(Array), 'image', {
+      replacePending: false,
+    })
+    expect(currentImageMap(wrapper).has(1)).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  test('窗口外晚到结果不写入，返回窗口后可重新探测 native cache', async () => {
+    const initialPreload = deferred<PreloadResult>()
+    mocks.preloadImages
+      .mockImplementationOnce(() => initialPreload.promise)
+      .mockResolvedValue({ cached: [], pending: [] } satisfies PreloadResult)
+
+    const wrapper = mountReader()
+    await settle()
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(1)
+
+    wrapper.findComponent(VerticalScrollViewStub).vm.$emit('update:current-index', 60)
+    await settle()
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(2)
+
+    initialPreload.resolve({ cached: [1], pending: [2] })
+    await settle()
+    mocks.imageReadyHandler?.(2)
+    await nextTick()
+    expect(currentImageMap(wrapper).has(1)).toBe(false)
+    expect(currentImageMap(wrapper).has(2)).toBe(false)
+
+    wrapper.findComponent(VerticalScrollViewStub).vm.$emit('update:current-index', 0)
+    await settle()
+
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(3)
+    const returnImages = mocks.preloadImages.mock.calls[2][1] as ImageInfo[]
+    expect(returnImages.map((image) => image.sortOrder)).toEqual([1, 2])
+
+    wrapper.unmount()
+  })
+
+  test('拖动预览可绕过 requested 标记，旧目标晚到事件被拒绝', async () => {
+    mocks.preloadImages.mockResolvedValue({ cached: [], pending: [1, 2] } satisfies PreloadResult)
+    const wrapper = mountReader()
+    await settle()
+    vi.useFakeTimers()
+
+    const toolbar = wrapper.findComponent(ReaderBottomToolbarStub)
+    toolbar.vm.$emit('progress-drag-start')
+    toolbar.vm.$emit('update:current-input', 2)
+    await nextTick()
+    vi.advanceTimersByTime(500)
+    await settle()
+
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(2)
+    expect(mocks.preloadImages.mock.calls[1][1]).toEqual([
+      expect.objectContaining({ sortOrder: 2 }),
+    ])
+    expect(mocks.preloadImages.mock.calls[1][3]).toEqual({ replacePending: true })
+
+    toolbar.vm.$emit('update:current-input', 50)
+    await nextTick()
+    vi.advanceTimersByTime(500)
+    await settle()
+    mocks.imageReadyHandler?.(2)
+    await nextTick()
+
+    expect(currentImageMap(wrapper).has(2)).toBe(false)
+
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/ReaderPage.test.ts
+++ b/tests/unit/ReaderPage.test.ts
@@ -282,6 +282,85 @@ describe('ReaderPage 在线/离线统一图片加载', () => {
     wrapper.unmount()
   })
 
+  test('预加载调用拒绝后可在同一窗口重新提交', async () => {
+    mocks.preloadImages
+      .mockRejectedValueOnce(new Error('bridge failure'))
+      .mockResolvedValue({ cached: [], pending: [1, 2] } satisfies PreloadResult)
+
+    const wrapper = mountReader()
+    await settle()
+
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(1)
+    const initialSortOrders = (mocks.preloadImages.mock.calls[0][1] as ImageInfo[]).map(
+      (image) => image.sortOrder,
+    )
+
+    wrapper.findComponent(VerticalScrollViewStub).vm.$emit('request-range', {
+      start: 0,
+      end: 2,
+      center: 0,
+    })
+    await settle()
+
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(2)
+    expect(mocks.preloadImages.mock.calls[1][3]).toEqual({ replacePending: false })
+    expect(
+      (mocks.preloadImages.mock.calls[1][1] as ImageInfo[]).map((image) => image.sortOrder),
+    ).toEqual(initialSortOrders)
+
+    wrapper.unmount()
+  })
+
+  test('旧批次晚到拒绝不会清除新批次请求标记', async () => {
+    const initialPreload = deferred<PreloadResult>()
+    mocks.preloadImages
+      .mockImplementationOnce(() => initialPreload.promise)
+      .mockResolvedValue({ cached: [], pending: [1, 2] } satisfies PreloadResult)
+
+    const wrapper = mountReader()
+    await settle()
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(1)
+
+    wrapper.findComponent(ReaderBottomToolbarStub).vm.$emit('update:current', 1)
+    await settle()
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(2)
+    expect(mocks.preloadImages.mock.calls[1][3]).toEqual({ replacePending: true })
+
+    initialPreload.reject(new Error('stale batch failure'))
+    await settle()
+
+    wrapper.findComponent(VerticalScrollViewStub).vm.$emit('request-range', {
+      start: 0,
+      end: 2,
+      center: 0,
+    })
+    await settle()
+
+    expect(mocks.preloadImages).toHaveBeenCalledTimes(2)
+
+    wrapper.unmount()
+  })
+
+  test('监听注册晚到时安全处理 remove 拒绝', async () => {
+    const listener = deferred<{ remove: () => Promise<void> }>()
+    const remove = vi.fn(() => Promise.reject(new Error('remove failed')))
+    mocks.addImageReadyListener.mockImplementationOnce(
+      (_photoId: string, handler: (sortOrder: number) => void) => {
+        mocks.imageReadyHandler = handler
+        return listener.promise
+      },
+    )
+
+    const wrapper = mountReader()
+    await vi.waitFor(() => expect(mocks.addImageReadyListener).toHaveBeenCalledTimes(1))
+    wrapper.unmount()
+
+    listener.resolve({ remove })
+    await settle()
+
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+
   test('窗口外晚到结果不写入，返回窗口后可重新探测 native cache', async () => {
     const initialPreload = deferred<PreloadResult>()
     mocks.preloadImages


### PR DESCRIPTION
- 在线和离线章节统一通过 preloadImages 准备阅读页图片
- 首次预加载前等待 imageReady 监听完成注册
- 增加章节版本、图片类型和活动窗口的严格回写校验
- 清理窗口外未完成请求，允许返回窗口后重新探测原生缓存
- 统一拖动预览入口并拒绝旧目标的晚到结果
- 为 imageReady 监听增加可选的图片类型过滤
- 补充 ReaderPage 和 JmcomicServiceFacade 单元测试

本次不涉及图片损坏校验、下载完整性、URL 刷新、重试恢复或原生网络 fallback。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 阅读器支持更精准的图片与缩略图就绪事件处理。
  - 优化章节图片预加载、缓存及拖动预览体验。
  - 章节切换、离线阅读和阅读器重新激活时，可更稳定地恢复当前阅读位置。

- **问题修复**
  - 避免窗口范围外的图片请求、缓存和延迟结果影响当前阅读内容。
  - 改善章节切换及阅读器停用后的异步状态清理，减少显示错误和过期图片干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->