### PR TITLE
feat(download): 完善下载完成校验与批量通知管理

### DIFF
--- a/android/app/src/androidTest/java/io/github/jukomu/data/FileStoreMetadataInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/FileStoreMetadataInstrumentedTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class FileStoreMetadataInstrumentedTest {
@@ -96,6 +97,25 @@ public class FileStoreMetadataInstrumentedTest {
 
         assertThrows(IOException.class,
             () -> fileStore.saveMeta("album", "chapter", new JSONObject()));
+    }
+
+    @Test
+    public void unsafeChapterIdsCannotDeleteOutsideBaseDirectory() throws Exception {
+        File outsideDir = new File(testBaseDir.getParentFile(),
+            testBaseDir.getName() + "-outside");
+        File marker = new File(outsideDir, "marker.txt");
+        try {
+            assertTrue(outsideDir.mkdirs());
+            Files.write(marker.toPath(), new byte[]{1});
+
+            assertThrows(IllegalArgumentException.class,
+                () -> fileStore.deleteChapter("..", outsideDir.getName()));
+            assertThrows(IllegalArgumentException.class,
+                () -> fileStore.deleteChapter("", ""));
+            assertTrue(marker.isFile());
+        } finally {
+            deleteRecursive(outsideDir);
+        }
     }
 
     private static void deleteRecursive(File file) {

--- a/android/app/src/androidTest/java/io/github/jukomu/data/FileStoreMetadataInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/FileStoreMetadataInstrumentedTest.java
@@ -1,0 +1,111 @@
+package io.github.jukomu.data;
+
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(AndroidJUnit4.class)
+public class FileStoreMetadataInstrumentedTest {
+
+    private FileStore fileStore;
+    private Field baseDirField;
+    private File testBaseDir;
+
+    @Before
+    public void setUp() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        testBaseDir = new File(context.getCacheDir(),
+            "file-store-metadata-test-" + System.nanoTime());
+        if (!testBaseDir.mkdirs()) {
+            throw new IOException("无法创建测试目录");
+        }
+
+        fileStore = FileStore.getInstance();
+        baseDirField = FileStore.class.getDeclaredField("baseDir");
+        baseDirField.setAccessible(true);
+        baseDirField.set(fileStore, testBaseDir);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        baseDirField.set(fileStore, null);
+        deleteRecursive(testBaseDir);
+    }
+
+    @Test
+    public void savesMetadataAtomicallyAndReadsItBack() throws Exception {
+        JSONObject metadata = new JSONObject().put("albumId", "album");
+
+        fileStore.saveMeta("album", "chapter", metadata);
+
+        assertEquals("album", fileStore.readMeta("album", "chapter").getString("albumId"));
+        assertFalse(new File(fileStore.getChapterDir("album", "chapter"),
+            "meta.json.tmp").exists());
+    }
+
+    @Test
+    public void preservesMetadataReadErrors() throws Exception {
+        assertThrows(FileNotFoundException.class,
+            () -> fileStore.readMeta("album", "missing"));
+
+        File chapterDir = fileStore.ensureChapterDir("album", "broken");
+        Files.write(new File(chapterDir, "meta.json").toPath(),
+            "{".getBytes(StandardCharsets.UTF_8));
+        assertThrows(org.json.JSONException.class,
+            () -> fileStore.readMeta("album", "broken"));
+    }
+
+    @Test
+    public void expectedImageFileUsesManifestFilenameOnly() throws Exception {
+        File chapterDir = fileStore.ensureChapterDir("album", "chapter");
+        File image = new File(chapterDir, "page.jpg");
+        Files.write(image.toPath(), new byte[]{1});
+
+        assertEquals(image.getCanonicalFile(),
+            fileStore.getExpectedImageFile("album", "chapter", "page.jpg"));
+        assertNull(fileStore.getExpectedImageFile("album", "chapter", null));
+        assertNull(fileStore.getExpectedImageFile("album", "chapter", " "));
+        assertNull(fileStore.getExpectedImageFile("album", "chapter", "missing.jpg"));
+        assertNull(fileStore.getExpectedImageFile("album", "chapter", "../page.jpg"));
+    }
+
+    @Test
+    public void saveMetadataFailureIsReported() throws Exception {
+        File invalidBase = new File(testBaseDir, "not-a-directory");
+        Files.write(invalidBase.toPath(), new byte[]{1});
+        baseDirField.set(fileStore, invalidBase);
+
+        assertThrows(IOException.class,
+            () -> fileStore.saveMeta("album", "chapter", new JSONObject()));
+    }
+
+    private static void deleteRecursive(File file) {
+        if (file == null || !file.exists()) return;
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursive(child);
+            }
+        }
+        file.delete();
+    }
+}

