### PR TITLE
fix(reader): 完善损坏图片校验与批量重试

### DIFF
--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/CachePluginContractInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/CachePluginContractInstrumentedTest.java
@@ -114,6 +114,32 @@ public class CachePluginContractInstrumentedTest {
         assertSynchronous(call);
     }
 
+    @Test
+    public void retryImageValidatesAndForwardsLatestMetadata() throws Exception {
+        RecordingPluginCall missingPhotoId = call(
+            "retryImage", "image", new JSObject().put("sortOrder", 1));
+        RecordingPluginCall missingImage = call("retryImage", "photoId", "photo-1");
+
+        plugin.retryImage(missingPhotoId);
+        plugin.retryImage(missingImage);
+
+        assertRejected(missingPhotoId, "photoId is required");
+        assertRejected(missingImage, "image is required");
+
+        JSObject image = new JSObject()
+            .put("sortOrder", 1)
+            .put("url", "https://latest.example.com/1.jpg");
+        RecordingPluginCall valid = call(
+            "retryImage", "photoId", "photo-1", "image", image);
+        plugin.retryImage(valid);
+
+        assertEquals("photo-1", preloadService.retryPhotoId);
+        assertEquals("https://latest.example.com/1.jpg",
+            preloadService.retryImage.getString("url"));
+        assertTrue(valid.resolvedData.getBool("success"));
+        assertSynchronous(valid);
+    }
+
     private static RecordingPluginCall call(String methodName, Object... entries) {
         JSObject data = new JSObject();
         for (int index = 0; index < entries.length; index += 2) {
@@ -162,6 +188,8 @@ public class CachePluginContractInstrumentedTest {
         private long capacityMb;
         private boolean cleared;
         private RuntimeException failure;
+        private String retryPhotoId;
+        private JSONObject retryImage;
 
         private FakePreloadService() {
             super(null, null, null, null, null, null, null, null);
@@ -177,6 +205,14 @@ public class CachePluginContractInstrumentedTest {
             return jsonObject(
                 "cached", new JSONArray(),
                 "pending", new JSONArray().put(7));
+        }
+
+        @Override
+        public void retryImage(String photoId, JSONObject image,
+                               ImageRetryCallback callback) {
+            this.retryPhotoId = photoId;
+            this.retryImage = image;
+            callback.onSuccess();
         }
 
         @Override

--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/FeatureEventAdapterInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/FeatureEventAdapterInstrumentedTest.java
@@ -74,6 +74,17 @@ public class FeatureEventAdapterInstrumentedTest {
     }
 
     @Test
+    public void imageFailedUsesExpectedPayload() {
+        adapter.onImageFailed("photo", 9, "image");
+
+        assertEquals("imageFailed", eventName);
+        assertEquals("photo", eventData.getString("photoId"));
+        assertEquals(9, eventData.getInteger("sortOrder").intValue());
+        assertEquals("image", eventData.getString("type"));
+        assertEquals(1, eventCount);
+    }
+
+    @Test
     public void relocationProgressIncludesCurrentFileOnlyWhenPresent() {
         adapter.onRelocationProgress(1, 3, "copy", "chapter/file.webp");
 

--- a/android/app/src/androidTest/java/io/github/jukomu/feature/download/validation/ImageFileValidatorInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/feature/download/validation/ImageFileValidatorInstrumentedTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 
@@ -68,6 +69,20 @@ public class ImageFileValidatorInstrumentedTest {
         Files.write(random.toPath(), new byte[]{1, 2, 3, 4});
         assertFalse(ImageFileValidator.validateQuick(random));
         assertFalse(ImageFileValidator.validateFull(random));
+    }
+
+    @Test
+    public void validatesImageBytesWithoutFullDecode() {
+        Bitmap bitmap = Bitmap.createBitmap(2, 3, Bitmap.Config.ARGB_8888);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output));
+        } finally {
+            bitmap.recycle();
+        }
+
+        assertTrue(ImageFileValidator.validateQuick(output.toByteArray()));
+        assertFalse(ImageFileValidator.validateQuick(new byte[]{1, 2, 3, 4}));
     }
 
     private static void deleteRecursive(File file) {

--- a/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
@@ -238,6 +238,36 @@ public class PreloadServiceTest {
     }
 
     @Test
+    public void localImageCacheAdmissionFailureNotifiesImageFailure() throws Exception {
+        byte[] oversizedImage = new byte[17 * 1024 * 1024];
+        byte[] png = createPng();
+        System.arraycopy(png, 0, oversizedImage, 0, png.length);
+        prepareLocalImage("local-cache-admission-failed", oversizedImage);
+
+        CountDownLatch failed = new CountDownLatch(1);
+        PreloadService service = createService(image -> createPng(), new PreloadEventSink() {
+            @Override
+            public void onImageReady(String photoId, int sortOrder, String type) {
+            }
+
+            @Override
+            public void onImageFailed(String photoId, int sortOrder, String type) {
+                assertEquals("local-cache-admission-failed", photoId);
+                assertEquals(1, sortOrder);
+                assertEquals("image", type);
+                failed.countDown();
+            }
+        });
+
+        JSONObject result = service.preloadImages(
+            "local-cache-admission-failed", "image", imageArray());
+
+        assertEquals(0, result.getJSONArray("cached").length());
+        assertEquals(0, result.getJSONArray("pending").length());
+        assertTrue(failed.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
     public void networkFailureNotifiesCurrentImageFailure() throws Exception {
         CountDownLatch failed = new CountDownLatch(1);
         AtomicReference<String> failedPhotoId = new AtomicReference<>();
@@ -262,6 +292,33 @@ public class PreloadServiceTest {
         assertTrue(failed.await(1, TimeUnit.SECONDS));
         assertEquals("network-failed", failedPhotoId.get());
         assertEquals(1, failedSortOrder.get());
+    }
+
+    @Test
+    public void invalidNetworkImageBytesNotifyFailureWithoutCaching() throws Exception {
+        CountDownLatch failed = new CountDownLatch(1);
+        PreloadService service = createService(image -> new byte[]{1, 2, 3, 4},
+            new PreloadEventSink() {
+                @Override
+                public void onImageReady(String photoId, int sortOrder, String type) {
+                    fail("无效网络图片不应发送 imageReady");
+                }
+
+                @Override
+                public void onImageFailed(String photoId, int sortOrder, String type) {
+                    assertEquals("invalid-network-image", photoId);
+                    assertEquals(1, sortOrder);
+                    assertEquals("image", type);
+                    failed.countDown();
+                }
+            });
+
+        service.preloadImages("invalid-network-image", "image", imageArray());
+
+        assertTrue(failed.await(1, TimeUnit.SECONDS));
+        networkExecutor.submit(() -> {
+        }).get(1, TimeUnit.SECONDS);
+        assertFalse(imageCache.has("invalid-network-image/1"));
     }
 
     @Test

--- a/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
@@ -1,6 +1,8 @@
 package io.github.jukomu.feature.preload;
 
+import android.graphics.Bitmap;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 import io.github.jukomu.feature.cache.CacheCapacityPolicy;
 import io.github.jukomu.feature.cache.ImageCache;
 import io.github.jukomu.feature.download.storage.FileStore;
@@ -11,11 +13,19 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 
@@ -23,24 +33,62 @@ import static org.junit.Assert.*;
 public class PreloadServiceTest {
 
     private final ImageCache imageCache = ImageCache.getInstance();
+    private final FileStore fileStore = FileStore.getInstance();
     private ExecutorService imageExecutor;
     private ExecutorService networkExecutor;
+    private Field baseDirField;
+    private File originalBaseDir;
+    private File testBaseDir;
+    private Map<String, String> chapterMappings;
+    private Map<String, String> filenameMappings;
+    private Map<String, String> originalChapterMappings;
+    private Map<String, String> originalFilenameMappings;
 
     @Before
-    public void setUp() {
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
         imageCache.applyPolicy(new CacheCapacityPolicy().calculate(
             16, 64L * CacheCapacityPolicy.MIB, false,
             CacheCapacityPolicy.PressureLevel.NORMAL));
         imageCache.clear();
         imageExecutor = Executors.newSingleThreadExecutor();
         networkExecutor = Executors.newSingleThreadExecutor();
+
+        testBaseDir = new File(
+            InstrumentationRegistry.getInstrumentation().getTargetContext().getCacheDir(),
+            "preload-service-test-" + System.nanoTime());
+        if (!testBaseDir.mkdirs()) {
+            throw new IOException("无法创建预载测试目录");
+        }
+        baseDirField = FileStore.class.getDeclaredField("baseDir");
+        baseDirField.setAccessible(true);
+        originalBaseDir = (File) baseDirField.get(fileStore);
+        baseDirField.set(fileStore, testBaseDir);
+
+        Field chapterMappingsField = FileStore.class.getDeclaredField("chapterIdToAlbumId");
+        chapterMappingsField.setAccessible(true);
+        chapterMappings = (Map<String, String>) chapterMappingsField.get(fileStore);
+        originalChapterMappings = new HashMap<>(chapterMappings);
+        chapterMappings.clear();
+
+        Field filenameMappingsField = FileStore.class.getDeclaredField("sortOrderToFilename");
+        filenameMappingsField.setAccessible(true);
+        filenameMappings = (Map<String, String>) filenameMappingsField.get(fileStore);
+        originalFilenameMappings = new HashMap<>(filenameMappings);
+        filenameMappings.clear();
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         imageExecutor.shutdownNow();
         networkExecutor.shutdownNow();
         imageCache.clear();
+        chapterMappings.clear();
+        chapterMappings.putAll(originalChapterMappings);
+        filenameMappings.clear();
+        filenameMappings.putAll(originalFilenameMappings);
+        baseDirField.set(fileStore, originalBaseDir);
+        deleteRecursive(testBaseDir);
     }
 
     @Test
@@ -156,5 +204,174 @@ public class PreloadServiceTest {
         assertEquals("image", entries.getJSONObject(0).getString("type"));
         assertEquals(50, entries.getJSONObject(1).getInt("sortOrder"));
         assertEquals("thumb", entries.getJSONObject(1).getString("type"));
+    }
+
+    @Test
+    public void validLocalImageIsCachedWithoutNetworkRequest() throws Exception {
+        prepareLocalImage("local-valid", createPng());
+        AtomicInteger fetchCount = new AtomicInteger();
+        PreloadService service = createService(image -> {
+            fetchCount.incrementAndGet();
+            return createPng();
+        });
+
+        JSONObject result = service.preloadImages("local-valid", "image", imageArray());
+
+        assertEquals(1, result.getJSONArray("cached").length());
+        assertEquals(0, fetchCount.get());
+        assertTrue(imageCache.has("local-valid/1"));
+    }
+
+    @Test
+    public void invalidLocalImageFallsThroughToNetworkRequest() throws Exception {
+        prepareLocalImage("local-invalid", new byte[]{1, 2, 3, 4});
+        CountDownLatch fetched = new CountDownLatch(1);
+        PreloadService service = createService(image -> {
+            fetched.countDown();
+            return createPng();
+        });
+
+        JSONObject result = service.preloadImages("local-invalid", "image", imageArray());
+
+        assertEquals(1, result.getJSONArray("pending").length());
+        assertTrue(fetched.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void networkFailureNotifiesCurrentImageFailure() throws Exception {
+        CountDownLatch failed = new CountDownLatch(1);
+        AtomicReference<String> failedPhotoId = new AtomicReference<>();
+        AtomicInteger failedSortOrder = new AtomicInteger();
+        PreloadService service = createService(image -> {
+            throw new IOException("network failed");
+        }, new PreloadEventSink() {
+            @Override
+            public void onImageReady(String photoId, int sortOrder, String type) {
+            }
+
+            @Override
+            public void onImageFailed(String photoId, int sortOrder, String type) {
+                failedPhotoId.set(photoId);
+                failedSortOrder.set(sortOrder);
+                failed.countDown();
+            }
+        });
+
+        service.preloadImages("network-failed", "image", imageArray());
+
+        assertTrue(failed.await(1, TimeUnit.SECONDS));
+        assertEquals("network-failed", failedPhotoId.get());
+        assertEquals(1, failedSortOrder.get());
+    }
+
+    @Test
+    public void retryImageBypassesExistingCacheAndRejectsInvalidReplacement() throws Exception {
+        byte[] oldBytes = new byte[]{9, 8, 7};
+        imageCache.put("retry-photo/1", oldBytes, "image/jpeg");
+        AtomicInteger fetchCount = new AtomicInteger();
+        PreloadService validService = createService(image -> {
+            fetchCount.incrementAndGet();
+            return createPng();
+        });
+
+        RetryOutcome valid = retry(validService, "retry-photo");
+
+        assertNull(valid.error);
+        assertEquals(1, fetchCount.get());
+        assertFalse(java.util.Arrays.equals(oldBytes, imageCache.get("retry-photo/1").data));
+
+        byte[] validBytes = imageCache.get("retry-photo/1").data;
+        PreloadService invalidService = createService(image -> new byte[]{1, 2, 3, 4});
+        RetryOutcome invalid = retry(invalidService, "retry-photo");
+
+        assertNotNull(invalid.error);
+        assertArrayEquals(validBytes, imageCache.get("retry-photo/1").data);
+    }
+
+    private PreloadService createService(PreloadService.ImageFetcher imageFetcher) {
+        return createService(imageFetcher, null);
+    }
+
+    private PreloadService createService(PreloadService.ImageFetcher imageFetcher,
+                                         PreloadEventSink eventSink) {
+        return new PreloadService(
+            imageCache, fileStore, null, null,
+            imageExecutor, networkExecutor, eventSink, null,
+            new CacheCapacityPolicy(), 2, imageFetcher);
+    }
+
+    private void prepareLocalImage(String photoId, byte[] bytes) throws Exception {
+        String albumId = "album";
+        String filename = "page.png";
+        chapterMappings.put(photoId, albumId);
+        filenameMappings.put(albumId + "_" + photoId + "_1", filename);
+        File chapterDir = new File(testBaseDir, albumId + File.separator + photoId);
+        if (!chapterDir.mkdirs()) {
+            throw new IOException("无法创建章节测试目录");
+        }
+        try (FileOutputStream output = new FileOutputStream(new File(chapterDir, filename))) {
+            output.write(bytes);
+        }
+    }
+
+    private RetryOutcome retry(PreloadService service, String photoId) throws Exception {
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        service.retryImage(photoId, imageArray().getJSONObject(0),
+            new PreloadService.ImageRetryCallback() {
+                @Override
+                public void onSuccess() {
+                    completed.countDown();
+                }
+
+                @Override
+                public void onError(Exception retryError) {
+                    error.set(retryError);
+                    completed.countDown();
+                }
+            });
+        assertTrue(completed.await(1, TimeUnit.SECONDS));
+        return new RetryOutcome(error.get());
+    }
+
+    private static JSONArray imageArray() throws Exception {
+        return new JSONArray().put(new JSONObject()
+            .put("sortOrder", 1)
+            .put("scrambleId", "scramble")
+            .put("filename", "page.png")
+            .put("url", "https://example.invalid/page.png")
+            .put("queryParams", ""));
+    }
+
+    private static byte[] createPng() {
+        Bitmap bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                throw new IllegalStateException("无法创建 PNG 测试图片");
+            }
+            return output.toByteArray();
+        } finally {
+            bitmap.recycle();
+        }
+    }
+
+    private static void deleteRecursive(File file) {
+        if (file == null || !file.exists()) return;
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursive(child);
+            }
+        }
+        file.delete();
+    }
+
+    private static final class RetryOutcome {
+        private final Exception error;
+
+        private RetryOutcome(Exception error) {
+            this.error = error;
+        }
     }
 }

--- a/android/app/src/main/java/io/github/jukomu/bridge/FeatureEventAdapter.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/FeatureEventAdapter.java
@@ -53,6 +53,15 @@ final class FeatureEventAdapter implements DownloadEventSink, PreloadEventSink,
     }
 
     @Override
+    public void onImageFailed(String photoId, int sortOrder, String type) {
+        JSObject event = new JSObject();
+        event.put("photoId", photoId);
+        event.put("sortOrder", sortOrder);
+        event.put("type", type);
+        eventPublisher.accept("imageFailed", event);
+    }
+
+    @Override
     public void onRelocationProgress(int current, int total, String phase,
                                      String currentFile) {
         JSObject event = new JSObject();

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -525,6 +525,11 @@ public class JmcomicPlugin extends Plugin {
         cacheHandler.preloadImages(call);
     }
 
+    @PluginMethod
+    public void retryImage(PluginCall call) {
+        cacheHandler.retryImage(call);
+    }
+
     // @PluginMethod  // 暂不暴露给 Vue，后续需要时取消注释
     public void clearPhotoCache(PluginCall call) {
         String photoId = call.getString("photoId");

--- a/android/app/src/main/java/io/github/jukomu/bridge/handler/CachePluginHandler.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/handler/CachePluginHandler.java
@@ -52,6 +52,37 @@ public final class CachePluginHandler {
     }
 
     /**
+     * 使用最新图片元数据直接重试单页，并等待缓存替换完成。
+     */
+    public void retryImage(PluginCall call) {
+        String photoId = call.getString("photoId");
+        JSObject image = call.getObject("image");
+        if (photoId == null || photoId.isEmpty()) {
+            call.reject("photoId is required");
+            return;
+        }
+        if (image == null) {
+            call.reject("image is required");
+            return;
+        }
+
+        preloadService.retryImage(photoId, image, new PreloadService.ImageRetryCallback() {
+            @Override
+            public void onSuccess() {
+                JSObject result = new JSObject();
+                result.put("success", true);
+                call.resolve(result);
+            }
+
+            @Override
+            public void onError(Exception error) {
+                Log.w(TAG, "图片重试失败", error);
+                call.reject(error.getMessage(), error);
+            }
+        });
+    }
+
+    /**
      * 设置 64 至 1024 MB 的缓存容量，并返回当前容量信息。
      */
     public void setCacheCapacity(PluginCall call) {

--- a/android/app/src/main/java/io/github/jukomu/feature/download/validation/ImageFileValidator.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/download/validation/ImageFileValidator.java
@@ -38,6 +38,25 @@ public final class ImageFileValidator {
     }
 
     /**
+     * 快速校验内存中的图片字节，只读取图片边界。
+     */
+    public static boolean validateQuick(byte[] imageBytes) {
+        if (imageBytes == null || imageBytes.length == 0) {
+            return false;
+        }
+
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        try {
+            BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.length, options);
+            return options.outWidth > 0 && options.outHeight > 0;
+        } catch (RuntimeException | OutOfMemoryError error) {
+            Log.w(TAG, "快速图片字节校验失败", error);
+            return false;
+        }
+    }
+
+    /**
      * 完整校验实际解码图片
      *
      */

--- a/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadEventSink.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadEventSink.java
@@ -5,4 +5,6 @@ package io.github.jukomu.feature.preload;
  */
 public interface PreloadEventSink {
     void onImageReady(String photoId, int sortOrder, String type);
+
+    void onImageFailed(String photoId, int sortOrder, String type);
 }

--- a/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import io.github.jukomu.feature.cache.CacheCapacityPolicy;
 import io.github.jukomu.feature.cache.ImageCache;
 import io.github.jukomu.feature.download.storage.FileStore;
+import io.github.jukomu.feature.download.validation.ImageFileValidator;
 import io.github.jukomu.jmcomic.api.model.JmImage;
 import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
 import io.github.jukomu.jmcomic.core.crypto.JmImageTool;
@@ -14,6 +15,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +31,12 @@ public class PreloadService {
     @FunctionalInterface
     interface ImageFetcher {
         byte[] fetch(JmImage image) throws Exception;
+    }
+
+    public interface ImageRetryCallback {
+        void onSuccess();
+
+        void onError(Exception error);
     }
 
     private static final String TAG = "PreloadService";
@@ -151,7 +159,7 @@ public class PreloadService {
 
             // 本地文件命中（已下载图片）
             File localFile = fileStore.getImageFileByPhotoId(photoId, sortOrder);
-            if (localFile != null) {
+            if (ImageFileValidator.validateQuick(localFile)) {
                 if (isThumb) {
                     // 缩略图：提交到线程池生成
                     pending.add(sortOrder);
@@ -211,26 +219,38 @@ public class PreloadService {
                 NetworkLoadGate.Permit permit = null;
                 try {
                     permit = networkLoadGate.acquire(() -> isStale(scopeKey, generation));
-                    if (permit == null || isStale(scopeKey, generation)) return;
+                    if (permit == null) {
+                        if (isStale(scopeKey, generation)) return;
+                        throw new IOException("当前内存压力过高，暂时无法加载图片");
+                    }
+                    if (isStale(scopeKey, generation)) return;
                     JmImage jmImage = new JmImage(photoId, scrambleId, filename, url, queryParams, sortOrder);
                     if (imageFetcher == null) {
                         throw new IllegalStateException("图片获取器未初始化");
                     }
                     byte[] decrypted = imageFetcher.fetch(jmImage);
-                    if (isStale(scopeKey, generation)
-                        || networkLoadGate.isCompletePressure()) return;
+                    if (isStale(scopeKey, generation)) return;
+                    if (networkLoadGate.isCompletePressure()) {
+                        throw new IOException("当前内存压力过高，已丢弃图片加载结果");
+                    }
                     String formatName = JmImageTool.getFormatName(filename);
                     String mimeType = "image/" + formatName;
 
                     try (ImageCache.IncomingReservation reservation =
                              imageCache.prepareForIncomingBytes(decrypted.length)) {
-                        if (reservation == null) return;
+                        if (reservation == null) {
+                            throw new IOException("图片无法写入内存缓存");
+                        }
                         if (isThumb) {
                             byte[] thumbBytes = ImageCache.createThumbnail(decrypted);
                             imageCache.put(photoId + "/" + sortOrder, decrypted, mimeType, reservation);
-                            if (!imageCache.put(cacheKey, thumbBytes, "image/jpeg")) return;
+                            if (!imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
+                                throw new IOException("缩略图无法写入内存缓存");
+                            }
                         } else {
-                            if (!imageCache.put(cacheKey, decrypted, mimeType, reservation)) return;
+                            if (!imageCache.put(cacheKey, decrypted, mimeType, reservation)) {
+                                throw new IOException("图片无法写入内存缓存");
+                            }
                         }
                     }
 
@@ -238,6 +258,9 @@ public class PreloadService {
                 } catch (Exception e) {
                     if (e instanceof InterruptedException) Thread.currentThread().interrupt();
                     Log.d(TAG, "图片下载或解密失败", e);
+                    if (!isStale(scopeKey, generation)) {
+                        notifyImageFailed(photoId, sortOrder, type);
+                    }
                 } finally {
                     if (permit != null) permit.close();
                     pendingKeys.remove(cacheKey, generation);
@@ -256,6 +279,81 @@ public class PreloadService {
             Log.d(TAG, "构建待处理列表失败", e);
         }
         return ret;
+    }
+
+    /**
+     * 使用调用方提供的最新图片元数据直接重新获取单页，仅替换内存缓存。
+     */
+    public void retryImage(String photoId, JSONObject imageObject, ImageRetryCallback callback) {
+        if (callback == null) {
+            throw new IllegalArgumentException("callback is required");
+        }
+        if (photoId == null || photoId.isEmpty()) {
+            callback.onError(new IllegalArgumentException("photoId is required"));
+            return;
+        }
+        if (imageObject == null) {
+            callback.onError(new IllegalArgumentException("image is required"));
+            return;
+        }
+
+        final int sortOrder = imageObject.optInt("sortOrder");
+        if (sortOrder <= 0) {
+            callback.onError(new IllegalArgumentException("sortOrder must be positive"));
+            return;
+        }
+        final String scrambleId = imageObject.optString("scrambleId");
+        final String filename = imageObject.optString("filename");
+        final String url = imageObject.optString("url");
+        final String queryParams = imageObject.optString("queryParams", "");
+
+        try {
+            networkExecutor.submit(() -> {
+                NetworkLoadGate.Permit permit = null;
+                Exception failure = null;
+                try {
+                    permit = networkLoadGate.acquire(null);
+                    if (permit == null) {
+                        throw new IOException("当前内存压力过高，暂时无法重试图片");
+                    }
+                    if (imageFetcher == null) {
+                        throw new IllegalStateException("图片获取器未初始化");
+                    }
+
+                    JmImage image = new JmImage(
+                        photoId, scrambleId, filename, url, queryParams, sortOrder);
+                    byte[] imageBytes = imageFetcher.fetch(image);
+                    if (!ImageFileValidator.validateQuick(imageBytes)) {
+                        throw new IOException("重新获取的图片无法解析");
+                    }
+                    if (networkLoadGate.isCompletePressure()) {
+                        throw new IOException("当前内存压力过高，已丢弃重试结果");
+                    }
+
+                    String mimeType = "image/" + JmImageTool.getFormatName(filename);
+                    if (!imageCache.put(photoId + "/" + sortOrder, imageBytes, mimeType)) {
+                        throw new IOException("重试图片无法写入内存缓存");
+                    }
+                } catch (Exception error) {
+                    if (error instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
+                    failure = error;
+                } finally {
+                    if (permit != null) {
+                        permit.close();
+                    }
+                }
+
+                if (failure == null) {
+                    callback.onSuccess();
+                } else {
+                    callback.onError(failure);
+                }
+            });
+        } catch (RuntimeException error) {
+            callback.onError(error);
+        }
     }
 
     private boolean isStale(String scopeKey, long generation) {
@@ -387,6 +485,13 @@ public class PreloadService {
         PreloadEventSink current = eventSink;
         if (current != null) {
             current.onImageReady(photoId, sortOrder, type);
+        }
+    }
+
+    private void notifyImageFailed(String photoId, int sortOrder, String type) {
+        PreloadEventSink current = eventSink;
+        if (current != null) {
+            current.onImageFailed(photoId, sortOrder, type);
         }
     }
 }

--- a/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
@@ -170,7 +170,9 @@ public class PreloadService {
                     imageExecutor.submit(() -> {
                         try (ImageCache.IncomingReservation reservation =
                                  imageCache.prepareForIncomingBytes(localFile.length())) {
-                            if (reservation == null) return;
+                            if (reservation == null) {
+                                throw new IOException("本地图片无法写入内存缓存");
+                            }
                             if (isStale(scopeKey, generation)) return;
                             byte[] localBytes = fileStore.readImageBytes(localFile);
                             byte[] thumbBytes = ImageCache.createThumbnail(localBytes);
@@ -179,27 +181,37 @@ public class PreloadService {
                             imageCache.put(imageKey, localBytes, mime, reservation);
                             if (imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
                                 notifyImageReady(photoId, sortOrder, type);
+                            } else {
+                                throw new IOException("本地缩略图无法写入内存缓存");
                             }
                         } catch (Exception e) {
                             Log.d(TAG, "缩略图生成失败", e);
+                            if (!isStale(scopeKey, generation)) {
+                                notifyImageFailed(photoId, sortOrder, type);
+                            }
                         } finally {
                             pendingKeys.remove(cacheKey, generation);
                         }
                     });
                 } else {
                     // 原图：直接缓存，同步通知
+                    boolean cachedLocally = false;
                     try (ImageCache.IncomingReservation reservation =
                              imageCache.prepareForIncomingBytes(localFile.length())) {
                         if (reservation != null) {
                             byte[] localBytes = fileStore.readImageBytes(localFile);
                             String mime = "image/" + ImageCache.guessFormatName(localBytes);
-                            if (imageCache.put(cacheKey, localBytes, mime, reservation)) {
+                            cachedLocally = imageCache.put(cacheKey, localBytes, mime, reservation);
+                            if (cachedLocally) {
                                 cached.add(sortOrder);
                                 notifyImageReady(photoId, sortOrder, type);
                             }
                         }
                     } catch (Exception e) {
                         Log.d(TAG, "本地图片读取失败", e);
+                    }
+                    if (!cachedLocally) {
+                        notifyImageFailed(photoId, sortOrder, type);
                     }
                 }
                 continue;
@@ -231,6 +243,9 @@ public class PreloadService {
                     }
                     byte[] decrypted = imageFetcher.fetch(jmImage);
                     if (isStale(scopeKey, generation)) return;
+                    if (!ImageFileValidator.validateQuick(decrypted)) {
+                        throw new IOException("获取的图片无法解析");
+                    }
                     if (networkLoadGate.isCompletePressure()) {
                         throw new IOException("当前内存压力过高，已丢弃图片加载结果");
                     }

--- a/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
@@ -136,7 +136,8 @@ public class PreloadService {
             }
 
             final int sortOrder = imgObj.optInt("sortOrder");
-            final String cacheKey = photoId + "/" + sortOrder + (isThumb ? "/thumb" : "");
+            final String imageKey = photoId + "/" + sortOrder;
+            final String cacheKey = imageKey + (isThumb ? "/thumb" : "");
 
             // 目标缓存命中
             if (imageCache.has(cacheKey)) {
@@ -146,7 +147,7 @@ public class PreloadService {
 
             // 缩略图：优先从已缓存的原图生成
             if (isThumb) {
-                ImageCache.ImageEntry original = imageCache.get(photoId + "/" + sortOrder);
+                ImageCache.ImageEntry original = imageCache.get(imageKey);
                 if (original != null) {
                     byte[] thumbBytes = ImageCache.createThumbnail(original.data);
                     if (imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
@@ -175,7 +176,7 @@ public class PreloadService {
                             byte[] thumbBytes = ImageCache.createThumbnail(localBytes);
                             if (isStale(scopeKey, generation)) return;
                             String mime = "image/" + ImageCache.guessFormatName(localBytes);
-                            imageCache.put(photoId + "/" + sortOrder, localBytes, mime, reservation);
+                            imageCache.put(imageKey, localBytes, mime, reservation);
                             if (imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
                                 notifyImageReady(photoId, sortOrder, type);
                             }
@@ -243,7 +244,7 @@ public class PreloadService {
                         }
                         if (isThumb) {
                             byte[] thumbBytes = ImageCache.createThumbnail(decrypted);
-                            imageCache.put(photoId + "/" + sortOrder, decrypted, mimeType, reservation);
+                            imageCache.put(imageKey, decrypted, mimeType, reservation);
                             if (!imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
                                 throw new IOException("缩略图无法写入内存缓存");
                             }

--- a/android/app/src/main/java/io/github/jukomu/runtime/RuntimeEventRouter.java
+++ b/android/app/src/main/java/io/github/jukomu/runtime/RuntimeEventRouter.java
@@ -54,6 +54,14 @@ final class RuntimeEventRouter implements DownloadEventSink, PreloadEventSink,
     }
 
     @Override
+    public void onImageFailed(String photoId, int sortOrder, String type) {
+        PreloadEventSink current = preloadDelegate;
+        if (current != null) {
+            current.onImageFailed(photoId, sortOrder, type);
+        }
+    }
+
+    @Override
     public void onRelocationProgress(int current, int total, String phase,
                                      String currentFile) {
         RelocationEventSink sink = relocationDelegate;

--- a/android/app/src/test/java/io/github/jukomu/feature/download/validation/ImageFileValidatorTest.java
+++ b/android/app/src/test/java/io/github/jukomu/feature/download/validation/ImageFileValidatorTest.java
@@ -14,7 +14,9 @@ public class ImageFileValidatorTest {
     @Test
     public void rejectsUnavailableFiles() {
         assertFalse(ImageFileValidator.validateFull(null));
-        assertFalse(ImageFileValidator.validateQuick(null));
+        assertFalse(ImageFileValidator.validateQuick((File) null));
+        assertFalse(ImageFileValidator.validateQuick((byte[]) null));
+        assertFalse(ImageFileValidator.validateQuick(new byte[0]));
         assertFalse(ImageFileValidator.validateFull(
             new File("missing-image-" + System.nanoTime() + ".jpg")));
     }
@@ -23,10 +25,13 @@ public class ImageFileValidatorTest {
     public void fullIsSynchronizedWhileQuickIsNot() throws Exception {
         Method full = ImageFileValidator.class.getMethod("validateFull", File.class);
         Method quick = ImageFileValidator.class.getMethod("validateQuick", File.class);
+        Method quickBytes = ImageFileValidator.class.getMethod("validateQuick", byte[].class);
 
         assertTrue(Modifier.isStatic(full.getModifiers()));
         assertTrue(Modifier.isSynchronized(full.getModifiers()));
         assertTrue(Modifier.isStatic(quick.getModifiers()));
         assertFalse(Modifier.isSynchronized(quick.getModifiers()));
+        assertTrue(Modifier.isStatic(quickBytes.getModifiers()));
+        assertFalse(Modifier.isSynchronized(quickBytes.getModifiers()));
     }
 }

--- a/android/app/src/test/java/io/github/jukomu/runtime/RuntimeEventRouterTest.java
+++ b/android/app/src/test/java/io/github/jukomu/runtime/RuntimeEventRouterTest.java
@@ -23,7 +23,7 @@ public class RuntimeEventRouterTest {
         emitAll(router);
 
         assertEquals(1, sinks.downloadCount);
-        assertEquals(1, sinks.preloadCount);
+        assertEquals(2, sinks.preloadCount);
         assertEquals(1, sinks.relocationCount);
         assertSame(callingThread, sinks.lastThread);
     }
@@ -43,7 +43,7 @@ public class RuntimeEventRouterTest {
         assertEquals(0, first.preloadCount);
         assertEquals(0, first.relocationCount);
         assertEquals(1, second.downloadCount);
-        assertEquals(1, second.preloadCount);
+        assertEquals(2, second.preloadCount);
         assertEquals(1, second.relocationCount);
     }
 
@@ -58,7 +58,7 @@ public class RuntimeEventRouterTest {
         emitAll(router);
 
         assertEquals(0, attached.downloadCount);
-        assertEquals(1, attached.preloadCount);
+        assertEquals(2, attached.preloadCount);
         assertEquals(0, attached.relocationCount);
     }
 
@@ -73,6 +73,7 @@ public class RuntimeEventRouterTest {
         router.onDownloadProgress(new DownloadProgressData(
             "task", "album", "chapter", 1, 2, "downloading", null, 3, 4, 5));
         router.onImageReady("photo", 6, "image");
+        router.onImageFailed("photo", 6, "image");
         router.onRelocationProgress(7, 8, "copy", "file");
     }
 
@@ -93,6 +94,12 @@ public class RuntimeEventRouterTest {
 
         @Override
         public void onImageReady(String photoId, int sortOrder, String type) {
+            preloadCount++;
+            lastThread = Thread.currentThread();
+        }
+
+        @Override
+        public void onImageFailed(String photoId, int sortOrder, String type) {
             preloadCount++;
             lastThread = Thread.currentThread();
         }

--- a/src/components/reader/HorizontalPageView.vue
+++ b/src/components/reader/HorizontalPageView.vue
@@ -3,8 +3,33 @@
     <div class="strip" :style="stripStyle">
       <div v-for="idx in visibleIndices" :key="idx" class="page-slot" :style="slotStyle(idx)">
         <div class="page-content" :style="idx === displayIndex ? contentStyle : undefined">
-          <template v-if="imageMap.get(idx + 1)">
-            <img :src="imageMap.get(idx + 1)!" class="page-image" alt="" />
+          <template v-if="failedSortOrders.has(idx + 1)">
+            <div class="image-error-state">
+              <span>图片加载失败</span>
+              <button
+                type="button"
+                class="image-retry-button"
+                :disabled="retryingSortOrders.size > 0"
+                @touchstart.stop
+                @touchend.stop
+                @click.stop="emit('retry-images')"
+              >
+                <IonIcon
+                  :icon="refreshOutline"
+                  :class="{ spinning: retryingSortOrders.has(idx + 1) }"
+                  aria-hidden="true"
+                />
+                <span>{{ retryButtonLabel(idx + 1) }}</span>
+              </button>
+            </div>
+          </template>
+          <template v-else-if="imageMap.get(idx + 1)">
+            <img
+              :src="imageMap.get(idx + 1)!"
+              class="page-image"
+              alt=""
+              @error="emit('image-error', idx + 1, imageMap.get(idx + 1)!)"
+            />
           </template>
           <template v-else>
             <div class="skeleton-page" />
@@ -16,20 +41,38 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { IonIcon } from '@ionic/vue'
+import { refreshOutline } from 'ionicons/icons'
+
 defineOptions({ name: 'HorizontalPageView' })
 
-const props = defineProps<{
-  imageMap: Map<number, string>
-  totalCount: number
-  currentIndex: number
-}>()
+const props = withDefaults(
+  defineProps<{
+    imageMap: Map<number, string>
+    failedSortOrders?: Set<number>
+    retryingSortOrders?: Set<number>
+    totalCount: number
+    currentIndex: number
+  }>(),
+  {
+    failedSortOrders: () => new Set<number>(),
+    retryingSortOrders: () => new Set<number>(),
+  },
+)
 
 const emit = defineEmits<{
   'update:currentIndex': [index: number]
   'toggle-toolbar': []
+  'image-error': [sortOrder: number, failedUrl: string]
+  'retry-images': []
 }>()
 
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+function retryButtonLabel(sortOrder: number) {
+  if (props.retryingSortOrders.has(sortOrder)) return '重试中'
+  if (props.retryingSortOrders.size > 0) return '请稍候'
+  return props.failedSortOrders.size > 1 ? `重试全部（${props.failedSortOrders.size}）` : '重试'
+}
 
 const SWIPE_THRESHOLD = 60
 const ZOOM_MAX = 5
@@ -456,6 +499,53 @@ defineExpose({ scrollToIndex })
   background: linear-gradient(90deg, #222 25%, #3a3a3a 50%, #222 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.image-error-state {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #aaa;
+  font-size: 14px;
+  background: #111;
+}
+
+.image-retry-button {
+  min-width: 96px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: #eee;
+  background: #222;
+  font: inherit;
+}
+
+.image-retry-button:disabled {
+  color: #888;
+  border-color: #444;
+}
+
+.image-retry-button ion-icon {
+  font-size: 18px;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes shimmer {

--- a/src/components/reader/VerticalScrollView.vue
+++ b/src/components/reader/VerticalScrollView.vue
@@ -16,12 +16,31 @@
           :style="item.style"
           :data-index="item.index"
         >
-          <template v-if="item.dataUrl">
+          <template v-if="failedSortOrders.has(item.index + 1)">
+            <div class="image-error-state">
+              <span>图片加载失败</span>
+              <button
+                type="button"
+                class="image-retry-button"
+                :disabled="retryingSortOrders.size > 0"
+                @click.stop="emit('retry-images')"
+              >
+                <IonIcon
+                  :icon="refreshOutline"
+                  :class="{ spinning: retryingSortOrders.has(item.index + 1) }"
+                  aria-hidden="true"
+                />
+                <span>{{ retryButtonLabel(item.index + 1) }}</span>
+              </button>
+            </div>
+          </template>
+          <template v-else-if="item.dataUrl">
             <img
               :src="item.dataUrl"
               class="reader-image"
               alt=""
               @load="onImageLoad(item.index, $event)"
+              @error="emit('image-error', item.index + 1, item.dataUrl)"
             />
           </template>
           <template v-else>
@@ -42,20 +61,38 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { IonIcon } from '@ionic/vue'
+import { refreshOutline } from 'ionicons/icons'
 
 defineOptions({ name: 'VerticalScrollView' })
 
-const props = defineProps<{
-  imageMap: Map<number, string>
-  totalCount: number
-  currentIndex: number
-}>()
+const props = withDefaults(
+  defineProps<{
+    imageMap: Map<number, string>
+    failedSortOrders?: Set<number>
+    retryingSortOrders?: Set<number>
+    totalCount: number
+    currentIndex: number
+  }>(),
+  {
+    failedSortOrders: () => new Set<number>(),
+    retryingSortOrders: () => new Set<number>(),
+  },
+)
 
 const emit = defineEmits<{
   'update:currentIndex': [index: number]
   requestRange: [range: { start: number; end: number; center: number }]
   'reached-bottom': []
+  'image-error': [sortOrder: number, failedUrl: string]
+  'retry-images': []
 }>()
+
+function retryButtonLabel(sortOrder: number) {
+  if (props.retryingSortOrders.has(sortOrder)) return '重试中'
+  if (props.retryingSortOrders.size > 0) return '请稍候'
+  return props.failedSortOrders.size > 1 ? `重试全部（${props.failedSortOrders.size}）` : '重试'
+}
 
 interface VisibleItem {
   index: number
@@ -706,6 +743,55 @@ defineExpose({ scrollToIndex, containerRef, isAtBottom })
   background: linear-gradient(90deg, #222 25%, #3a3a3a 50%, #222 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.image-error-state {
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #aaa;
+  font-size: 14px;
+  line-height: normal;
+  background: #111;
+}
+
+.image-retry-button {
+  min-width: 96px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: #eee;
+  background: #222;
+  font: inherit;
+}
+
+.image-retry-button:disabled {
+  color: #888;
+  border-color: #444;
+}
+
+.image-retry-button ion-icon {
+  font-size: 18px;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes shimmer {

--- a/src/services/jmcomic/JmcomicClient.ts
+++ b/src/services/jmcomic/JmcomicClient.ts
@@ -45,6 +45,8 @@ export interface ImageReadyEvent {
   type: string
 }
 
+export type ImageFailedEvent = ImageReadyEvent
+
 export interface JmcomicListenerHandle {
   remove: () => Promise<void>
 }
@@ -79,6 +81,8 @@ export interface JmcomicClient {
     type: string
     replacePending?: boolean
   }): Promise<PreloadResult>
+
+  retryImage(options: { photoId: string; image: ImageInfo }): Promise<{ success: boolean }>
 
   setCacheCapacity(options: { mb: number }): Promise<CacheCapacityInfo & { success: boolean }>
 
@@ -129,6 +133,11 @@ export interface JmcomicClient {
   addListener(
     event: 'imageReady',
     handler: (data: ImageReadyEvent) => void,
+  ): Promise<JmcomicListenerHandle>
+
+  addListener(
+    event: 'imageFailed',
+    handler: (data: ImageFailedEvent) => void,
   ): Promise<JmcomicListenerHandle>
 
   addListener(

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -13,7 +13,12 @@ import type {
   SearchQuery,
   SearchResultItem,
 } from '../JmcomicTypes'
-import type { ImageReadyEvent, JmcomicClient, JmcomicListenerHandle } from './JmcomicClient'
+import type {
+  ImageFailedEvent,
+  ImageReadyEvent,
+  JmcomicClient,
+  JmcomicListenerHandle,
+} from './JmcomicClient'
 import { jmcomicNativeClient } from './JmcomicNativeClient'
 
 const native: JmcomicClient = jmcomicNativeClient
@@ -134,6 +139,11 @@ export const JmcomicService = {
     return native.preloadImages({ photoId, images, type, replacePending: options.replacePending })
   },
 
+  /** 使用最新图片元数据绕过本地来源和旧缓存重试单页。 */
+  retryImage(photoId: string, image: ImageInfo) {
+    return native.retryImage({ photoId, image })
+  },
+
   /** 设置图片缓存容量（MB），供设置页调用 */
   setCacheCapacity(mb: number) {
     return native.setCacheCapacity({ mb })
@@ -206,6 +216,19 @@ export const JmcomicService = {
     options: { type?: 'image' | 'thumb' } = {},
   ): Promise<JmcomicListenerHandle> {
     return native.addListener('imageReady', (data: ImageReadyEvent) => {
+      if (data.photoId === photoId && (!options.type || data.type === options.type)) {
+        handler(data.sortOrder)
+      }
+    })
+  },
+
+  /** 注册图片预载失败监听。 */
+  addImageFailedListener(
+    photoId: string,
+    handler: (sortOrder: number) => void,
+    options: { type?: 'image' | 'thumb' } = {},
+  ): Promise<JmcomicListenerHandle> {
+    return native.addListener('imageFailed', (data: ImageFailedEvent) => {
       if (data.photoId === photoId && (!options.type || data.type === options.type)) {
         handler(data.sortOrder)
       }

--- a/src/views/ReaderPage.vue
+++ b/src/views/ReaderPage.vue
@@ -11,20 +11,28 @@
         v-if="isVertical"
         ref="verticalViewRef"
         :image-map="imageMap"
+        :failed-sort-orders="failedSortOrders"
+        :retrying-sort-orders="retryingSortOrders"
         :total-count="totalCount"
         :current-index="currentIndex"
         @update:current-index="onPageChange"
         @request-range="onVerticalRequestRange"
         @reached-bottom="scheduleToolbarAtReaderEnd"
+        @image-error="onImageError"
+        @retry-images="retryFailedImages"
       />
       <HorizontalPageView
         v-else
         ref="horizontalViewRef"
         :image-map="imageMap"
+        :failed-sort-orders="failedSortOrders"
+        :retrying-sort-orders="retryingSortOrders"
         :total-count="totalCount"
         :current-index="currentIndex"
         @update:current-index="onPageChange"
         @toggle-toolbar="toggleToolbar"
+        @image-error="onImageError"
+        @retry-images="retryFailedImages"
       />
 
       <!-- 底部工具栏 -->
@@ -111,6 +119,8 @@ const isVertical = ref(SettingsStore.getReaderDisplayMode() === 'vertical')
 const currentIndex = ref(0)
 const totalCount = ref(0)
 const imageMap = shallowRef<Map<number, string>>(new Map())
+const failedSortOrders = shallowRef<Set<number>>(new Set())
+const retryingSortOrders = shallowRef<Set<number>>(new Set())
 const chapters = ref<PhotoMeta[]>([])
 const toolbarVisible = ref(true)
 const isDragProgress = ref(false)
@@ -128,6 +138,7 @@ let chapterLoadVersion = 0
 let chapterStateKey = ''
 let chapterStateAlbumId = ''
 let imageReadyListenerHandle: PluginListenerHandle | null = null
+let imageFailedListenerHandle: PluginListenerHandle | null = null
 let imageReadyListenerSetupPromise: Promise<void> | null = null
 let imageReadyListenerSetupId = 0
 let volumeKeyListenerHandle: PluginListenerHandle | null = null
@@ -136,6 +147,9 @@ let loadedSortOrders = new Set<number>()
 let requestedSortOrders = new Map<number, number>()
 let preloadRequestSequence = 0
 let sortOrderToImage = new Map<number, ImageInfo>()
+let retryBatchSequence = 0
+let activeRetryBatchId: number | null = null
+let retryUrlRevision = 0
 let activeAllowedSortOrders = new Set<number>()
 let activeDragPreviewSortOrder: number | null = null
 let lastWindowCenter = -1
@@ -386,6 +400,28 @@ const applyImageMap = () => {
   imageMap.value = new Map(imageMap.value)
 }
 
+const setFailedSortOrder = (sortOrder: number, failed: boolean) => {
+  const next = new Set(failedSortOrders.value)
+  if (failed) next.add(sortOrder)
+  else next.delete(sortOrder)
+  failedSortOrders.value = next
+}
+
+const onImageError = (sortOrder: number, failedUrl: string) => {
+  if (
+    !photoDetail ||
+    sortOrder < 1 ||
+    sortOrder > totalCount.value ||
+    imageMap.value.get(sortOrder) !== failedUrl
+  )
+    return
+
+  imageMap.value.delete(sortOrder)
+  loadedSortOrders.delete(sortOrder)
+  setFailedSortOrder(sortOrder, true)
+  applyImageMap()
+}
+
 interface ImageExposureContext {
   version: number
   albumId: string
@@ -408,6 +444,95 @@ const isCurrentImageExposureContext = (context: ImageExposureContext) =>
   context.albumId === albumId.value &&
   context.chapterId === chapterId.value &&
   context.photoId === photoDetail?.id
+
+const retryFailedImages = () => {
+  const context = createImageExposureContext()
+  if (!context || activeRetryBatchId !== null || failedSortOrders.value.size === 0) return
+
+  const failedSnapshot = [...failedSortOrders.value].filter(
+    (sortOrder) => sortOrder >= 1 && sortOrder <= totalCount.value,
+  )
+  if (failedSnapshot.length === 0) return
+
+  const batchId = ++retryBatchSequence
+  activeRetryBatchId = batchId
+  retryingSortOrders.value = new Set(failedSnapshot)
+
+  void (async () => {
+    let failedCount = failedSnapshot.length
+    try {
+      const latestPhoto = await JmcomicService.getPhoto(context.chapterId)
+      if (
+        activeRetryBatchId !== batchId ||
+        !isCurrentImageExposureContext(context) ||
+        latestPhoto.id !== context.photoId
+      )
+        return
+
+      const latestImages = new Map<number, ImageInfo>()
+      const duplicateSortOrders = new Set<number>()
+      for (const image of latestPhoto.images) {
+        if (latestImages.has(image.sortOrder)) duplicateSortOrders.add(image.sortOrder)
+        latestImages.set(image.sortOrder, image)
+      }
+
+      const results = await Promise.all(
+        failedSnapshot.map(async (sortOrder) => {
+          const image = latestImages.get(sortOrder)
+          if (!image || duplicateSortOrders.has(sortOrder)) {
+            return { sortOrder, image: null, success: false }
+          }
+          try {
+            await JmcomicService.retryImage(context.photoId, image)
+            return { sortOrder, image, success: true }
+          } catch {
+            return { sortOrder, image, success: false }
+          }
+        }),
+      )
+      if (activeRetryBatchId !== batchId || !isCurrentImageExposureContext(context)) return
+
+      failedCount = 0
+      const nextFailed = new Set(failedSortOrders.value)
+      retryUrlRevision = Math.max(Date.now(), retryUrlRevision + 1)
+      for (const result of results) {
+        if (!result.success) {
+          failedCount++
+          continue
+        }
+
+        nextFailed.delete(result.sortOrder)
+        sortOrderToImage.set(result.sortOrder, result.image!)
+        requestedSortOrders.delete(result.sortOrder)
+        if (activeAllowedSortOrders.has(result.sortOrder)) {
+          imageMap.value.set(
+            result.sortOrder,
+            `${getImageUrl(context.photoId, result.sortOrder, 'image')}?retry=${retryUrlRevision}`,
+          )
+          loadedSortOrders.add(result.sortOrder)
+        }
+      }
+      failedSortOrders.value = nextFailed
+      applyImageMap()
+    } catch {
+      if (activeRetryBatchId !== batchId || !isCurrentImageExposureContext(context)) return
+    } finally {
+      if (activeRetryBatchId === batchId) {
+        activeRetryBatchId = null
+        if (isCurrentImageExposureContext(context)) {
+          retryingSortOrders.value = new Set()
+          if (failedCount > 0) {
+            const message =
+              failedCount === failedSnapshot.length
+                ? '图片重试失败，请检查网络后重试'
+                : `${failedCount} 张图片重试失败`
+            void showToast(message, 'danger')
+          }
+        }
+      }
+    }
+  })()
+}
 
 const exposeImageIfAllowed = (
   context: ImageExposureContext,
@@ -438,6 +563,22 @@ const exposeImagesIfAllowed = (
   if (changed) applyImageMap()
 }
 
+const onPreloadImageReady = (context: ImageExposureContext, sortOrder: number) => {
+  if (!isCurrentImageExposureContext(context)) return
+  if (failedSortOrders.value.has(sortOrder)) setFailedSortOrder(sortOrder, false)
+  exposeImagesIfAllowed(context, [sortOrder], 'image')
+}
+
+const onPreloadImageFailed = (context: ImageExposureContext, sortOrder: number) => {
+  if (!isCurrentImageExposureContext(context) || sortOrder < 1 || sortOrder > totalCount.value)
+    return
+
+  imageMap.value.delete(sortOrder)
+  loadedSortOrders.delete(sortOrder)
+  if (!failedSortOrders.value.has(sortOrder)) setFailedSortOrder(sortOrder, true)
+  applyImageMap()
+}
+
 const setActiveAllowedSortOrders = (
   sortOrders: Iterable<number>,
   dragPreviewSortOrder: number | null,
@@ -456,7 +597,8 @@ const cleanupRequestedSortOrdersOutsideAllowed = () => {
 
 const preloadSortOrders = (sortOrders: number[], replacePending = false) => {
   const context = createImageExposureContext()
-  if (!context || !readerRuntimeActive || !imageReadyListenerHandle) return
+  if (!context || !readerRuntimeActive || !imageReadyListenerHandle || !imageFailedListenerHandle)
+    return
 
   const images: ImageInfo[] = []
   for (const sortOrder of new Set(sortOrders)) {
@@ -682,27 +824,49 @@ const removeListenerSafely = (handle: PluginListenerHandle | null) => {
 }
 
 const setupImageReadyListener = async () => {
-  if (imageReadyListenerHandle) return
+  if (imageReadyListenerHandle && imageFailedListenerHandle) return
   if (imageReadyListenerSetupPromise) return imageReadyListenerSetupPromise
   const context = createImageExposureContext()
   if (!readerRuntimeActive || !context) return
 
   const setupId = ++imageReadyListenerSetupId
   const setupPromise = (async () => {
-    const handle = await JmcomicService.addImageReadyListener(
-      context.photoId,
-      (sortOrder) => exposeImagesIfAllowed(context, [sortOrder], 'image'),
-      { type: 'image' },
-    )
-    if (
-      setupId !== imageReadyListenerSetupId ||
-      !readerRuntimeActive ||
-      !isCurrentImageExposureContext(context)
-    ) {
-      removeListenerSafely(handle)
-      return
+    let readyHandle: PluginListenerHandle | null = null
+    let failedHandle: PluginListenerHandle | null = null
+    const isCurrentSetup = () =>
+      setupId === imageReadyListenerSetupId &&
+      readerRuntimeActive &&
+      isCurrentImageExposureContext(context)
+
+    try {
+      readyHandle = await JmcomicService.addImageReadyListener(
+        context.photoId,
+        (sortOrder) => onPreloadImageReady(context, sortOrder),
+        { type: 'image' },
+      )
+      if (!isCurrentSetup()) {
+        removeListenerSafely(readyHandle)
+        return
+      }
+
+      failedHandle = await JmcomicService.addImageFailedListener(
+        context.photoId,
+        (sortOrder) => onPreloadImageFailed(context, sortOrder),
+        { type: 'image' },
+      )
+      if (!isCurrentSetup()) {
+        removeListenerSafely(readyHandle)
+        removeListenerSafely(failedHandle)
+        return
+      }
+
+      imageReadyListenerHandle = readyHandle
+      imageFailedListenerHandle = failedHandle
+    } catch (error) {
+      removeListenerSafely(readyHandle)
+      removeListenerSafely(failedHandle)
+      throw error
     }
-    imageReadyListenerHandle = handle
   })()
   imageReadyListenerSetupPromise = setupPromise
   try {
@@ -733,6 +897,8 @@ const deactivateReaderRuntime = () => {
   clearToolbarTapTimer()
   removeListenerSafely(imageReadyListenerHandle)
   imageReadyListenerHandle = null
+  removeListenerSafely(imageFailedListenerHandle)
+  imageFailedListenerHandle = null
   removeListenerSafely(volumeKeyListenerHandle)
   volumeKeyListenerHandle = null
   restoreSystemState()
@@ -890,16 +1056,22 @@ const resetChapterState = () => {
   clearAutoShowToolbarTimer()
   removeListenerSafely(imageReadyListenerHandle)
   imageReadyListenerHandle = null
+  removeListenerSafely(imageFailedListenerHandle)
+  imageFailedListenerHandle = null
   photoDetail = null
   currentIndex.value = 0
   totalCount.value = 0
   imageMap.value = new Map()
+  failedSortOrders.value = new Set()
+  retryingSortOrders.value = new Set()
   isOffline.value = route.query.source === 'download'
   isDragProgress.value = false
   settingsPanelVisible.value = false
   loadedSortOrders = new Set()
   requestedSortOrders = new Map()
   sortOrderToImage = new Map()
+  retryBatchSequence++
+  activeRetryBatchId = null
   activeAllowedSortOrders = new Set()
   activeDragPreviewSortOrder = null
   lastWindowCenter = -1

--- a/tests/unit/HorizontalPageView.test.ts
+++ b/tests/unit/HorizontalPageView.test.ts
@@ -96,4 +96,33 @@ describe('HorizontalPageView', () => {
     expect(wrapper.emitted('update:currentIndex')).toEqual([[0], [1]])
     wrapper.unmount()
   })
+
+  test('图片错误上报原 URL，多个失败页显示聚合重试', async () => {
+    const wrapper = mount(HorizontalPageView, {
+      props: {
+        imageMap: new Map([
+          [1, 'image-1'],
+          [2, 'image-2'],
+        ]),
+        failedSortOrders: new Set<number>(),
+        retryingSortOrders: new Set<number>(),
+        totalCount: 2,
+        currentIndex: 0,
+      },
+    })
+
+    await wrapper.get('.page-image').trigger('error')
+    expect(wrapper.emitted('image-error')).toEqual([[1, 'image-1']])
+
+    await wrapper.setProps({failedSortOrders: new Set([1, 2])})
+    const retryButton = wrapper.get('button')
+    expect(retryButton.text()).toContain('重试全部（2）')
+    await retryButton.trigger('click')
+    expect(wrapper.emitted('retry-images')).toEqual([[]])
+
+    await wrapper.setProps({retryingSortOrders: new Set([1, 2])})
+    expect(wrapper.get('button').attributes()).toHaveProperty('disabled')
+    expect(wrapper.get('button').text()).toContain('重试中')
+    wrapper.unmount()
+  })
 })

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   addListener: vi.fn(),
+  retryImage: vi.fn(),
 }))
 
 vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
   jmcomicNativeClient: {
     addListener: mocks.addListener,
+    retryImage: mocks.retryImage,
   },
 }))
 
@@ -47,5 +49,46 @@ describe('JmcomicService.addImageReadyListener', () => {
     imageReadyHandler?.({ photoId: 'chapter-1', sortOrder: 2, type: 'image' })
 
     expect(handler.mock.calls).toEqual([[1], [2]])
+  })
+})
+
+describe('JmcomicService.addImageFailedListener', () => {
+  test('只转发当前章节指定类型的失败事件', async () => {
+    let imageFailedHandler: ((event: ImageReadyEvent) => void) | null = null
+    mocks.addListener.mockReset()
+    mocks.addListener.mockImplementation(
+      (_event: string, handler: (event: ImageReadyEvent) => void) => {
+        imageFailedHandler = handler
+        return Promise.resolve({ remove: vi.fn(() => Promise.resolve()) })
+      },
+    )
+    const handler = vi.fn()
+
+    await JmcomicService.addImageFailedListener('chapter-1', handler, { type: 'image' })
+
+    imageFailedHandler?.({ photoId: 'chapter-1', sortOrder: 1, type: 'thumb' })
+    imageFailedHandler?.({ photoId: 'chapter-2', sortOrder: 2, type: 'image' })
+    imageFailedHandler?.({ photoId: 'chapter-1', sortOrder: 3, type: 'image' })
+
+    expect(mocks.addListener).toHaveBeenCalledWith('imageFailed', expect.any(Function))
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(3)
+  })
+})
+
+describe('JmcomicService.retryImage', () => {
+  test('转发最新图片元数据', async () => {
+    const image = {
+      photoId: 'chapter-1',
+      scrambleId: '0',
+      filename: '1.jpg',
+      url: 'https://latest.example.com/1.jpg',
+      queryParams: '',
+      sortOrder: 1,
+    }
+    mocks.retryImage.mockResolvedValueOnce({ success: true })
+
+    await expect(JmcomicService.retryImage('chapter-1', image)).resolves.toEqual({ success: true })
+    expect(mocks.retryImage).toHaveBeenCalledWith({ photoId: 'chapter-1', image })
   })
 })

--- a/tests/unit/ReaderPage.test.ts
+++ b/tests/unit/ReaderPage.test.ts
@@ -15,9 +15,13 @@ const mocks = vi.hoisted(() => ({
   getPhoto: vi.fn(),
   getAlbum: vi.fn(),
   preloadImages: vi.fn(),
+  retryImage: vi.fn(),
+  showToast: vi.fn(() => Promise.resolve()),
   addImageReadyListener: vi.fn(),
+  addImageFailedListener: vi.fn(),
   addVolumeKeyListener: vi.fn(),
   imageReadyHandler: null as null | ((sortOrder: number) => void),
+  imageFailedHandler: null as null | ((sortOrder: number) => void),
   listenerRemove: vi.fn(() => Promise.resolve()),
   getImageUrl: vi.fn(
     (photoId: string, sortOrder: number, type: string) =>
@@ -55,13 +59,15 @@ vi.mock('@ionic/vue', async () => {
 
 vi.mock('@/services/JmcomicService', () => ({
   getImageUrl: mocks.getImageUrl,
-  showToast: vi.fn(() => Promise.resolve()),
+  showToast: mocks.showToast,
   JmcomicService: {
     getDownloadedPhoto: mocks.getDownloadedPhoto,
     getPhoto: mocks.getPhoto,
     getAlbum: mocks.getAlbum,
     preloadImages: mocks.preloadImages,
+    retryImage: mocks.retryImage,
     addImageReadyListener: mocks.addImageReadyListener,
+    addImageFailedListener: mocks.addImageFailedListener,
     addVolumeKeyListener: mocks.addVolumeKeyListener,
     setReaderBrightness: vi.fn(() => Promise.resolve()),
     setReaderScreenOrientation: vi.fn(() => Promise.resolve()),
@@ -99,10 +105,12 @@ const VerticalScrollViewStub = defineComponent({
   name: 'VerticalScrollView',
   props: {
     imageMap: { type: Object as PropType<Map<number, string>>, required: true },
+    failedSortOrders: { type: Object as PropType<Set<number>>, required: true },
+    retryingSortOrders: { type: Object as PropType<Set<number>>, required: true },
     totalCount: { type: Number, required: true },
     currentIndex: { type: Number, required: true },
   },
-  emits: ['update:current-index', 'request-range', 'reached-bottom'],
+  emits: ['update:current-index', 'request-range', 'reached-bottom', 'image-error', 'retry-images'],
   setup(_, { expose }) {
     expose({
       scrollToIndex: vi.fn(),
@@ -116,10 +124,12 @@ const HorizontalPageViewStub = defineComponent({
   name: 'HorizontalPageView',
   props: {
     imageMap: { type: Object as PropType<Map<number, string>>, required: true },
+    failedSortOrders: { type: Object as PropType<Set<number>>, required: true },
+    retryingSortOrders: { type: Object as PropType<Set<number>>, required: true },
     totalCount: { type: Number, required: true },
     currentIndex: { type: Number, required: true },
   },
-  emits: ['update:current-index', 'toggle-toolbar'],
+  emits: ['update:current-index', 'toggle-toolbar', 'image-error', 'retry-images'],
   setup(_, { expose }) {
     expose({ scrollToIndex: vi.fn() })
     return () => h('div')
@@ -210,13 +220,21 @@ describe('ReaderPage 在线/离线统一图片加载', () => {
     vi.clearAllMocks()
     mocks.setRouteSource?.('download')
     mocks.imageReadyHandler = null
+    mocks.imageFailedHandler = null
     mocks.getDownloadedPhoto.mockResolvedValue(makePhoto())
     mocks.getPhoto.mockResolvedValue(makePhoto())
     mocks.getAlbum.mockRejectedValue(new Error('skip history metadata'))
     mocks.preloadImages.mockResolvedValue({ cached: [], pending: [] } satisfies PreloadResult)
+    mocks.retryImage.mockResolvedValue({ success: true })
     mocks.addImageReadyListener.mockImplementation(
       (_photoId: string, handler: (sortOrder: number) => void) => {
         mocks.imageReadyHandler = handler
+        return Promise.resolve({ remove: mocks.listenerRemove })
+      },
+    )
+    mocks.addImageFailedListener.mockImplementation(
+      (_photoId: string, handler: (sortOrder: number) => void) => {
+        mocks.imageFailedHandler = handler
         return Promise.resolve({ remove: mocks.listenerRemove })
       },
     )
@@ -420,6 +438,85 @@ describe('ReaderPage 在线/离线统一图片加载', () => {
 
     expect(currentImageMap(wrapper).has(2)).toBe(false)
 
+    wrapper.unmount()
+  })
+
+  test('纯在线章节一次重试当前全部失败图片并保留部分失败状态', async () => {
+    mocks.setRouteSource?.()
+    mocks.getDownloadedPhoto.mockRejectedValue(new Error('not downloaded'))
+    const initialPhoto = makePhoto(2)
+    const latestPhoto = makePhoto(2)
+    latestPhoto.images[0].url = 'https://latest.example.com/1.jpg'
+    latestPhoto.images[1].url = 'https://latest.example.com/2.jpg'
+    mocks.getPhoto.mockResolvedValueOnce(initialPhoto).mockResolvedValueOnce(latestPhoto)
+    mocks.preloadImages.mockResolvedValue({ cached: [1, 2], pending: [] } satisfies PreloadResult)
+    mocks.retryImage
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('retry failed'))
+
+    const wrapper = mountReader()
+    await settle()
+    const view = wrapper.findComponent(VerticalScrollViewStub)
+    const firstUrl = currentImageMap(wrapper).get(1)!
+    const secondUrl = currentImageMap(wrapper).get(2)!
+
+    view.vm.$emit('image-error', 1, firstUrl)
+    view.vm.$emit('image-error', 2, secondUrl)
+    await nextTick()
+    expect(view.props('failedSortOrders')).toEqual(new Set([1, 2]))
+
+    view.vm.$emit('retry-images')
+    await settle()
+
+    expect(mocks.getPhoto).toHaveBeenCalledTimes(2)
+    expect(mocks.getPhoto).toHaveBeenLastCalledWith('chapter-1')
+    expect(mocks.retryImage.mock.calls).toEqual([
+      ['chapter-1', expect.objectContaining({ sortOrder: 1, url: latestPhoto.images[0].url })],
+      ['chapter-1', expect.objectContaining({ sortOrder: 2, url: latestPhoto.images[1].url })],
+    ])
+    expect(currentImageMap(wrapper).get(1)).toContain('?retry=')
+    expect(currentImageMap(wrapper).has(2)).toBe(false)
+    expect(view.props('failedSortOrders')).toEqual(new Set([2]))
+    expect(mocks.showToast).toHaveBeenCalledWith('1 张图片重试失败', 'danger')
+
+    wrapper.unmount()
+  })
+
+  test('普通预载网络失败进入同一失败集合并可直接批量重试', async () => {
+    mocks.preloadImages.mockResolvedValue({ cached: [], pending: [1, 2] } satisfies PreloadResult)
+    const wrapper = mountReader()
+    await settle()
+
+    mocks.imageFailedHandler?.(1)
+    mocks.imageFailedHandler?.(2)
+    await nextTick()
+
+    const view = wrapper.findComponent(VerticalScrollViewStub)
+    expect(view.props('failedSortOrders')).toEqual(new Set([1, 2]))
+
+    view.vm.$emit('retry-images')
+    await settle()
+
+    expect(mocks.getPhoto).toHaveBeenCalledWith('chapter-1')
+    expect(mocks.retryImage.mock.calls).toEqual([
+      ['chapter-1', expect.objectContaining({ sortOrder: 1 })],
+      ['chapter-1', expect.objectContaining({ sortOrder: 2 })],
+    ])
+    expect(view.props('failedSortOrders')).toEqual(new Set())
+    wrapper.unmount()
+  })
+
+  test('旧图片 URL 晚到的错误事件不会覆盖当前图片', async () => {
+    mocks.preloadImages.mockResolvedValue({ cached: [1], pending: [] } satisfies PreloadResult)
+    const wrapper = mountReader()
+    await settle()
+
+    const view = wrapper.findComponent(VerticalScrollViewStub)
+    view.vm.$emit('image-error', 1, 'jqviewer.local/chapter-1/image/stale')
+    await nextTick()
+
+    expect(currentImageMap(wrapper).has(1)).toBe(true)
+    expect(view.props('failedSortOrders')).toEqual(new Set())
     wrapper.unmount()
   })
 })

--- a/tests/unit/VerticalScrollView.test.ts
+++ b/tests/unit/VerticalScrollView.test.ts
@@ -159,4 +159,26 @@ describe('VerticalScrollView', () => {
 
     wrapper.unmount()
   })
+
+  test('失败图片保持槽位并触发聚合重试', async () => {
+    const wrapper = mount(VerticalScrollView, {
+      props: {
+        imageMap: new Map([[1, 'image-1']]),
+        failedSortOrders: new Set<number>(),
+        retryingSortOrders: new Set<number>(),
+        totalCount: 1,
+        currentIndex: 0,
+      },
+    })
+    await flushAnimationFrames()
+
+    await wrapper.get('.reader-image').trigger('error')
+    expect(wrapper.emitted('image-error')).toEqual([[1, 'image-1']])
+
+    await wrapper.setProps({failedSortOrders: new Set([1])})
+    expect(wrapper.get('.image-error-state').text()).toContain('图片加载失败')
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.emitted('retry-images')).toEqual([[]])
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
- 快速校验本地图片，无效时回退网络加载
- 统一处理预载失败与 WebView 解码失败
- 使用最新章节元数据批量重试所有失败图片
- 绕过旧缓存并支持部分失败状态保留

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 阅读器新增图片加载失败提示及单张、批量重试功能。
  - 重试时自动获取最新图片信息，并更新成功的图片内容。
  - 新增图片加载失败事件通知，支持按图片类型和章节监听。

- **错误修复**
  - 优化无效图片缓存、网络加载失败及重试失败时的处理，避免显示错误内容。

- **测试**
  - 补充图片校验、缓存回退、失败通知、批量重试及阅读器交互测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->