### PR TITLE
fix(download): 修复批量下载离开详情页后的参数竞态

### DIFF
--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -1421,34 +1421,62 @@ const handleToggleFavorite = async () => {
   void openFolderPicker()
 }
 
-const downloadSingleChapter = async (chapterId: string): Promise<boolean> => {
-  if (!albumDetail.value) return false
+type ChapterDownloadContext = {
+  albumId: string
+  albumTitle: string
+  coverUrl: string
+  isSingleEpisode?: boolean
+  chapterTitles: Map<string, string>
+}
 
-  const taskId = makeTaskId(albumId.value, chapterId)
+const createChapterDownloadContext = (): ChapterDownloadContext | null => {
+  const targetAlbumId = typeof albumId.value === 'string' ? albumId.value.trim() : ''
+  const album = albumDetail.value
+  if (!targetAlbumId || !album) return null
+
+  return {
+    albumId: targetAlbumId,
+    albumTitle: album.title,
+    coverUrl: album.image,
+    isSingleEpisode: album.isSingleEpisode,
+    chapterTitles: new Map(
+      album.photoMetas
+        .filter((meta) => typeof meta.id === 'string' && meta.id.trim().length > 0)
+        .map((meta) => [meta.id, meta.title] as const),
+    ),
+  }
+}
+
+const downloadSingleChapter = async (
+  chapterId: unknown,
+  context: ChapterDownloadContext,
+): Promise<boolean> => {
+  if (typeof chapterId !== 'string' || !chapterId.trim()) return false
+  const targetChapterId = chapterId.trim()
+  const taskId = makeTaskId(context.albumId, targetChapterId)
   const existing = OfflineDownloadService.getAll().find(
     (t) => t.taskId === taskId && t.status !== 'failed',
   )
   if (existing) return false
 
-  const chapterTitle =
-    albumDetail.value.photoMetas.find((m) => m.id === chapterId)?.title || chapterId
+  const chapterTitle = context.chapterTitles.get(targetChapterId) || targetChapterId
 
   try {
     await JmcomicService.downloadChapter(
-      albumId.value,
-      chapterId,
-      albumDetail.value.title,
+      context.albumId,
+      targetChapterId,
+      context.albumTitle,
       chapterTitle,
-      albumDetail.value.image,
+      context.coverUrl,
     )
     OfflineDownloadService.addTask({
       taskId,
-      albumId: albumId.value,
-      chapterId,
-      albumTitle: albumDetail.value.title,
+      albumId: context.albumId,
+      chapterId: targetChapterId,
+      albumTitle: context.albumTitle,
       chapterTitle,
-      coverUrl: albumDetail.value.image,
-      isSingleEpisode: albumDetail.value.isSingleEpisode,
+      coverUrl: context.coverUrl,
+      isSingleEpisode: context.isSingleEpisode,
       totalPages: 0,
       downloadedPages: 0,
       status: 'queued',
@@ -1463,9 +1491,10 @@ const downloadSingleChapter = async (chapterId: string): Promise<boolean> => {
 
 const handleDownload = async () => {
   const chapterId = selectedChapterId.value
-  if (!chapterId || !albumDetail.value) return
+  const context = createChapterDownloadContext()
+  if (!chapterId || !context) return
 
-  const taskId = makeTaskId(albumId.value, chapterId)
+  const taskId = makeTaskId(context.albumId, chapterId)
   const existing = OfflineDownloadService.getAll().find(
     (t) => t.taskId === taskId && t.status !== 'failed',
   )
@@ -1474,7 +1503,7 @@ const handleDownload = async () => {
     return
   }
 
-  const success = await downloadSingleChapter(chapterId)
+  const success = await downloadSingleChapter(chapterId, context)
   if (success) {
     await showToast('已加入下载队列', 'success')
     await refreshDownloadStatuses()
@@ -1483,9 +1512,15 @@ const handleDownload = async () => {
 
 const onBatchDownload = async (chapterIds: string[]) => {
   if (!chapterIds.length) return
+  const context = createChapterDownloadContext()
+  if (!context) {
+    await showToast('下载信息已失效，请重新进入详情页', 'danger')
+    return
+  }
+
   let successCount = 0
   for (const id of chapterIds) {
-    if (await downloadSingleChapter(id)) {
+    if (await downloadSingleChapter(id, context)) {
       successCount++
     }
   }

--- a/tests/unit/AlbumDetailPage.test.ts
+++ b/tests/unit/AlbumDetailPage.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   },
   getAlbum: vi.fn(() => new Promise(() => {})),
   getPhoto: vi.fn(() => new Promise(() => {})),
+  downloadChapter: vi.fn(),
   getDownloadedPhoto: vi.fn(),
   getDownloadTasks: vi.fn(),
   getImportedPdfs: vi.fn(),
@@ -95,6 +96,7 @@ vi.mock('@/services/JmcomicService', () => ({
   JmcomicService: {
     getAlbum: mocks.getAlbum,
     getPhoto: mocks.getPhoto,
+    downloadChapter: mocks.downloadChapter,
     getDownloadedPhoto: mocks.getDownloadedPhoto,
     getDownloadTasks: mocks.getDownloadTasks,
     getImportedPdfs: mocks.getImportedPdfs,
@@ -110,7 +112,10 @@ vi.mock('@/services/PdfReaderService', () => ({
 }))
 
 vi.mock('@/services/OfflineDownloadService', () => ({
-  OfflineDownloadService: {},
+  OfflineDownloadService: {
+    getAll: vi.fn(() => []),
+    addTask: vi.fn(),
+  },
 }))
 
 vi.mock('@/services/OfflineFavoriteService', () => ({
@@ -145,7 +150,7 @@ vi.mock('@/components/album/AlbumChaptersTab.vue', async () => {
       props: {
         selectedChapterId: {type: String, default: ''},
       },
-      emits: ['select-chapter'],
+      emits: ['select-chapter', 'batch-download'],
       setup(props) {
         return () =>
           h('div', {
@@ -314,8 +319,8 @@ const clickTab = async (wrapper: VueWrapper, label: string) => {
   await settle()
 }
 
-const mountLoadedPage = async ({downloaded = false, pdf = false} = {}) => {
-  mocks.getAlbum.mockResolvedValue(makeAlbum())
+const mountLoadedPage = async ({downloaded = false, pdf = false, album = makeAlbum()} = {}) => {
+  mocks.getAlbum.mockResolvedValue(album)
   mocks.getPhoto.mockResolvedValue(makePhoto())
   mocks.getDownloadTasks.mockResolvedValue({
     tasks: downloaded ? [makeDownloadTask()] : [],
@@ -328,6 +333,7 @@ const mountLoadedPage = async ({downloaded = false, pdf = false} = {}) => {
   await settle()
 
   mocks.getPhoto.mockClear()
+  mocks.downloadChapter.mockClear()
   mocks.getDownloadedPhoto.mockClear()
   mocks.addImageReadyListener.mockClear()
   mocks.preloadImages.mockClear()
@@ -350,6 +356,7 @@ beforeEach(() => {
   mocks.setRouteChapterId?.(undefined)
   mocks.getAlbum.mockImplementation(() => new Promise(() => {}))
   mocks.getPhoto.mockImplementation(() => new Promise(() => {}))
+  mocks.downloadChapter.mockResolvedValue({taskId: '123_chapter-1'})
   mocks.getDownloadedPhoto.mockResolvedValue(makePhoto())
   mocks.getDownloadTasks.mockResolvedValue({tasks: [], usedBytes: 0, availableBytes: 0})
   mocks.getImportedPdfs.mockResolvedValue({pdfs: []})
@@ -520,6 +527,47 @@ describe('AlbumDetailPage 章节路由定位', () => {
       'chapter-2',
     )
     expect(wrapper.findComponent({name: 'AlbumHeader'}).props('pageCount')).toBe(3)
+    wrapper.unmount()
+  })
+})
+
+describe('AlbumDetailPage 批量下载', () => {
+  test('离开详情页后继续使用提交时的专辑上下文', async () => {
+    const firstSubmit = deferred<{taskId: string}>()
+    mocks.downloadChapter
+      .mockReturnValueOnce(firstSubmit.promise)
+      .mockResolvedValueOnce({taskId: '123_chapter-2'})
+    const wrapper = await mountLoadedPage({album: makeMultiChapterAlbum()})
+
+    wrapper
+      .findComponent({name: 'AlbumChaptersTab'})
+      .vm.$emit('batch-download', ['chapter-1', 'chapter-2'])
+    await nextTick()
+
+    expect(mocks.downloadChapter).toHaveBeenNthCalledWith(
+      1,
+      '123',
+      'chapter-1',
+      '测试本子',
+      '第一章',
+      '',
+    )
+
+    mocks.setRouteId?.(undefined)
+    await nextTick()
+    firstSubmit.resolve({taskId: '123_chapter-1'})
+    await settle()
+
+    expect(mocks.downloadChapter).toHaveBeenNthCalledWith(
+      2,
+      '123',
+      'chapter-2',
+      '测试本子',
+      '第二章',
+      '',
+    )
+    expect(mocks.showToast).toHaveBeenCalledWith('已加入 2 个下载任务', 'success')
+
     wrapper.unmount()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化单章下载流程，确保下载任务使用正确的专辑、封面及章节信息。
  - 优化批量下载，即使离开专辑详情页，任务仍可继续使用提交时的数据创建。
- **问题修复**
  - 增加章节信息校验，避免无效章节创建下载任务。
  - 当专辑或下载信息不可用时，批量下载会及时提示错误并终止操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->