--- a/android/app/src/androidTest/java/io/github/jukomu/data/ImageFileValidatorInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/ImageFileValidatorInstrumentedTest.java
@@ -1,0 +1,83 @@
+package io.github.jukomu.data;
+
+import android.graphics.Bitmap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class ImageFileValidatorInstrumentedTest {
+
+    private File testDir;
+
+    @Before
+    public void setUp() {
+        File cacheDir = InstrumentationRegistry.getInstrumentation()
+            .getTargetContext().getCacheDir();
+        testDir = new File(cacheDir, "image-validator-test-" + System.nanoTime());
+        if (!testDir.mkdirs()) {
+            throw new IllegalStateException("无法创建测试目录");
+        }
+    }
+
+    @After
+    public void tearDown() {
+        deleteRecursive(testDir);
+    }
+
+    @Test
+    public void acceptsDecodedJpegWithFullAndQuickValidation() throws Exception {
+        File image = new File(testDir, "page.jpg");
+        Bitmap bitmap = Bitmap.createBitmap(2, 3, Bitmap.Config.ARGB_8888);
+        try (FileOutputStream output = new FileOutputStream(image)) {
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 90, output));
+        } finally {
+            bitmap.recycle();
+        }
+
+        assertTrue(ImageFileValidator.validateQuick(image));
+        assertTrue(ImageFileValidator.validateFull(image));
+    }
+
+    @Test
+    public void rejectsMissingEmptyDirectoryAndRandomFiles() throws Exception {
+        assertFalse(ImageFileValidator.validateFull(null));
+        assertFalse(ImageFileValidator.validateQuick(new File(testDir, "missing.jpg")));
+
+        File empty = new File(testDir, "empty.jpg");
+        Files.createFile(empty.toPath());
+        assertFalse(ImageFileValidator.validateFull(empty));
+
+        File directory = new File(testDir, "directory.jpg");
+        assertTrue(directory.mkdirs());
+        assertFalse(ImageFileValidator.validateFull(directory));
+
+        File random = new File(testDir, "random.jpg");
+        Files.write(random.toPath(), new byte[]{1, 2, 3, 4});
+        assertFalse(ImageFileValidator.validateQuick(random));
+        assertFalse(ImageFileValidator.validateFull(random));
+    }
+
+    private static void deleteRecursive(File file) {
+        if (file == null || !file.exists()) return;
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursive(child);
+            }
+        }
+        file.delete();
+    }
+}

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -165,8 +165,16 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
                 String s = t.optString("status");
                 if ("queued".equals(s) || "downloading".equals(s)
                     || "paused".equals(s) || "verifying".equals(s)) {
-                    FileStore.getInstance().deleteChapter(
-                        t.optString("albumId"), t.optString("chapterId"));
+                    String albumId = t.optString("albumId");
+                    String chapterId = t.optString("chapterId");
+                    try {
+                        FileStore.validateChapterIds(albumId, chapterId);
+                    } catch (IllegalArgumentException error) {
+                        Log.w(TAG, "跳过章节标识无效的遗留任务: "
+                            + t.optString("taskId"), error);
+                        continue;
+                    }
+                    FileStore.getInstance().deleteChapter(albumId, chapterId);
                 }
             }
 

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -163,13 +163,14 @@ public class JmcomicPlugin extends Plugin implements ServiceListener {
             List<JSONObject> zombieTasks = downloadDb.getAllTasks();
             for (JSONObject t : zombieTasks) {
                 String s = t.optString("status");
-                if ("queued".equals(s) || "downloading".equals(s) || "paused".equals(s)) {
+                if ("queued".equals(s) || "downloading".equals(s)
+                    || "paused".equals(s) || "verifying".equals(s)) {
                     FileStore.getInstance().deleteChapter(
                         t.optString("albumId"), t.optString("chapterId"));
                 }
             }
 
-            downloadDb.validateOnStartup(FileStore.getInstance().getBaseDir());
+            downloadDb.validateOnStartup();
         }
 
         // 读取用户期望容量，通过统一策略初始化实际缓存上限

--- a/android/app/src/main/java/io/github/jukomu/data/DownloadStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/DownloadStore.java
@@ -9,7 +9,6 @@ import android.util.Log;
 
 import org.json.JSONObject;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -210,7 +209,8 @@ public class DownloadStore extends SQLiteOpenHelper {
                 if (c.moveToFirst()) {
                     String status = c.getString(0);
                     return "queued".equals(status) || "downloading".equals(status)
-                        || "paused".equals(status) || "completed".equals(status);
+                        || "paused".equals(status) || "verifying".equals(status)
+                        || "completed".equals(status);
                 }
             } finally {
                 c.close();
@@ -220,8 +220,6 @@ public class DownloadStore extends SQLiteOpenHelper {
     }
 
     public List<JSONObject> getAllTasks() {
-        normalizeFullyDownloadedFailures();
-
         List<JSONObject> list = new ArrayList<>();
         Cursor c = getReadableDatabase().query(TABLE_TASKS, null, null,
             null, null, null, COL_CREATED_AT + " DESC", "500");
@@ -243,8 +241,6 @@ public class DownloadStore extends SQLiteOpenHelper {
     }
 
     public JSONObject getTask(String taskId) {
-        normalizeFullyDownloadedFailures();
-
         Cursor c = getReadableDatabase().query(TABLE_TASKS, null,
             COL_TASK_ID + " = ?", new String[]{taskId},
             null, null, null);
@@ -326,124 +322,14 @@ public class DownloadStore extends SQLiteOpenHelper {
 
     // ========== 启动校验 ==========
 
-    public void validateOnStartup(File baseDir) {
+    public void validateOnStartup() {
         SQLiteDatabase db = getWritableDatabase();
-        db.beginTransaction();
-        try {
-            // 1. 僵尸恢复：queued/downloading → failed
-            ContentValues cvZombie = new ContentValues();
-            cvZombie.put(COL_STATUS, "failed");
-            cvZombie.put(COL_ERROR, "App restart, task interrupted");
-            db.update(TABLE_TASKS, cvZombie,
-                COL_STATUS + " IN ('queued', 'downloading', 'paused')", null);
-
-            // 2. 校验 completed 任务的文件完整性
-            Cursor c = db.query(TABLE_TASKS,
-                new String[]{COL_TASK_ID, COL_ALBUM_ID, COL_CHAPTER_ID, COL_TOTAL_PAGES},
-                COL_STATUS + " = ?", new String[]{"completed"},
-                null, null, null);
-            if (c != null) {
-                try {
-                    while (c.moveToNext()) {
-                        String taskId = c.getString(0);
-                        String aid = c.getString(1);
-                        String cid = c.getString(2);
-                        int total = c.getInt(3);
-
-                        File chapterDir = new File(baseDir,
-                            aid + File.separator + cid);
-                        if (!chapterDir.isDirectory()) {
-                            ContentValues cv = new ContentValues();
-                            cv.put(COL_STATUS, "failed");
-                            cv.put(COL_ERROR, "Download file directory missing");
-                            db.update(TABLE_TASKS, cv,
-                                COL_TASK_ID + " = ?", new String[]{taskId});
-                            Log.w(TAG, "Startup check: mark " + taskId + " failed (dir missing)");
-                            continue;
-                        }
-
-                        // 检查 meta.json 是否存在作为快速校验
-                        File metaFile = new File(chapterDir, "meta.json");
-                        if (!metaFile.exists()) {
-                            ContentValues cv = new ContentValues();
-                            cv.put(COL_STATUS, "failed");
-                            cv.put(COL_ERROR, "meta.json missing");
-                            db.update(TABLE_TASKS, cv,
-                                COL_TASK_ID + " = ?", new String[]{taskId});
-                            Log.w(TAG, "Startup check: mark " + taskId + " failed (meta missing)");
-                        }
-
-                        // 检查图片文件数量
-                        File[] imageFiles = chapterDir.listFiles(
-                            (dir, name) -> !name.equals("meta.json") && !name.endsWith(".tmp"));
-                        int fileCount = imageFiles != null ? imageFiles.length : 0;
-                        if (fileCount < total) {
-                            ContentValues cv = new ContentValues();
-                            cv.put(COL_STATUS, "failed");
-                            cv.put(COL_ERROR, "Missing images: " + fileCount + "/" + total);
-                            db.update(TABLE_TASKS, cv,
-                                COL_TASK_ID + " = ?", new String[]{taskId});
-                            Log.w(TAG, "Startup check: mark " + taskId
-                                + " failed (images " + fileCount + "/" + total + ")");
-                        }
-                    }
-                } finally {
-                    c.close();
-                }
-            }
-            db.setTransactionSuccessful();
-        } finally {
-            db.endTransaction();
-        }
-    }
-
-    // ========== 辅助 ==========
-
-    private void normalizeFullyDownloadedFailures() {
-        SQLiteDatabase db = getWritableDatabase();
-        Cursor c = db.query(TABLE_TASKS,
-            new String[]{COL_TASK_ID, COL_FIRST_IMAGE_SORT_ORDER},
-            COL_STATUS + " = ? AND " + COL_TOTAL_PAGES + " > 0 AND "
-                + COL_DOWNLOADED_PAGES + " >= " + COL_TOTAL_PAGES,
-            new String[]{"failed"}, null, null, null);
-        if (c != null) {
-            try {
-                while (c.moveToNext()) {
-                    String taskId = c.getString(0);
-                    ContentValues cv = new ContentValues();
-                    cv.put(COL_STATUS, "completed");
-                    cv.putNull(COL_ERROR);
-                    cv.put(COL_COMPLETED_AT, System.currentTimeMillis());
-                    if (c.isNull(1)) {
-                        Integer firstSortOrder = findFirstImageSortOrder(db, taskId);
-                        if (firstSortOrder != null) {
-                            cv.put(COL_FIRST_IMAGE_SORT_ORDER, firstSortOrder);
-                        }
-                    }
-                    db.update(TABLE_TASKS, cv,
-                        COL_TASK_ID + " = ?", new String[]{taskId});
-                }
-            } finally {
-                c.close();
-            }
-        }
-    }
-
-    private Integer findFirstImageSortOrder(SQLiteDatabase db, String taskId) {
-        Cursor c = db.query(TABLE_IMAGES,
-            new String[]{"MIN(" + COL_SORT_ORDER + ")"},
-            COL_TASK_ID + " = ?", new String[]{taskId},
-            null, null, null);
-        if (c != null) {
-            try {
-                if (c.moveToFirst() && !c.isNull(0)) {
-                    return c.getInt(0);
-                }
-            } finally {
-                c.close();
-            }
-        }
-        return null;
+        ContentValues values = new ContentValues();
+        values.put(COL_STATUS, "failed");
+        values.put(COL_ERROR, "应用重启，下载或校验中断");
+        db.update(TABLE_TASKS, values,
+            COL_STATUS + " IN (?, ?, ?, ?)",
+            new String[]{"queued", "downloading", "paused", "verifying"});
     }
 
     private JSONObject cursorToTaskJson(Cursor c) {

--- a/android/app/src/main/java/io/github/jukomu/data/FileStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/FileStore.java
@@ -115,7 +115,13 @@ public class FileStore {
 
     // ---- 目录/文件操作 ----
 
+    public static void validateChapterIds(String albumId, String chapterId) {
+        validatePathSegment("albumId", albumId);
+        validatePathSegment("chapterId", chapterId);
+    }
+
     public File getChapterDir(String albumId, String chapterId) {
+        validateChapterIds(albumId, chapterId);
         return new File(baseDir, albumId + File.separator + chapterId);
     }
 
@@ -612,5 +618,14 @@ public class FileStore {
             }
         }
         dir.delete();
+    }
+
+    private static void validatePathSegment(String fieldName, String value) {
+        if (value == null || value.trim().isEmpty()
+            || ".".equals(value) || "..".equals(value)
+            || value.indexOf('/') >= 0 || value.indexOf('\\') >= 0
+            || new File(value).isAbsolute()) {
+            throw new IllegalArgumentException(fieldName + " 必须是非空的单个路径段");
+        }
     }
 }

--- a/android/app/src/main/java/io/github/jukomu/data/FileStore.java
+++ b/android/app/src/main/java/io/github/jukomu/data/FileStore.java
@@ -5,10 +5,14 @@ import android.content.Context;
 import android.media.MediaScannerConnection;
 import android.os.Environment;
 import android.util.Log;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -124,25 +128,62 @@ public class FileStore {
     }
 
     @SuppressLint("NewApi")
-    public void saveMeta(String albumId, String chapterId, JSONObject metaJson) {
+    public void saveMeta(String albumId, String chapterId, JSONObject metaJson)
+            throws IOException {
+        File dir = ensureChapterDir(albumId, chapterId);
+        File target = new File(dir, META_FILE);
+        File temp = new File(dir, META_FILE + ".tmp");
+        final byte[] bytes;
         try {
-            File dir = ensureChapterDir(albumId, chapterId);
-            File metaFile = new File(dir, META_FILE);
-            Files.write(metaFile.toPath(), metaJson.toString(2).getBytes("UTF-8"));
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to save meta.json", e);
+            bytes = metaJson.toString(2).getBytes(StandardCharsets.UTF_8);
+        } catch (JSONException error) {
+            throw new IOException("meta.json 序列化失败", error);
+        }
+
+        try {
+            Files.write(temp.toPath(), bytes);
+            try {
+                Files.move(temp.toPath(), target.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException error) {
+                Files.move(temp.toPath(), target.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException error) {
+            try {
+                Files.deleteIfExists(temp.toPath());
+            } catch (IOException cleanupError) {
+                error.addSuppressed(cleanupError);
+            }
+            throw error;
         }
     }
 
     @SuppressLint("NewApi")
-    JSONObject readMeta(String albumId, String chapterId) {
+    public JSONObject readMeta(String albumId, String chapterId)
+            throws IOException, JSONException {
+        File metaFile = new File(getChapterDir(albumId, chapterId), META_FILE);
+        if (!metaFile.isFile()) {
+            throw new FileNotFoundException(metaFile.getPath());
+        }
+
+        byte[] bytes = Files.readAllBytes(metaFile.toPath());
+        return new JSONObject(new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    public File getExpectedImageFile(String albumId, String chapterId,
+                                     String expectedFilename) {
+        if (expectedFilename == null || expectedFilename.trim().isEmpty()) {
+            return null;
+        }
+
         try {
-            File metaFile = new File(getChapterDir(albumId, chapterId), META_FILE);
-            if (!metaFile.exists()) return null;
-            byte[] bytes = Files.readAllBytes(metaFile.toPath());
-            return new JSONObject(new String(bytes, "UTF-8"));
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to read meta.json", e);
+            return resolveImageFile(
+                getChapterDir(albumId, chapterId),
+                expectedFilename);
+        } catch (IOException error) {
+            Log.w(TAG, "预期图片文件查询失败", error);
             return null;
         }
     }

--- a/android/app/src/main/java/io/github/jukomu/data/ImageFileValidator.java
+++ b/android/app/src/main/java/io/github/jukomu/data/ImageFileValidator.java
@@ -1,0 +1,69 @@
+package io.github.jukomu.data;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import java.io.File;
+
+/**
+ * 图片文件校验工具。
+ *
+ */
+public final class ImageFileValidator {
+
+    private static final String TAG = "ImageFileValidator";
+
+    private ImageFileValidator() {
+    }
+
+    /**
+     * 快速校验只读取图片边界
+     *
+     */
+    public static boolean validateQuick(File imageFile) {
+        if (!isNonEmptyFile(imageFile)) {
+            return false;
+        }
+
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        try {
+            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), options);
+            return options.outWidth > 0 && options.outHeight > 0;
+        } catch (RuntimeException | OutOfMemoryError error) {
+            Log.w(TAG, "快速图片校验失败: " + imageFile.getPath(), error);
+            return false;
+        }
+    }
+
+    /**
+     * 完整校验实际解码图片
+     *
+     */
+    public static synchronized boolean validateFull(File imageFile) {
+        if (!isNonEmptyFile(imageFile)) {
+            return false;
+        }
+
+        Bitmap bitmap = null;
+        try {
+            bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath());
+            return bitmap != null && bitmap.getWidth() > 0 && bitmap.getHeight() > 0;
+        } catch (RuntimeException error) {
+            Log.w(TAG, "完整图片校验失败: " + imageFile.getPath(), error);
+            return false;
+        } catch (OutOfMemoryError error) {
+            Log.e(TAG, "完整图片校验资源不足: " + imageFile.getPath(), error);
+            throw error;
+        } finally {
+            if (bitmap != null && !bitmap.isRecycled()) {
+                bitmap.recycle();
+            }
+        }
+    }
+
+    private static boolean isNonEmptyFile(File imageFile) {
+        return imageFile != null && imageFile.isFile() && imageFile.length() > 0L;
+    }
+}

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadNotificationHelper.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadNotificationHelper.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Build;
+import android.service.notification.StatusBarNotification;
 import android.util.Log;
 import android.widget.RemoteViews;
 import androidx.core.app.NotificationCompat;
@@ -19,7 +20,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -33,16 +40,30 @@ public class DownloadNotificationHelper {
     private static final int ICON = R.mipmap.ic_launcher;
     private static final int MAX_COVER_BYTES = 3 * 1024 * 1024;
     private static final int COVER_TARGET_SIZE = 256;
+    private static final int MAX_VISIBLE_TASK_NOTIFICATIONS = 12;
+    private static final int MAX_RECENT_RESULTS = 5;
+    private static final long INVALID_NOTIFICATION_VERSION = -1L;
 
     private final Context context;
     private final NotificationManager manager;
-    private final Map<String, String> queuedTasks = new ConcurrentHashMap<>();
     private final Map<String, Bitmap> coverCache = new ConcurrentHashMap<>();
+    private final Object notificationStateLock = new Object();
+    private final Set<String> pendingTaskIds = new HashSet<>();
+    private final Set<String> visibleTaskIds = new HashSet<>();
+    private final Set<String> pausedTaskIds = new LinkedHashSet<>();
+    private final Map<String, Long> taskNotificationVersions = new HashMap<>();
+    private final ArrayDeque<String> recentCompleted = new ArrayDeque<>();
+    private final ArrayDeque<String> recentFailed = new ArrayDeque<>();
+    private long nextNotificationVersion;
+    private int completedCount;
+    private int failedCount;
+    private int cancelledCount;
 
     public DownloadNotificationHelper(Context context) {
         this.context = context.getApplicationContext();
         this.manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         createChannel();
+        clearStaleDownloadNotifications();
     }
 
     private void createChannel() {
@@ -58,59 +79,32 @@ public class DownloadNotificationHelper {
         }
     }
 
-    public void showQueued(String taskId, String chapterTitle) {
-        queuedTasks.put(taskId, chapterTitle);
-        updateQueuedSummary();
-    }
-
-    public void removeQueued(String taskId) {
-        queuedTasks.remove(taskId);
-        updateQueuedSummary();
-    }
-
-    private void updateQueuedSummary() {
-        if (queuedTasks.isEmpty()) {
-            cancel(NotificationIds.DOWNLOAD_QUEUE_SUMMARY);
-            return;
+    public void registerTask(String taskId) {
+        synchronized (notificationStateLock) {
+            if (pendingTaskIds.isEmpty()) {
+                for (String visibleTaskId : visibleTaskIds) {
+                    cancel(NotificationIds.downloadTask(visibleTaskId));
+                }
+                visibleTaskIds.clear();
+                pausedTaskIds.clear();
+                taskNotificationVersions.clear();
+                completedCount = 0;
+                failedCount = 0;
+                cancelledCount = 0;
+                recentCompleted.clear();
+                recentFailed.clear();
+                cancel(NotificationIds.DOWNLOAD_COMPLETED_SUMMARY);
+                cancel(NotificationIds.DOWNLOAD_FAILED_SUMMARY);
+            }
+            pendingTaskIds.add(taskId);
         }
-
-        NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle()
-            .setBigContentTitle("下载队列 (" + queuedTasks.size() + ")");
-        int count = 0;
-        for (String title : queuedTasks.values()) {
-            if (count >= 5) break;
-            style.addLine(title);
-            count++;
-        }
-        if (queuedTasks.size() > count) {
-            style.setSummaryText("还有 " + (queuedTasks.size() - count) + " 个任务");
-        }
-
-        notify(NotificationIds.DOWNLOAD_QUEUE_SUMMARY, new NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(ICON)
-            .setContentTitle("下载队列")
-            .setContentText("已排队 " + queuedTasks.size() + " 个章节")
-            .setStyle(style)
-            .setContentIntent(createLaunchIntent(NotificationIds.DOWNLOAD_QUEUE_SUMMARY))
-            .setAutoCancel(false)
-            .setOngoing(false)
-            .setOnlyAlertOnce(true)
-            .build());
-    }
-
-    public void showPreparing(int notificationId, String taskId, String albumTitle,
-                              String chapterId, String chapterTitle, String coverUrl) {
-        NotificationCompat.Builder builder = buildTaskNotification(
-            taskId, albumTitle, chapterId, chapterTitle, coverUrl,
-            0, 0, "准备下载", true);
-        builder.addAction(ICON, "取消", createActionIntent(
-            DownloadNotificationActionReceiver.ACTION_CANCEL, taskId));
-        notify(notificationId, builder.build());
     }
 
     public void showProgress(int notificationId, String taskId, String albumTitle,
                              String chapterId, String chapterTitle, String coverUrl,
                              int downloadedPages, int totalPages) {
+        long version = beginTaskNotificationUpdate(taskId, true);
+        if (version == INVALID_NOTIFICATION_VERSION) return;
         NotificationCompat.Builder builder = buildTaskNotification(
             taskId, albumTitle, chapterId, chapterTitle, coverUrl,
             downloadedPages, totalPages, "正在下载", true);
@@ -118,12 +112,24 @@ public class DownloadNotificationHelper {
             DownloadNotificationActionReceiver.ACTION_PAUSE, taskId));
         builder.addAction(ICON, "取消", createActionIntent(
             DownloadNotificationActionReceiver.ACTION_CANCEL, taskId));
-        notify(notificationId, builder.build());
+        publishTaskNotification(notificationId, taskId, version, builder.build());
+    }
+
+    public void showVerifying(int notificationId, String taskId, String albumTitle,
+                              String chapterId, String chapterTitle, String coverUrl) {
+        long version = beginTaskNotificationUpdate(taskId, true);
+        if (version == INVALID_NOTIFICATION_VERSION) return;
+        NotificationCompat.Builder builder = buildTaskNotification(
+            taskId, albumTitle, chapterId, chapterTitle, coverUrl,
+            0, 0, "正在校验", true);
+        publishTaskNotification(notificationId, taskId, version, builder.build());
     }
 
     public void showPaused(int notificationId, String taskId, String albumTitle,
                            String chapterId, String chapterTitle, String coverUrl,
                            int downloadedPages, int totalPages) {
+        long version = beginTaskNotificationUpdate(taskId, false);
+        if (version == INVALID_NOTIFICATION_VERSION) return;
         NotificationCompat.Builder builder = buildTaskNotification(
             taskId, albumTitle, chapterId, chapterTitle, coverUrl,
             downloadedPages, totalPages, "下载已暂停", false);
@@ -131,36 +137,43 @@ public class DownloadNotificationHelper {
             DownloadNotificationActionReceiver.ACTION_RESUME, taskId));
         builder.addAction(ICON, "取消", createActionIntent(
             DownloadNotificationActionReceiver.ACTION_CANCEL, taskId));
-        notify(notificationId, builder.build());
+        publishTaskNotification(notificationId, taskId, version, builder.build());
     }
 
-    public void showComplete(int notificationId, String albumTitle, String chapterId,
-                             String chapterTitle, String coverUrl) {
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(ICON)
-            .setContentTitle("下载完成")
-            .setContentText(buildTitle(albumTitle, chapterTitle))
-            .setSubText(buildIdText(chapterId))
-            .setContentIntent(createLaunchIntent(notificationId))
-            .setAutoCancel(true)
-            .setOngoing(false);
-        applyCover(builder, coverUrl);
-        notify(notificationId, builder.build());
+    public void showComplete(int notificationId, String taskId, String albumTitle,
+                             String chapterId, String chapterTitle) {
+        synchronized (notificationStateLock) {
+            releaseTaskNotificationLocked(notificationId, taskId);
+            if (!pendingTaskIds.remove(taskId)) return;
+            completedCount++;
+            addRecentResult(recentCompleted,
+                buildResultTitle(albumTitle, chapterId, chapterTitle));
+            notify(NotificationIds.DOWNLOAD_COMPLETED_SUMMARY,
+                buildCompletedSummaryLocked());
+        }
     }
 
-    public void showError(int notificationId, String albumTitle, String chapterId,
-                          String chapterTitle, String coverUrl, String error) {
+    public void showError(int notificationId, String taskId, String albumTitle,
+                          String chapterId, String chapterTitle, String error) {
         String message = error != null && !error.isEmpty() ? error : "下载失败";
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(ICON)
-            .setContentTitle("下载失败: " + buildTitle(albumTitle, chapterTitle))
-            .setContentText(message)
-            .setSubText(buildIdText(chapterId))
-            .setContentIntent(createLaunchIntent(notificationId))
-            .setAutoCancel(true)
-            .setOngoing(false);
-        applyCover(builder, coverUrl);
-        notify(notificationId, builder.build());
+        synchronized (notificationStateLock) {
+            releaseTaskNotificationLocked(notificationId, taskId);
+            if (!pendingTaskIds.remove(taskId)) return;
+            failedCount++;
+            addRecentResult(recentFailed,
+                buildResultTitle(albumTitle, chapterId, chapterTitle) + ": " + message);
+            notify(NotificationIds.DOWNLOAD_FAILED_SUMMARY,
+                buildFailedSummaryLocked());
+        }
+    }
+
+    public void cancelTask(int notificationId, String taskId) {
+        synchronized (notificationStateLock) {
+            releaseTaskNotificationLocked(notificationId, taskId);
+            if (pendingTaskIds.remove(taskId)) {
+                cancelledCount++;
+            }
+        }
     }
 
     public void cancel(int notificationId) {
@@ -172,6 +185,127 @@ public class DownloadNotificationHelper {
             } catch (RuntimeException e) {
                 Log.w(TAG, "取消下载通知失败", e);
             }
+        }
+    }
+
+    private long beginTaskNotificationUpdate(String taskId, boolean active) {
+        synchronized (notificationStateLock) {
+            if (!pendingTaskIds.contains(taskId)) return INVALID_NOTIFICATION_VERSION;
+
+            if (!visibleTaskIds.contains(taskId)) {
+                if (visibleTaskIds.size() >= MAX_VISIBLE_TASK_NOTIFICATIONS) {
+                    if (!active || pausedTaskIds.isEmpty()) {
+                        return INVALID_NOTIFICATION_VERSION;
+                    }
+                    Iterator<String> pausedTasks = pausedTaskIds.iterator();
+                    String evictedTaskId = pausedTasks.next();
+                    pausedTasks.remove();
+                    visibleTaskIds.remove(evictedTaskId);
+                    taskNotificationVersions.remove(evictedTaskId);
+                    cancel(NotificationIds.downloadTask(evictedTaskId));
+                }
+                visibleTaskIds.add(taskId);
+            }
+
+            if (active) {
+                pausedTaskIds.remove(taskId);
+            } else {
+                pausedTaskIds.add(taskId);
+            }
+
+            long version = ++nextNotificationVersion;
+            taskNotificationVersions.put(taskId, version);
+            return version;
+        }
+    }
+
+    private void publishTaskNotification(int notificationId, String taskId,
+                                         long version, Notification notification) {
+        synchronized (notificationStateLock) {
+            Long currentVersion = taskNotificationVersions.get(taskId);
+            if (!pendingTaskIds.contains(taskId)
+                || !visibleTaskIds.contains(taskId)
+                || currentVersion == null
+                || currentVersion != version) {
+                return;
+            }
+            notify(notificationId, notification);
+        }
+    }
+
+    private void releaseTaskNotificationLocked(int notificationId, String taskId) {
+        visibleTaskIds.remove(taskId);
+        pausedTaskIds.remove(taskId);
+        taskNotificationVersions.remove(taskId);
+        cancel(notificationId);
+    }
+
+    private Notification buildCompletedSummaryLocked() {
+        boolean allCompleted = pendingTaskIds.isEmpty()
+            && failedCount == 0
+            && cancelledCount == 0;
+        NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle()
+            .setBigContentTitle(allCompleted ? "全部下载完成" : "下载完成");
+        for (String result : recentCompleted) {
+            style.addLine(result);
+        }
+        style.setSummaryText("已完成 " + completedCount + " 个章节");
+
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(ICON)
+            .setContentTitle(allCompleted ? "全部下载完成" : "下载完成")
+            .setContentText("已完成 " + completedCount + " 个章节")
+            .setStyle(style)
+            .setContentIntent(createLaunchIntent(NotificationIds.DOWNLOAD_COMPLETED_SUMMARY))
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(true)
+            .setOngoing(false)
+            .build();
+    }
+
+    private Notification buildFailedSummaryLocked() {
+        NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle()
+            .setBigContentTitle("下载失败");
+        for (String result : recentFailed) {
+            style.addLine(result);
+        }
+        style.setSummaryText("失败 " + failedCount + " 个章节");
+
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(ICON)
+            .setContentTitle("下载失败")
+            .setContentText("失败 " + failedCount + " 个章节")
+            .setStyle(style)
+            .setContentIntent(createLaunchIntent(NotificationIds.DOWNLOAD_FAILED_SUMMARY))
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(true)
+            .setOngoing(false)
+            .build();
+    }
+
+    private void addRecentResult(ArrayDeque<String> results, String result) {
+        results.addFirst(result);
+        while (results.size() > MAX_RECENT_RESULTS) {
+            results.removeLast();
+        }
+    }
+
+    private void clearStaleDownloadNotifications() {
+        cancel(NotificationIds.DOWNLOAD_QUEUE_SUMMARY);
+        cancel(NotificationIds.DOWNLOAD_COMPLETED_SUMMARY);
+        cancel(NotificationIds.DOWNLOAD_FAILED_SUMMARY);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || manager == null) return;
+
+        try {
+            for (StatusBarNotification notification : manager.getActiveNotifications()) {
+                if (NotificationIds.containsDownloadTask(notification.getId())) {
+                    manager.cancel(notification.getId());
+                }
+            }
+        } catch (SecurityException e) {
+            Log.d(TAG, "通知权限未授予，跳过清理旧下载通知", e);
+        } catch (RuntimeException e) {
+            Log.w(TAG, "清理旧下载通知失败", e);
         }
     }
 
@@ -290,6 +424,17 @@ public class DownloadNotificationHelper {
     private String buildTitle(String albumTitle, String chapterTitle) {
         if (albumTitle != null && !albumTitle.isEmpty()) return albumTitle;
         return safeText(chapterTitle, "章节下载");
+    }
+
+    private String buildResultTitle(String albumTitle, String chapterId,
+                                    String chapterTitle) {
+        String safeChapterTitle = chapterTitle != null && !chapterTitle.trim().isEmpty()
+            ? chapterTitle
+            : safeText(chapterId, "章节");
+        if (albumTitle == null || albumTitle.trim().isEmpty()) {
+            return safeChapterTitle;
+        }
+        return albumTitle + " · " + safeChapterTitle;
     }
 
     private String buildIdText(String chapterId) {

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadObserver.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadObserver.java
@@ -50,16 +50,8 @@ class DownloadObserver implements TaskObserver {
         if (newState.isTerminal() && !markFinalized()) return;
 
         if (newState == TaskState.COMPLETED) {
-            Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
-            downloadDb.updateCompleted(ourTaskId, totalImages,
-                firstSO != null ? firstSO : 1);
-            long totalSize = service.calcChapterFileSize(albumId, chapterId);
-            downloadDb.updateSize(ourTaskId, totalSize);
-            notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
-                null, 0, totalSize);
-            service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
-                DownloadService.STATUS_COMPLETED, null);
-            service.cleanupTaskMapping(ourTaskId);
+            service.finishDownloadWithValidation(
+                ourTaskId, albumId, chapterId, totalImages);
         } else if (newState == TaskState.FAILED) {
             downloadDb.updateFailed(ourTaskId, 0, "下载失败");
             notifyProgress(0, totalImages, DownloadService.STATUS_FAILED, "下载失败");
@@ -86,16 +78,8 @@ class DownloadObserver implements TaskObserver {
             DownloadResult result = task.getCurrentDownloadResult();
             int failed = result.getFailedTasks().size();
             if (failed == 0) {
-                Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
-                downloadDb.updateCompleted(ourTaskId, totalImages,
-                    firstSO != null ? firstSO : 1);
-                long totalSize = service.calcChapterFileSize(albumId, chapterId);
-                downloadDb.updateSize(ourTaskId, totalSize);
-                notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
-                    null, 0, totalSize);
-                service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
-                    DownloadService.STATUS_COMPLETED, null);
-                service.cleanupTaskMapping(ourTaskId);
+                service.finishDownloadWithValidation(
+                    ourTaskId, albumId, chapterId, totalImages);
                 return;
             }
             int succeeded = totalImages - failed;
@@ -109,16 +93,8 @@ class DownloadObserver implements TaskObserver {
                 DownloadService.STATUS_FAILED, error);
             service.cleanupTaskMapping(ourTaskId);
         } else if (newState == TaskState.SKIPPED) {
-            Integer firstSO = fileStore.getFirstImageSortOrder(albumId, chapterId);
-            downloadDb.updateCompleted(ourTaskId, totalImages,
-                firstSO != null ? firstSO : 1);
-            long totalSize = service.calcChapterFileSize(albumId, chapterId);
-            downloadDb.updateSize(ourTaskId, totalSize);
-            notifyProgress(totalImages, totalImages, DownloadService.STATUS_COMPLETED,
-                null, 0, totalSize);
-            service.updateDownloadNotification(ourTaskId, totalImages, totalImages,
-                DownloadService.STATUS_COMPLETED, null);
-            service.cleanupTaskMapping(ourTaskId);
+            service.finishDownloadWithValidation(
+                ourTaskId, albumId, chapterId, totalImages);
         }
     }
 

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
@@ -83,6 +83,7 @@ public class DownloadService {
     @SuppressLint("NewApi")
     public String downloadChapter(String albumId, String chapterId,
                                   String albumTitle, String chapterTitle, String coverUrl) {
+        FileStore.validateChapterIds(albumId, chapterId);
         String taskId = albumId + "_" + chapterId;
 
         if (downloadDb.hasActiveOrCompleted(taskId)) {
@@ -431,10 +432,12 @@ public class DownloadService {
                                       String chapterId, int totalImages) {
         if (isCancelled(taskId)) return;
 
+        downloadDb.updateProgress(taskId, totalImages);
         downloadDb.updateStatus(taskId, STATUS_VERIFYING);
-        notifyProgress(taskId, albumId, chapterId, 0, totalImages,
+        notifyProgress(taskId, albumId, chapterId, totalImages, totalImages,
             STATUS_VERIFYING, null);
-        updateDownloadNotification(taskId, 0, totalImages, STATUS_VERIFYING, null);
+        updateDownloadNotification(taskId, totalImages, totalImages,
+            STATUS_VERIFYING, null);
 
         ChapterValidation result = validateCompletedDownload(
             taskId, albumId, chapterId, totalImages);

--- a/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/service/DownloadService.java
@@ -3,9 +3,9 @@ package io.github.jukomu.service;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.Log;
-
 import io.github.jukomu.data.DownloadStore;
 import io.github.jukomu.data.FileStore;
+import io.github.jukomu.data.ImageFileValidator;
 import io.github.jukomu.jmcomic.api.download.task.BaseDownloadTask;
 import io.github.jukomu.jmcomic.api.model.JmImage;
 import io.github.jukomu.jmcomic.api.model.JmPhoto;
@@ -15,10 +15,9 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
@@ -34,6 +33,7 @@ public class DownloadService {
     static final String STATUS_QUEUED = "queued";
     static final String STATUS_DOWNLOADING = "downloading";
     static final String STATUS_PAUSED = "paused";
+    static final String STATUS_VERIFYING = "verifying";
     static final String STATUS_COMPLETED = "completed";
     static final String STATUS_FAILED = "failed";
 
@@ -97,18 +97,16 @@ public class DownloadService {
         cancelledTaskIds.remove(taskId);
         downloadDb.insertTask(taskId, albumId, chapterId,
             albumTitle, chapterTitle, coverUrl);
+        notificationHelper.registerTask(taskId);
         startForegroundTask(taskId);
-        showQueuedNotification(taskId, chapterTitle);
 
         prepareExecutor.submit(() -> {
             try {
                 if (downloadDb.getTask(taskId) == null) {
-                    removeQueuedNotification(taskId);
                     cleanupTaskMapping(taskId);
                     cancelNotification(taskId);
                     return;
                 }
-                showPreparingNotification(taskId, albumTitle, chapterId, chapterTitle, coverUrl);
                 JmPhoto photo = client.getPhoto(chapterId);
                 List<JmImage> images = photo.getImages();
 
@@ -154,8 +152,6 @@ public class DownloadService {
                     images.size(), downloadDb, fileStore, this));
 
                 downloadDb.updateStatus(taskId, STATUS_DOWNLOADING);
-                showDownloadNotification(taskId, albumTitle, chapterId, chapterTitle,
-                    coverUrl, 0, images.size(), true);
                 notifyProgress(taskId, albumId, chapterId, 0, images.size(),
                     STATUS_DOWNLOADING, null);
 
@@ -165,7 +161,6 @@ public class DownloadService {
                     downloadDb.deleteTask(taskId);
                     cleanupTaskMapping(taskId);
                     cancelNotification(taskId);
-                    removeQueuedNotification(taskId);
                     return;
                 }
 
@@ -175,8 +170,8 @@ public class DownloadService {
                 }
             } catch (Exception e) {
                 downloadDb.updateFailed(taskId, 0, e.getMessage());
-                showFailedNotification(taskId, albumTitle, chapterId, chapterTitle,
-                    coverUrl, e.getMessage());
+                showFailedNotification(taskId, albumTitle, chapterId,
+                    chapterTitle, e.getMessage());
                 notifyProgress(taskId, albumId, chapterId, 0, 0,
                     STATUS_FAILED, e.getMessage());
                 cleanupTaskMapping(taskId);
@@ -237,6 +232,8 @@ public class DownloadService {
                 }
             }
             completeCancel(taskId, task);
+        } else if (STATUS_VERIFYING.equals(status)) {
+            throw new IllegalStateException("校验中的任务不能取消");
         } else {
             completeCancel(taskId, task);
         }
@@ -314,7 +311,6 @@ public class DownloadService {
         downloadDb.deleteTask(taskId);
         cleanupTaskMapping(taskId);
         cancelNotification(taskId);
-        removeQueuedNotification(taskId);
     }
 
     public JSONObject getDownloadedPhoto(String albumId, String chapterId) {
@@ -383,15 +379,16 @@ public class DownloadService {
             stopForegroundTask(taskId);
             showPausedNotification(taskId, albumTitle, chapterId, chapterTitle, coverUrl,
                 downloadedPages, totalPages);
+        } else if (STATUS_VERIFYING.equals(status)) {
+            notificationHelper.showVerifying(notificationId(taskId), taskId, albumTitle,
+                chapterId, chapterTitle, coverUrl);
         } else if (STATUS_COMPLETED.equals(status)) {
-            showCompletedNotification(taskId, albumTitle, chapterId, chapterTitle, coverUrl);
+            showCompletedNotification(taskId, albumTitle, chapterId, chapterTitle);
         } else if (STATUS_FAILED.equals(status)) {
             if ("已取消".equals(error)) {
                 cancelNotification(taskId);
-                removeQueuedNotification(taskId);
             } else {
-                showFailedNotification(taskId, albumTitle, chapterId, chapterTitle,
-                    coverUrl, error);
+                showFailedNotification(taskId, albumTitle, chapterId, chapterTitle, error);
             }
         }
     }
@@ -430,6 +427,177 @@ public class DownloadService {
         }
     }
 
+    void finishDownloadWithValidation(String taskId, String albumId,
+                                      String chapterId, int totalImages) {
+        if (isCancelled(taskId)) return;
+
+        downloadDb.updateStatus(taskId, STATUS_VERIFYING);
+        notifyProgress(taskId, albumId, chapterId, 0, totalImages,
+            STATUS_VERIFYING, null);
+        updateDownloadNotification(taskId, 0, totalImages, STATUS_VERIFYING, null);
+
+        ChapterValidation result = validateCompletedDownload(
+            taskId, albumId, chapterId, totalImages);
+
+        if (isCancelled(taskId)) return;
+
+        long totalSize = calcChapterFileSize(albumId, chapterId);
+        downloadDb.updateSize(taskId, totalSize);
+        if (!result.valid) {
+            downloadDb.updateFailed(taskId, result.verifiedPages, result.error);
+            updateDownloadNotification(taskId, result.verifiedPages,
+                totalImages, STATUS_FAILED, result.error);
+            notifyProgress(taskId, albumId, chapterId, result.verifiedPages,
+                totalImages, STATUS_FAILED, result.error, 0, totalSize);
+            cleanupTaskMapping(taskId);
+            return;
+        }
+
+        Integer firstSortOrder = fileStore.getFirstImageSortOrder(albumId, chapterId);
+        downloadDb.updateCompleted(taskId, totalImages,
+            firstSortOrder != null ? firstSortOrder : 1);
+        updateDownloadNotification(taskId, totalImages,
+            totalImages, STATUS_COMPLETED, null);
+        notifyProgress(taskId, albumId, chapterId, totalImages,
+            totalImages, STATUS_COMPLETED, null, 0, totalSize);
+        cleanupTaskMapping(taskId);
+    }
+
+    private ChapterValidation validateCompletedDownload(String taskId,
+                                                        String albumId,
+                                                        String chapterId,
+                                                        int totalImages) {
+        JSONObject meta;
+        try {
+            meta = fileStore.readMeta(albumId, chapterId);
+        } catch (FileNotFoundException error) {
+            return ChapterValidation.failure(0, "meta.json 缺失");
+        } catch (org.json.JSONException error) {
+            return ChapterValidation.failure(0, "meta.json 内容无效");
+        } catch (java.io.IOException error) {
+            Log.e(TAG, "meta.json 读取失败: " + taskId, error);
+            return ChapterValidation.failure(0, "meta.json 读取失败");
+        }
+
+        JSONObject databaseTask = downloadDb.getTask(taskId);
+        if (databaseTask == null
+            || !albumId.equals(requiredString(databaseTask, "albumId"))
+            || !chapterId.equals(requiredString(databaseTask, "chapterId"))
+            || databaseTask.optInt("totalPages", -1) != totalImages) {
+            return ChapterValidation.failure(0, "DB 与 meta.json 记录不一致");
+        }
+
+        List<JSONObject> databaseImages = downloadDb.getImages(taskId);
+        JSONArray metaImages = meta.optJSONArray("images");
+        if (!sameImageManifest(albumId, chapterId, totalImages,
+            databaseImages, meta, metaImages)) {
+            return ChapterValidation.failure(0, "DB 与 meta.json 记录不一致");
+        }
+
+        int verifiedPages = 0;
+        boolean allValid = true;
+        for (JSONObject image : databaseImages) {
+            String filename = image.optString("filename", "");
+            File imageFile = fileStore.getExpectedImageFile(
+                albumId, chapterId, filename);
+
+            try {
+                if (ImageFileValidator.validateFull(imageFile)) {
+                    verifiedPages++;
+                    continue;
+                }
+
+                allValid = false;
+                if (imageFile != null && imageFile.isFile() && !imageFile.delete()) {
+                    Log.w(TAG, "校验失败图片删除失败: " + imageFile.getPath());
+                }
+            } catch (OutOfMemoryError error) {
+                Log.e(TAG, "图片完整校验资源不足: " + filename, error);
+                return ChapterValidation.failure(verifiedPages, "图片校验资源不足");
+            }
+        }
+
+        return allValid
+            ? ChapterValidation.success(verifiedPages)
+            : ChapterValidation.failure(verifiedPages, "至少一张图片不可用");
+    }
+
+    private boolean sameImageManifest(String albumId, String chapterId,
+                                      int totalImages, List<JSONObject> databaseImages,
+                                      JSONObject meta, JSONArray metaImages) {
+        if (databaseImages == null || metaImages == null
+            || databaseImages.size() != totalImages
+            || metaImages.length() != totalImages
+            || metaImages.length() != databaseImages.size()
+            || !albumId.equals(requiredString(meta, "albumId"))
+            || !chapterId.equals(requiredString(meta, "chapterId"))
+            || meta.optInt("totalPages", -1) != totalImages) {
+            return false;
+        }
+
+        Map<Integer, JSONObject> databaseBySortOrder = new HashMap<>();
+        for (JSONObject image : databaseImages) {
+            String filename = requiredString(image, "filename");
+            String photoId = requiredString(image, "photoId");
+            if (filename == null || photoId == null) return false;
+
+            int sortOrder = image.optInt("sortOrder", Integer.MIN_VALUE);
+            if (sortOrder == Integer.MIN_VALUE
+                || databaseBySortOrder.put(sortOrder, image) != null) {
+                return false;
+            }
+        }
+
+        Set<Integer> seenSortOrders = new HashSet<>();
+        for (int index = 0; index < metaImages.length(); index++) {
+            JSONObject image = metaImages.optJSONObject(index);
+            if (image == null) return false;
+
+            String filename = requiredString(image, "filename");
+            String photoId = requiredString(image, "photoId");
+            int sortOrder = image.optInt("sortOrder", Integer.MIN_VALUE);
+            if (filename == null || photoId == null
+                || sortOrder == Integer.MIN_VALUE
+                || !seenSortOrders.add(sortOrder)) {
+                return false;
+            }
+
+            JSONObject databaseImage = databaseBySortOrder.get(sortOrder);
+            if (databaseImage == null
+                || !filename.equals(requiredString(databaseImage, "filename"))
+                || !photoId.equals(requiredString(databaseImage, "photoId"))) {
+                return false;
+            }
+        }
+        return seenSortOrders.size() == databaseBySortOrder.size();
+    }
+
+    private String requiredString(JSONObject object, String key) {
+        if (object == null || !object.has(key) || object.isNull(key)) return null;
+        String value = object.optString(key, null);
+        return value == null || value.trim().isEmpty() ? null : value;
+    }
+
+    private static final class ChapterValidation {
+        private final boolean valid;
+        private final int verifiedPages;
+        private final String error;
+
+        private ChapterValidation(boolean valid, int verifiedPages, String error) {
+            this.valid = valid;
+            this.verifiedPages = verifiedPages;
+            this.error = error;
+        }
+
+        private static ChapterValidation success(int pages) {
+            return new ChapterValidation(true, pages, null);
+        }
+
+        private static ChapterValidation failure(int pages, String error) {
+            return new ChapterValidation(false, pages, error);
+        }
+    }
+
     private void completeCancel(String taskId, JSONObject task) {
         cancelledTaskIds.add(taskId);
         pendingCancel.remove(taskId);
@@ -439,7 +607,6 @@ public class DownloadService {
         downloadDb.deleteImages(taskId);
         downloadDb.deleteTask(taskId);
         cancelNotification(taskId);
-        removeQueuedNotification(taskId);
         notifyProgress(taskId, albumId, chapterId, 0,
             task.optInt("totalPages"), "cancelled", "已取消");
         cleanupTaskMapping(taskId);
@@ -456,23 +623,10 @@ public class DownloadService {
         return NotificationIds.downloadTask(taskId);
     }
 
-    private void showQueuedNotification(String taskId, String chapterTitle) {
-        notificationHelper.showQueued(taskId, chapterTitle);
-    }
-
-    private void showPreparingNotification(String taskId, String albumTitle,
-                                           String chapterId, String chapterTitle,
-                                           String coverUrl) {
-        removeQueuedNotification(taskId);
-        notificationHelper.showPreparing(notificationId(taskId), taskId, albumTitle,
-            chapterId, chapterTitle, coverUrl);
-    }
-
     private void showDownloadNotification(String taskId, String albumTitle,
                                           String chapterId, String chapterTitle,
                                           String coverUrl,
                                           int downloadedPages, int totalPages, boolean force) {
-        removeQueuedNotification(taskId);
         long now = System.currentTimeMillis();
         Long last = lastNotificationAt.get(taskId);
         if (!force && last != null && now - last < 1000) return;
@@ -485,34 +639,28 @@ public class DownloadService {
                                         String chapterId, String chapterTitle,
                                         String coverUrl,
                                         int downloadedPages, int totalPages) {
-        removeQueuedNotification(taskId);
         notificationHelper.showPaused(notificationId(taskId), taskId, albumTitle,
             chapterId, chapterTitle, coverUrl, downloadedPages, totalPages);
     }
 
     private void showCompletedNotification(String taskId, String albumTitle,
-                                           String chapterId, String chapterTitle,
-                                           String coverUrl) {
-        removeQueuedNotification(taskId);
-        notificationHelper.showComplete(notificationId(taskId), albumTitle,
-            chapterId, chapterTitle, coverUrl);
+                                           String chapterId, String chapterTitle) {
+        lastNotificationAt.remove(taskId);
+        notificationHelper.showComplete(notificationId(taskId), taskId,
+            albumTitle, chapterId, chapterTitle);
     }
 
     private void showFailedNotification(String taskId, String albumTitle,
                                         String chapterId, String chapterTitle,
-                                        String coverUrl, String error) {
-        removeQueuedNotification(taskId);
-        notificationHelper.showError(notificationId(taskId), albumTitle,
-            chapterId, chapterTitle, coverUrl, error);
+                                        String error) {
+        lastNotificationAt.remove(taskId);
+        notificationHelper.showError(notificationId(taskId), taskId,
+            albumTitle, chapterId, chapterTitle, error);
     }
 
     private void cancelNotification(String taskId) {
         lastNotificationAt.remove(taskId);
-        notificationHelper.cancel(notificationId(taskId));
-    }
-
-    private void removeQueuedNotification(String taskId) {
-        notificationHelper.removeQueued(taskId);
+        notificationHelper.cancelTask(notificationId(taskId), taskId);
     }
 
     private void startForegroundTask(String taskId) {

--- a/android/app/src/main/java/io/github/jukomu/service/NotificationIds.java
+++ b/android/app/src/main/java/io/github/jukomu/service/NotificationIds.java
@@ -5,6 +5,8 @@ final class NotificationIds {
     static final int PDF_FOREGROUND = 202001;
     static final int DOWNLOAD_QUEUE_SUMMARY = 203000;
     static final int DOWNLOAD_FOREGROUND = 203001;
+    static final int DOWNLOAD_COMPLETED_SUMMARY = 203002;
+    static final int DOWNLOAD_FAILED_SUMMARY = 203003;
 
     static final int PDF_TASK_BASE = 210000;
     static final int PDF_TASK_LIMIT = 219999;

--- a/android/app/src/test/java/io/github/jukomu/data/FileStoreTest.java
+++ b/android/app/src/test/java/io/github/jukomu/data/FileStoreTest.java
@@ -47,4 +47,22 @@ public class FileStoreTest {
         assertNull(FileStore.resolveImageFile(chapterDir, "../../outside.jpg"));
         assertNull(FileStore.resolveImageFile(chapterDir, outside.getAbsolutePath()));
     }
+
+    @Test
+    public void validatesChapterIdsAsSinglePathSegments() {
+        FileStore.validateChapterIds("album", "chapter");
+
+        assertThrows(IllegalArgumentException.class,
+            () -> FileStore.validateChapterIds(null, "chapter"));
+        assertThrows(IllegalArgumentException.class,
+            () -> FileStore.validateChapterIds("", "chapter"));
+        assertThrows(IllegalArgumentException.class,
+            () -> FileStore.validateChapterIds("album", " "));
+        assertThrows(IllegalArgumentException.class,
+            () -> FileStore.validateChapterIds("..", "chapter"));
+        assertThrows(IllegalArgumentException.class,
+            () -> FileStore.validateChapterIds("album/child", "chapter"));
+        assertThrows(IllegalArgumentException.class,
+            () -> FileStore.validateChapterIds("album", "parent\\child"));
+    }
 }

--- a/android/app/src/test/java/io/github/jukomu/data/ImageFileValidatorTest.java
+++ b/android/app/src/test/java/io/github/jukomu/data/ImageFileValidatorTest.java
@@ -20,13 +20,13 @@ public class ImageFileValidatorTest {
     }
 
     @Test
-    public void fullAndQuickUseStaticSynchronizedMethods() throws Exception {
+    public void fullIsSynchronizedWhileQuickIsNot() throws Exception {
         Method full = ImageFileValidator.class.getMethod("validateFull", File.class);
         Method quick = ImageFileValidator.class.getMethod("validateQuick", File.class);
 
         assertTrue(Modifier.isStatic(full.getModifiers()));
         assertTrue(Modifier.isSynchronized(full.getModifiers()));
         assertTrue(Modifier.isStatic(quick.getModifiers()));
-        assertTrue(Modifier.isSynchronized(quick.getModifiers()));
+        assertFalse(Modifier.isSynchronized(quick.getModifiers()));
     }
 }

--- a/android/app/src/test/java/io/github/jukomu/data/ImageFileValidatorTest.java
+++ b/android/app/src/test/java/io/github/jukomu/data/ImageFileValidatorTest.java
@@ -1,0 +1,32 @@
+package io.github.jukomu.data;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ImageFileValidatorTest {
+
+    @Test
+    public void rejectsUnavailableFiles() {
+        assertFalse(ImageFileValidator.validateFull(null));
+        assertFalse(ImageFileValidator.validateQuick(null));
+        assertFalse(ImageFileValidator.validateFull(
+            new File("missing-image-" + System.nanoTime() + ".jpg")));
+    }
+
+    @Test
+    public void fullAndQuickUseStaticSynchronizedMethods() throws Exception {
+        Method full = ImageFileValidator.class.getMethod("validateFull", File.class);
+        Method quick = ImageFileValidator.class.getMethod("validateQuick", File.class);
+
+        assertTrue(Modifier.isStatic(full.getModifiers()));
+        assertTrue(Modifier.isSynchronized(full.getModifiers()));
+        assertTrue(Modifier.isStatic(quick.getModifiers()));
+        assertTrue(Modifier.isSynchronized(quick.getModifiers()));
+    }
+}

--- a/android/app/src/test/java/io/github/jukomu/service/NotificationIdsTest.java
+++ b/android/app/src/test/java/io/github/jukomu/service/NotificationIdsTest.java
@@ -18,6 +18,8 @@ public class NotificationIdsTest {
         assertTrue(fixedIds.add(NotificationIds.PDF_FOREGROUND));
         assertTrue(fixedIds.add(NotificationIds.DOWNLOAD_QUEUE_SUMMARY));
         assertTrue(fixedIds.add(NotificationIds.DOWNLOAD_FOREGROUND));
+        assertTrue(fixedIds.add(NotificationIds.DOWNLOAD_COMPLETED_SUMMARY));
+        assertTrue(fixedIds.add(NotificationIds.DOWNLOAD_FAILED_SUMMARY));
 
         for (int fixedId : fixedIds) {
             assertFalse(NotificationIds.containsPdfTask(fixedId));

--- a/src/components/download/DownloadTaskCard.vue
+++ b/src/components/download/DownloadTaskCard.vue
@@ -44,6 +44,9 @@
       <!-- 已暂停 -->
       <div v-else-if="cardStatus === 'paused'" class="status-tag paused">已暂停</div>
 
+      <!-- 校验中 -->
+      <div v-else-if="cardStatus === 'verifying'" class="status-tag verifying">校验中</div>
+
       <!-- 已完成 -->
       <div v-else-if="cardStatus === 'completed'" class="status-row">
         <span v-if="!isPdfEntry" class="tag completed">共 {{ displayTotalPages }} 页</span>
@@ -424,6 +427,11 @@ const onCardClick = () => {
 .status-tag.paused {
   background: #fff8e1;
   color: #f0a030;
+}
+
+.status-tag.verifying {
+  background: #eef3ff;
+  color: #5a78c8;
 }
 
 .status-row {

--- a/src/services/JmcomicTypes.ts
+++ b/src/services/JmcomicTypes.ts
@@ -274,6 +274,7 @@ export type DownloadStatus =
   | 'queued'
   | 'downloading'
   | 'paused'
+  | 'verifying'
   | 'completed'
   | 'failed'
   | 'cancelled'

--- a/src/services/OfflineDownloadService.ts
+++ b/src/services/OfflineDownloadService.ts
@@ -69,6 +69,7 @@ export const OfflineDownloadService = {
       if (downloadedPages !== undefined) task.downloadedPages = downloadedPages
       if (totalPages !== undefined) task.totalPages = totalPages
       if (error !== undefined) task.error = error
+      if (status === 'verifying') task.error = undefined
       if (status === 'completed') task.completedAt = Date.now()
       writeTasks(tasks)
     }

--- a/src/views/DownloadPage.vue
+++ b/src/views/DownloadPage.vue
@@ -489,20 +489,17 @@ const hasTasks = computed(() => tasks.value.length > 0 || importedPdfs.value.len
 
 const activeTasks = computed(() =>
   tasks.value.filter(
-    (t) => t.status === 'queued' || t.status === 'downloading' || t.status === 'paused',
+    (t) =>
+      t.status === 'queued' ||
+      t.status === 'downloading' ||
+      t.status === 'paused' ||
+      t.status === 'verifying',
   ),
 )
 
-const isFullyDownloadedFailure = (task: DownloadTask) =>
-  task.status === 'failed' && task.totalPages > 0 && task.downloadedPages >= task.totalPages
+const completedTasks = computed(() => tasks.value.filter((t) => t.status === 'completed'))
 
-const completedTasks = computed(() =>
-  tasks.value.filter((t) => t.status === 'completed' || isFullyDownloadedFailure(t)),
-)
-
-const failedTasks = computed(() =>
-  tasks.value.filter((t) => t.status === 'failed' && !isFullyDownloadedFailure(t)),
-)
+const failedTasks = computed(() => tasks.value.filter((t) => t.status === 'failed'))
 
 const sortedActiveTasks = computed(() => sortTasks(activeTasks.value))
 const sortedFailedTasks = computed(() => sortTasks(failedTasks.value))
@@ -774,6 +771,18 @@ onMounted(async () => {
       task.status = 'downloading'
       updateSpeedSample(task, data.downloadedBytes, data.speed)
       OfflineDownloadService.updateProgress(data.taskId, data.downloadedPages, data.totalPages)
+    } else if (data.status === 'verifying') {
+      task.downloadedPages = data.downloadedPages
+      task.totalPages = data.totalPages || task.totalPages
+      task.status = 'verifying'
+      task.speed = 0
+      speedSamples.delete(data.taskId)
+      OfflineDownloadService.updateStatus(
+        data.taskId,
+        'verifying',
+        data.downloadedPages,
+        task.totalPages,
+      )
     } else if (data.status === 'paused') {
       task.downloadedPages = data.downloadedPages
       task.totalPages = data.totalPages || task.totalPages
@@ -813,19 +822,6 @@ onMounted(async () => {
       task.totalSize = data.totalSize
       task.speed = 0
       speedSamples.delete(data.taskId)
-      if (isFullyDownloadedFailure({ ...task, status: 'failed' })) {
-        task.status = 'completed'
-        task.error = undefined
-        task.completedAt = Date.now()
-        OfflineDownloadService.updateStatus(
-          data.taskId,
-          'completed',
-          data.downloadedPages,
-          data.totalPages,
-        )
-        void syncDownloadState()
-        return
-      }
       task.status = 'failed'
       task.error = data.error
       OfflineDownloadService.updateStatus(


### PR DESCRIPTION
- 新增图片完整性校验，下载结束后交叉验证数据库、meta.json 和图片文件，全部通过后才标记完成。
- 完善 FileStore metadata 读写，增加原子写入、明确异常类型及预期图片文件查询入口。
- 增加 verifying 状态，移除启动检查和前后端中可能将校验失败任务恢复为完成的旧逻辑。
- 优化批量下载通知，隐藏排队任务、限制活动通知数量、汇总完成和失败结果，并修复通知上限及终态旧通知残留问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
- 下载完成后新增图片与元数据校验，降低损坏文件被误标记为完成的风险。
- 新增“校验中”状态及界面展示，校验期间暂不可取消任务。
- 下载通知支持校验中、完成和失败汇总，并限制同时显示的任务通知数量。
- 元数据支持更可靠的保存与读取，图片文件新增快速及完整校验。

## Bug 修复
- 应用重启时正确处理下载或校验中的任务。
- 改进无效图片、异常元数据及不安全章节路径的错误处理。

## 测试
- 补充元数据、图片校验、通知标识及异常场景测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->