### PR TITLE
fix(preview): 统一详情页图片预览加载流程

### DIFF
--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -446,6 +446,12 @@ interface PreviewLoadContext {
 let previewRequestGeneration = 0
 let previewLoadContext: PreviewLoadContext | null = null
 
+const removePreviewImageReadyListener = (handle = imageReadyListenerHandle) => {
+  if (!handle) return
+  if (handle === imageReadyListenerHandle) imageReadyListenerHandle = null
+  void handle.remove().catch(() => {})
+}
+
 const clearPreviewPdf = () => {
   for (const url of previewObjectUrls) {
     URL.revokeObjectURL(url)
@@ -467,8 +473,7 @@ const invalidatePreviewRequest = () => {
   previewImageTotal.value = 0
   previewLoadedKey.value = ''
   previewLoading.value = false
-  imageReadyListenerHandle?.remove()
-  imageReadyListenerHandle = null
+  removePreviewImageReadyListener()
   clearPreviewPdf()
 }
 
@@ -880,8 +885,47 @@ const toggleSourceMenu = () => {
 }
 
 // ---- 预览 ----
-const loadDownloadedPreview = (targetAlbumId: string, chapterId: string) =>
-  JmcomicService.getDownloadedPhoto(targetAlbumId, chapterId)
+const setupPreviewImageReadyListener = async (
+  chapterId: string,
+  requestGeneration: number,
+  setImageSlot: PreviewImageSlotSetter,
+): Promise<boolean> => {
+  const listenerHandle = await JmcomicService.addImageReadyListener(
+    chapterId,
+    (sortOrder) => {
+      setImageSlot(sortOrder, getImageUrl(chapterId, sortOrder, 'thumb'))
+    },
+    { type: 'thumb' },
+  )
+  if (!isCurrentPreviewRequest(requestGeneration)) {
+    removePreviewImageReadyListener(listenerHandle)
+    return false
+  }
+  imageReadyListenerHandle = listenerHandle
+  return true
+}
+
+const loadDownloadedPreview = async (
+  targetAlbumId: string,
+  chapterId: string,
+  requestGeneration: number,
+  setImageSlot: PreviewImageSlotSetter,
+): Promise<PhotoDetail | null> => {
+  let photo: PhotoDetail
+  try {
+    photo = await JmcomicService.getPhoto(chapterId)
+  } catch {
+    if (!isCurrentPreviewRequest(requestGeneration)) return null
+    photo = await JmcomicService.getDownloadedPhoto(targetAlbumId, chapterId)
+  }
+  if (!isCurrentPreviewRequest(requestGeneration)) return null
+  const listenerReady = await setupPreviewImageReadyListener(
+    chapterId,
+    requestGeneration,
+    setImageSlot,
+  )
+  return listenerReady ? photo : null
+}
 
 const renderPdfPreviewPage = async (
   pdfDoc: pdfjsLib.PDFDocumentProxy,
@@ -971,20 +1015,14 @@ const loadNetworkPreview = async (
   requestGeneration: number,
   setImageSlot: PreviewImageSlotSetter,
 ): Promise<PhotoDetail | null> => {
-  const listenerHandle = await JmcomicService.addImageReadyListener(chapterId, (sortOrder) => {
-    setImageSlot(sortOrder, getImageUrl(chapterId, sortOrder, 'thumb'))
-  })
-  if (!isCurrentPreviewRequest(requestGeneration)) {
-    void listenerHandle.remove()
-    return null
-  }
-  imageReadyListenerHandle = listenerHandle
   const photo = await JmcomicService.getPhoto(chapterId)
-  if (!isCurrentPreviewRequest(requestGeneration)) {
-    void listenerHandle.remove()
-    return null
-  }
-  return photo
+  if (!isCurrentPreviewRequest(requestGeneration)) return null
+  const listenerReady = await setupPreviewImageReadyListener(
+    chapterId,
+    requestGeneration,
+    setImageSlot,
+  )
+  return listenerReady ? photo : null
 }
 
 const loadPreviewBatch = async (
@@ -1002,13 +1040,6 @@ const loadPreviewBatch = async (
 
   const photo = context.photo
   if (!photo) return
-
-  if (context.source === 'download') {
-    for (const image of photo.images.slice(start, end)) {
-      setImageSlot(image.sortOrder, getImageUrl(photo.id, image.sortOrder, 'thumb'))
-    }
-    return
-  }
 
   const batch = photo.images.slice(start, end)
   const result: PreloadResult = await JmcomicService.preloadImages(
@@ -1069,44 +1100,70 @@ const loadPreview = async () => {
   try {
     let context: PreviewLoadContext | null = null
     if (source === 'download') {
-      const photo = await loadDownloadedPreview(targetAlbumId, chapterId)
-      if (!isCurrentPreviewRequest(requestGeneration)) return
-      photoDetail.value = photo
-      previewImageTotal.value = photo.images.length
-      context = {
-        requestGeneration,
-        albumId: targetAlbumId,
-        chapterId,
-        source,
-        photo,
-        pdfDoc: null,
+      try {
+        const setImageSlot = previewBatches.createImageSlotSetter()
+        const photo = await loadDownloadedPreview(
+          targetAlbumId,
+          chapterId,
+          requestGeneration,
+          setImageSlot,
+        )
+        if (!photo || !isCurrentPreviewRequest(requestGeneration)) return
+        photoDetail.value = photo
+        previewImageTotal.value = photo.images.length
+        context = {
+          requestGeneration,
+          albumId: targetAlbumId,
+          chapterId,
+          source,
+          photo,
+          pdfDoc: null,
+        }
+      } catch (e: unknown) {
+        if (!isCurrentPreviewRequest(requestGeneration)) return
+        removePreviewImageReadyListener()
+        await showToast(sanitizeError(e, '预览加载失败'), 'danger')
+        return
       }
     } else if (source === 'pdf' && pdf) {
-      const pdfDoc = await loadPdfPreview(pdf, requestGeneration)
-      if (!pdfDoc || !isCurrentPreviewRequest(requestGeneration)) return
-      previewPdfDoc = pdfDoc
-      previewImageTotal.value = pdfDoc.numPages
-      context = {
-        requestGeneration,
-        albumId: targetAlbumId,
-        chapterId,
-        source,
-        photo: null,
-        pdfDoc,
+      try {
+        const pdfDoc = await loadPdfPreview(pdf, requestGeneration)
+        if (!pdfDoc || !isCurrentPreviewRequest(requestGeneration)) return
+        previewPdfDoc = pdfDoc
+        previewImageTotal.value = pdfDoc.numPages
+        context = {
+          requestGeneration,
+          albumId: targetAlbumId,
+          chapterId,
+          source,
+          photo: null,
+          pdfDoc,
+        }
+      } catch (e: unknown) {
+        if (!isCurrentPreviewRequest(requestGeneration)) return
+        await showToast(sanitizeError(e, '预览加载失败'), 'danger')
+        return
       }
     } else {
-      const setImageSlot = previewBatches.createImageSlotSetter()
-      const photo = await loadNetworkPreview(chapterId, requestGeneration, setImageSlot)
-      if (!photo || !isCurrentPreviewRequest(requestGeneration)) return
-      photoDetail.value = photo
-      previewImageTotal.value = photo.images.length
-      context = {
-        requestGeneration,
-        albumId: targetAlbumId,
-        chapterId,
-        source: 'network',
-        photo,
-        pdfDoc: null,
+      try {
+        const setImageSlot = previewBatches.createImageSlotSetter()
+        const photo = await loadNetworkPreview(chapterId, requestGeneration, setImageSlot)
+        if (!photo || !isCurrentPreviewRequest(requestGeneration)) return
+        photoDetail.value = photo
+        previewImageTotal.value = photo.images.length
+        context = {
+          requestGeneration,
+          albumId: targetAlbumId,
+          chapterId,
+          source: 'network',
+          photo,
+          pdfDoc: null,
+        }
+      } catch (e: unknown) {
+        if (!isCurrentPreviewRequest(requestGeneration)) return
+        removePreviewImageReadyListener()
+        await showToast(sanitizeError(e, '预览加载失败'), 'danger')
+        return
       }
     }
 
@@ -1116,40 +1173,6 @@ const loadPreview = async () => {
     await previewBatches.initialize()
     if (!isCurrentPreviewRequest(requestGeneration)) return
     previewLoadedKey.value = cacheKey
-  } catch (e: any) {
-    if (!isCurrentPreviewRequest(requestGeneration)) return
-    if (source === 'download' && pdf) {
-      try {
-        previewBatches.reset()
-        previewLoadContext = null
-        previewSourceOverride.value = null
-        previewAutoLoad.value = false
-        previewImageTotal.value = 0
-        clearPreviewPdf()
-        const pdfDoc = await loadPdfPreview(pdf, requestGeneration)
-        if (!pdfDoc || !isCurrentPreviewRequest(requestGeneration)) return
-        previewPdfDoc = pdfDoc
-        previewImageTotal.value = pdfDoc.numPages
-        previewLoadContext = {
-          requestGeneration,
-          albumId: targetAlbumId,
-          chapterId,
-          source: 'pdf',
-          photo: null,
-          pdfDoc,
-        }
-        previewSourceOverride.value = 'pdf'
-        await previewBatches.initialize()
-        if (!isCurrentPreviewRequest(requestGeneration)) return
-        previewLoadedKey.value = `pdf:${chapterId}:${pdf.id}`
-        return
-      } catch {
-        // 继续走统一错误提示
-      }
-    }
-    imageReadyListenerHandle?.remove()
-    imageReadyListenerHandle = null
-    await showToast(sanitizeError(e, '预览加载失败'), 'danger')
   } finally {
     if (isCurrentPreviewRequest(requestGeneration)) previewLoading.value = false
   }

--- a/tests/unit/AlbumDetailPage.test.ts
+++ b/tests/unit/AlbumDetailPage.test.ts
@@ -2,6 +2,7 @@
 import {flushPromises, mount, type VueWrapper} from '@vue/test-utils'
 import {KeepAlive, defineComponent, h, nextTick, ref} from 'vue'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import type {AlbumDetail, DownloadTask, ImportedPdf, PhotoDetail, PreloadResult} from '@/services/JmcomicTypes'
 
 const mocks = vi.hoisted(() => ({
   route: {
@@ -15,6 +16,19 @@ const mocks = vi.hoisted(() => ({
   },
   getAlbum: vi.fn(() => new Promise(() => {})),
   getPhoto: vi.fn(() => new Promise(() => {})),
+  getDownloadedPhoto: vi.fn(),
+  getDownloadTasks: vi.fn(),
+  getImportedPdfs: vi.fn(),
+  addDownloadProgressListener: vi.fn(),
+  addImageReadyListener: vi.fn(),
+  preloadImages: vi.fn(),
+  listenerRemove: vi.fn(),
+  imageReadyHandler: undefined as undefined | ((sortOrder: number) => void),
+  getImageUrl: vi.fn(),
+  showToast: vi.fn(),
+  fetchPdfArrayBuffer: vi.fn(),
+  buildPdfDocumentParams: vi.fn(),
+  pdfGetDocument: vi.fn(),
   menuSwipeGesture: vi.fn(() => Promise.resolve()),
 }))
 
@@ -66,22 +80,28 @@ vi.mock('@ionic/vue', async () => {
 
 vi.mock('pdfjs-dist', () => ({
   GlobalWorkerOptions: {workerSrc: ''},
-  getDocument: vi.fn(),
+  getDocument: mocks.pdfGetDocument,
 }))
 
 vi.mock('@/services/JmcomicService', () => ({
-  getImageUrl: vi.fn(),
+  getImageUrl: mocks.getImageUrl,
   sanitizeError: vi.fn((error: unknown, fallback: string) => String(error || fallback)),
-  showToast: vi.fn(() => Promise.resolve()),
+  showToast: mocks.showToast,
   JmcomicService: {
     getAlbum: mocks.getAlbum,
     getPhoto: mocks.getPhoto,
+    getDownloadedPhoto: mocks.getDownloadedPhoto,
+    getDownloadTasks: mocks.getDownloadTasks,
+    getImportedPdfs: mocks.getImportedPdfs,
+    addDownloadProgressListener: mocks.addDownloadProgressListener,
+    addImageReadyListener: mocks.addImageReadyListener,
+    preloadImages: mocks.preloadImages,
   },
 }))
 
 vi.mock('@/services/PdfReaderService', () => ({
-  buildPdfDocumentParams: vi.fn(),
-  fetchPdfArrayBuffer: vi.fn(),
+  buildPdfDocumentParams: mocks.buildPdfDocumentParams,
+  fetchPdfArrayBuffer: mocks.fetchPdfArrayBuffer,
 }))
 
 vi.mock('@/services/OfflineDownloadService', () => ({
@@ -110,9 +130,25 @@ vi.mock('@/components/album/AlbumInfoTab.vue', () => ({
 vi.mock('@/components/album/AlbumChaptersTab.vue', () => ({
   default: {name: 'AlbumChaptersTab', render: () => null},
 }))
-vi.mock('@/components/album/AlbumPreviewTab.vue', () => ({
-  default: {name: 'AlbumPreviewTab', render: () => null},
-}))
+vi.mock('@/components/album/AlbumPreviewTab.vue', async () => {
+  const {defineComponent, h} = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'AlbumPreviewTab',
+      inheritAttrs: false,
+      props: {
+        loadedCount: {type: Number, required: true},
+      },
+      setup(props) {
+        return () =>
+          h('div', {
+            class: 'album-preview-tab-stub',
+            'data-loaded-count': String(props.loadedCount),
+          })
+      },
+    }),
+  }
+})
 vi.mock('@/components/album/AlbumCommentsTab.vue', () => ({
   default: {name: 'AlbumCommentsTab', render: () => null},
 }))
@@ -122,12 +158,93 @@ vi.mock('@/components/favorite/FavoriteFolderPicker.vue', () => ({
 
 import AlbumDetailPage from '@/views/AlbumDetailPage.vue'
 
+const makePhoto = (): PhotoDetail => ({
+  id: 'chapter-1',
+  title: '第一章',
+  albumId: '123',
+  sortOrder: 1,
+  author: '作者',
+  tags: [],
+  images: [
+    {
+      photoId: 'chapter-1',
+      scrambleId: 'scramble-1',
+      filename: '1.webp',
+      url: 'https://example.test/1.webp',
+      queryParams: '',
+      sortOrder: 1,
+    },
+    {
+      photoId: 'chapter-1',
+      scrambleId: 'scramble-1',
+      filename: '2.webp',
+      url: 'https://example.test/2.webp',
+      queryParams: '',
+      sortOrder: 2,
+    },
+  ],
+})
+
+const makeAlbum = (): AlbumDetail => ({
+  id: '123',
+  title: '测试本子',
+  description: '',
+  addTime: '',
+  pageCount: 2,
+  likes: '0',
+  views: '0',
+  commentCount: 0,
+  image: '',
+  category: null,
+  subCategory: null,
+  authors: ['作者'],
+  works: [],
+  actors: [],
+  tags: [],
+  relatedAlbums: [],
+  photoMetas: [{id: 'chapter-1', title: '第一章', sortOrder: 1}],
+  seriesId: '1',
+  isFavorite: false,
+  isLiked: false,
+  price: '',
+  purchased: '',
+})
+
+const makeDownloadTask = (): DownloadTask => ({
+  taskId: '123_chapter-1',
+  albumId: '123',
+  chapterId: 'chapter-1',
+  albumTitle: '测试本子',
+  chapterTitle: '第一章',
+  coverUrl: '',
+  totalPages: 2,
+  downloadedPages: 2,
+  status: 'completed',
+  createdAt: 1,
+})
+
+const makeImportedPdf = (): ImportedPdf => ({
+  id: 1,
+  filePath: '/imports/chapter-1.pdf',
+  fileName: 'chapter-1.pdf',
+  albumId: '123',
+  albumTitle: '测试本子',
+  coverUrl: '',
+  authors: '作者',
+  chapterId: 'chapter-1',
+  chapterTitle: '第一章',
+  chapterSortOrder: 1,
+  createdAt: 1,
+})
+
 class ResizeObserverStub {
   observe() {}
   disconnect() {}
 }
 
 const settle = async () => {
+  await flushPromises()
+  await nextTick()
   await flushPromises()
   await nextTick()
 }
@@ -139,15 +256,73 @@ const clickTab = async (wrapper: VueWrapper, label: string) => {
   await settle()
 }
 
+const mountLoadedPage = async ({downloaded = false, pdf = false} = {}) => {
+  mocks.getAlbum.mockResolvedValue(makeAlbum())
+  mocks.getPhoto.mockResolvedValue(makePhoto())
+  mocks.getDownloadTasks.mockResolvedValue({
+    tasks: downloaded ? [makeDownloadTask()] : [],
+    usedBytes: 0,
+    availableBytes: 0,
+  })
+  mocks.getImportedPdfs.mockResolvedValue({pdfs: pdf ? [makeImportedPdf()] : []})
+
+  const wrapper = mount(AlbumDetailPage)
+  await settle()
+
+  mocks.getPhoto.mockClear()
+  mocks.getDownloadedPhoto.mockClear()
+  mocks.addImageReadyListener.mockClear()
+  mocks.preloadImages.mockClear()
+  mocks.fetchPdfArrayBuffer.mockClear()
+  mocks.showToast.mockClear()
+  return wrapper
+}
+
+const openPreview = async (wrapper: VueWrapper) => {
+  await clickTab(wrapper, '预览')
+  await vi.runAllTimersAsync()
+  await settle()
+}
+
+beforeEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+  mocks.setRouteId?.('123')
+  mocks.getAlbum.mockImplementation(() => new Promise(() => {}))
+  mocks.getPhoto.mockImplementation(() => new Promise(() => {}))
+  mocks.getDownloadedPhoto.mockResolvedValue(makePhoto())
+  mocks.getDownloadTasks.mockResolvedValue({tasks: [], usedBytes: 0, availableBytes: 0})
+  mocks.getImportedPdfs.mockResolvedValue({pdfs: []})
+  mocks.listenerRemove.mockResolvedValue(undefined)
+  mocks.addDownloadProgressListener.mockResolvedValue({remove: mocks.listenerRemove})
+  mocks.addImageReadyListener.mockImplementation((_photoId: string, handler: (sortOrder: number) => void) => {
+    mocks.imageReadyHandler = handler
+    return Promise.resolve({remove: mocks.listenerRemove})
+  })
+  mocks.preloadImages.mockResolvedValue({cached: [1], pending: [2]} satisfies PreloadResult)
+  mocks.getImageUrl.mockImplementation(
+    (photoId: string, sortOrder: number, type: string) => `https://jqviewer.local/${type}/${photoId}/${sortOrder}`,
+  )
+  mocks.showToast.mockResolvedValue(undefined)
+  mocks.fetchPdfArrayBuffer.mockResolvedValue(new ArrayBuffer(0))
+  mocks.buildPdfDocumentParams.mockReturnValue({data: new Uint8Array()})
+  mocks.pdfGetDocument.mockReturnValue({
+    promise: Promise.resolve({
+      numPages: 0,
+      destroy: vi.fn(() => Promise.resolve()),
+    }),
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
 describe('AlbumDetailPage tab 状态', () => {
   beforeEach(() => {
-    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
     mocks.menuSwipeGesture.mockClear()
-    mocks.setRouteId?.('123')
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
   })
 
   test('每个 tab 切换后恢复各自的滚动位置', async () => {
@@ -206,6 +381,136 @@ describe('AlbumDetailPage tab 状态', () => {
 
     expect(wrapper.findComponent(AlbumDetailPage).get('.tab-btn.active').text()).toBe('预览')
     expect(scrollElement.scrollTop).toBe(720)
+
+    wrapper.unmount()
+  })
+})
+
+describe('AlbumDetailPage 预览来源', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  test.each([
+    {pdf: true, label: '已下载且存在 PDF'},
+    {pdf: false, label: '仅已下载'},
+  ])('$label 时优先进入下载分支', async ({pdf}) => {
+    const wrapper = await mountLoadedPage({downloaded: true, pdf})
+
+    await openPreview(wrapper)
+
+    expect(mocks.getPhoto).toHaveBeenCalledWith('chapter-1')
+    expect(mocks.getDownloadedPhoto).not.toHaveBeenCalled()
+    expect(mocks.fetchPdfArrayBuffer).not.toHaveBeenCalled()
+    expect(mocks.addImageReadyListener).toHaveBeenCalledWith('chapter-1', expect.any(Function), {
+      type: 'thumb',
+    })
+    expect(mocks.preloadImages).toHaveBeenCalledWith('chapter-1', makePhoto().images, 'thumb')
+
+    const preview = wrapper.findComponent({name: 'AlbumPreviewTab'})
+    expect(preview.props('loadedCount')).toBe(1)
+    mocks.imageReadyHandler?.(2)
+    await settle()
+    expect(preview.props('loadedCount')).toBe(2)
+
+    wrapper.unmount()
+  })
+
+  test('仅存在 PDF 时只进入 PDF 分支', async () => {
+    const wrapper = await mountLoadedPage({pdf: true})
+
+    await openPreview(wrapper)
+
+    expect(mocks.fetchPdfArrayBuffer).toHaveBeenCalledWith('/imports/chapter-1.pdf')
+    expect(mocks.getPhoto).not.toHaveBeenCalled()
+    expect(mocks.getDownloadedPhoto).not.toHaveBeenCalled()
+    expect(mocks.addImageReadyListener).not.toHaveBeenCalled()
+    expect(mocks.preloadImages).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  test('没有任何本地来源时只进入网络分支', async () => {
+    const wrapper = await mountLoadedPage()
+
+    await openPreview(wrapper)
+
+    expect(mocks.getPhoto).toHaveBeenCalledWith('chapter-1')
+    expect(mocks.getDownloadedPhoto).not.toHaveBeenCalled()
+    expect(mocks.fetchPdfArrayBuffer).not.toHaveBeenCalled()
+    expect(mocks.preloadImages).toHaveBeenCalledWith('chapter-1', makePhoto().images, 'thumb')
+
+    wrapper.unmount()
+  })
+
+  test('下载分支在线元数据失败后只回退下载元数据', async () => {
+    const wrapper = await mountLoadedPage({downloaded: true, pdf: true})
+    mocks.getPhoto.mockRejectedValueOnce(new Error('online metadata failed'))
+
+    await openPreview(wrapper)
+
+    expect(mocks.getDownloadedPhoto).toHaveBeenCalledWith('123', 'chapter-1')
+    expect(mocks.fetchPdfArrayBuffer).not.toHaveBeenCalled()
+    expect(mocks.preloadImages).toHaveBeenCalledWith('chapter-1', makePhoto().images, 'thumb')
+
+    wrapper.unmount()
+  })
+
+  test('下载分支完全失败后不跨到 PDF 分支', async () => {
+    const wrapper = await mountLoadedPage({downloaded: true, pdf: true})
+    mocks.getPhoto.mockRejectedValueOnce(new Error('online metadata failed'))
+    mocks.getDownloadedPhoto.mockRejectedValueOnce(new Error('download metadata failed'))
+
+    await openPreview(wrapper)
+
+    expect(mocks.fetchPdfArrayBuffer).not.toHaveBeenCalled()
+    expect(mocks.preloadImages).not.toHaveBeenCalled()
+    expect(mocks.showToast).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  test('PDF 分支失败后不跨到图片分支', async () => {
+    const wrapper = await mountLoadedPage({pdf: true})
+    mocks.fetchPdfArrayBuffer.mockRejectedValueOnce(new Error('pdf failed'))
+
+    await openPreview(wrapper)
+
+    expect(mocks.getPhoto).not.toHaveBeenCalled()
+    expect(mocks.getDownloadedPhoto).not.toHaveBeenCalled()
+    expect(mocks.preloadImages).not.toHaveBeenCalled()
+    expect(mocks.showToast).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  test('网络分支失败后不查询下载或 PDF 来源', async () => {
+    const wrapper = await mountLoadedPage()
+    mocks.getPhoto.mockRejectedValueOnce(new Error('network failed'))
+
+    await openPreview(wrapper)
+
+    expect(mocks.getDownloadedPhoto).not.toHaveBeenCalled()
+    expect(mocks.fetchPdfArrayBuffer).not.toHaveBeenCalled()
+    expect(mocks.preloadImages).not.toHaveBeenCalled()
+    expect(mocks.showToast).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  test('来源失效后的旧 imageReady 事件不能写回预览槽位', async () => {
+    const wrapper = await mountLoadedPage({downloaded: true})
+    await openPreview(wrapper)
+    const staleImageReadyHandler = mocks.imageReadyHandler
+    expect(staleImageReadyHandler).toBeTypeOf('function')
+
+    mocks.setRouteId?.('456')
+    await settle()
+    staleImageReadyHandler?.(2)
+    await settle()
+
+    const preview = wrapper.findComponent({name: 'AlbumPreviewTab'})
+    expect(preview.props('loadedCount')).toBe(0)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
- 按已下载、仅 PDF、无本地来源确定预览分支，保持图片来源优先于 PDF
- 已下载分支优先使用 getPhoto，失败时仅回退下载元数据
- 统一下载与网络图片的缩略图预加载和 imageReady 槽位填充
- 隔离各来源失败处理，防止跨分支回退和旧事件写回
- 补充来源优先级、失败回退及异步时序测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化预览加载流程，支持下载图片、导入 PDF 和网络图片等来源。
  * 显示图片预加载进度，提升预览加载反馈。
  * 在预览请求失效或加载失败时及时停止相关监听，避免旧图片事件影响当前内容。

* **错误修复**
  * 优先使用最新在线章节数据加载下载预览，失败时自动使用本地下载数据。
  * 优化网络预览及 PDF 预览的失败提示和加载状态处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->