### PR TITLE
fix(android): 修复低版本分页兼容性与 instrumentation 测试稳定性

### DIFF
--- a/.github/workflows/ci-android-instrumentation.yml
+++ b/.github/workflows/ci-android-instrumentation.yml
@@ -59,14 +59,15 @@ jobs:
           mkdir -p android/app/build/ci-diagnostics
           echo "api-level=${{ matrix.api-level }}" > android/app/build/ci-diagnostics/matrix.txt
           echo "arch=x86_64" >> android/app/build/ci-diagnostics/matrix.txt
-          echo "target=default" >> android/app/build/ci-diagnostics/matrix.txt
+          echo "target=${{ matrix.api-level == 27 && 'default' || 'google_apis' }}" \
+            >> android/app/build/ci-diagnostics/matrix.txt
 
       - name: Run instrumentation tests on API ${{ matrix.api-level }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          target: default
+          target: ${{ matrix.api-level == 27 && 'default' || 'google_apis' }}
           disable-animations: true
           script: >
             diagnostics_dir="android/app/build/ci-diagnostics";

--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/HistoryPluginContractInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/HistoryPluginContractInstrumentedTest.java
@@ -70,6 +70,25 @@ public class HistoryPluginContractInstrumentedTest {
     }
 
     @Test
+    public void nonZeroOffsetPaginationRemainsCompatible() throws Exception {
+        plugin.recordBrowse(call("recordBrowse", "albumId", "album-1"));
+        plugin.recordBrowse(call("recordBrowse", "albumId", "album-2"));
+        RecordingPluginCall browseRead = call(
+            "getBrowseHistory", "limit", 1, "offset", 1);
+        plugin.getBrowseHistory(browseRead);
+        assertEquals(1, browseRead.resolvedData.getJSONArray("items").length());
+
+        plugin.addParseHistory(call("addParseHistory", "text", "first"));
+        plugin.addParseHistory(call("addParseHistory", "text", "second"));
+        RecordingPluginCall parseRead = call(
+            "getParseHistory", "limit", 1, "offset", 1);
+        plugin.getParseHistory(parseRead);
+        assertEquals(1, parseRead.resolvedData.getJSONArray("items").length());
+
+        assertNotKeptAlive(browseRead, parseRead);
+    }
+
+    @Test
     public void deleteAndClearMethodsKeepTheirSuccessContract() throws Exception {
         plugin.recordBrowse(call("recordBrowse", "albumId", "album-1"));
         plugin.recordBrowse(call("recordBrowse", "albumId", "album-2"));

--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/SystemPluginContractInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/SystemPluginContractInstrumentedTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -138,7 +139,7 @@ public class SystemPluginContractInstrumentedTest {
     }
 
     @Test
-    public void notificationPermissionUsesAndroidTwelveBranch() {
+    public void notificationPermissionUsesPlatformBranch() {
         permissionService.notificationGranted = false;
         RecordingPluginCall checkDenied = call("checkNotificationPermission");
         RecordingPluginCall requestDenied = call("requestNotificationPermission");
@@ -147,8 +148,25 @@ public class SystemPluginContractInstrumentedTest {
         plugin.requestNotificationPermission(requestDenied);
 
         assertFalse(checkDenied.resolvedData.getBool("granted"));
+        assertSynchronous(checkDenied);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            assertNull(requestDenied.resolvedData);
+            assertTrue(requestDenied.isKeptAlive());
+            assertArrayEquals(
+                new String[]{"android.permission.POST_NOTIFICATIONS"},
+                activity.requestedPermissions);
+            assertEquals(
+                PermissionService.REQUEST_POST_NOTIFICATIONS,
+                activity.permissionRequestCode);
+            plugin.handlePermissionResult(
+                PermissionService.REQUEST_POST_NOTIFICATIONS,
+                activity.requestedPermissions,
+                new int[]{PackageManager.PERMISSION_DENIED});
+            assertEquals(1, requestDenied.completionCount);
+        } else {
+            assertSynchronous(requestDenied);
+        }
         assertFalse(requestDenied.resolvedData.getBool("granted"));
-        assertSynchronous(checkDenied, requestDenied);
 
         permissionService.notificationGranted = true;
         RecordingPluginCall requestGranted = call("requestNotificationPermission");

--- a/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
@@ -67,6 +67,8 @@ public class PreloadServiceTest {
 
         assertEquals(1, result.getJSONArray("pending").length());
         assertTrue(fetched.await(1, TimeUnit.SECONDS));
+        networkExecutor.submit(() -> {
+        }).get(1, TimeUnit.SECONDS);
         assertEquals(1, fetchCount.get());
     }
 
@@ -101,6 +103,8 @@ public class PreloadServiceTest {
         service.setMemoryPressureLevel(CacheCapacityPolicy.PressureLevel.NORMAL);
         service.preloadImages("complete-photo", "image", images);
         assertTrue(fetched.await(1, TimeUnit.SECONDS));
+        networkExecutor.submit(() -> {
+        }).get(1, TimeUnit.SECONDS);
         assertEquals(1, fetchCount.get());
     }
 

--- a/android/app/src/main/java/io/github/jukomu/feature/favorite/data/FavoriteStore.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/favorite/data/FavoriteStore.java
@@ -231,7 +231,7 @@ public class FavoriteStore extends SQLiteOpenHelper {
                     COL_AUTHORS, COL_TAGS},
                 where, whereArgs, null, null,
                 COL_ID + " ASC",
-                pageSize + " OFFSET " + offset);
+                offset + "," + pageSize);
 
             JSONArray content = new JSONArray();
             while (dataCursor.moveToNext()) {

--- a/android/app/src/main/java/io/github/jukomu/feature/history/data/HistoryStore.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/history/data/HistoryStore.java
@@ -135,7 +135,7 @@ public class HistoryStore extends SQLiteOpenHelper {
         Cursor c = null;
         try {
             String limitClause = limit > 0
-                ? (offset > 0 ? limit + " OFFSET " + offset : String.valueOf(limit))
+                ? (offset > 0 ? offset + "," + limit : String.valueOf(limit))
                 : null;
             c = getReadableDatabase().query(TABLE_BROWSE,
                 new String[]{COL_ID, COL_ALBUM_ID, COL_ALBUM_TITLE, COL_COVER_URL, COL_AUTHORS,
@@ -214,7 +214,7 @@ public class HistoryStore extends SQLiteOpenHelper {
         Cursor c = null;
         try {
             String limitClause = limit > 0
-                ? (offset > 0 ? limit + " OFFSET " + offset : String.valueOf(limit))
+                ? (offset > 0 ? offset + "," + limit : String.valueOf(limit))
                 : null;
             c = getReadableDatabase().query(TABLE_PARSE,
                 new String[]{COL_ID, COL_TEXT, COL_TIMESTAMP, COL_MODE},


### PR DESCRIPTION
- 修复 API 24–29 收藏夹及历史记录分页查询
- 按 Android 版本验证通知权限流程
- 消除预加载缓存测试竞态
- 为 instrumentation 矩阵配置可用的 WebView 镜像

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复收藏列表分页查询，确保偏移量和每页数量按预期生效。
  * 修复浏览历史与解析历史的分页结果，提升分页数据准确性。
  * 优化不同 Android 版本下的通知权限处理与验证。

* **Tests**
  * 新增历史记录分页兼容性测试。
  * 增强预加载流程测试，确保异步网络操作完成后再进行验证。
  * 调整 Android 设备兼容性测试配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->