### PR TITLE
ci: 将 release 任务迁移到 self-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
   release:
     needs: [validate-release-input, frontend, android-jvm, instrumentation]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, jqviewer-release]
     permissions:
       contents: write
 
@@ -422,3 +422,13 @@ jobs:
           fi
 
           echo "Public release assets verified: identical APK and latest.json"
+
+      - name: Cleanup release secrets and artifacts
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          rm -f android/app/release.keystore
+          rm -f android/keystore.properties
+          rm -f android/app/build/outputs/apk/release/app-release.apk
+          rm -f JQ-Viewer-*.apk
+          rm -f "$RUNNER_TEMP/latest.json"


### PR DESCRIPTION
- release job 改用 JQViewer-WSL runner
- 发布结束后清理签名文件和构建产物

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化发布流程的运行环境，提升发布任务的稳定性。
  * 新增发布后的自动清理机制，及时移除临时构建文件和敏感配置，增强安全性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->