### PR TITLE
[codex] ASTRA-5: add collapsible history date groups

### DIFF
--- a/src/utils/historyDateGroups.ts
+++ b/src/utils/historyDateGroups.ts
@@ -69,6 +69,8 @@ function getGroupKey(
   timestamp: number,
   boundaries: readonly BrowseGroupBoundary[],
 ): BrowseGroupKey {
+  if (!Number.isFinite(timestamp)) return 'earlier'
+
   for (const boundary of boundaries) {
     if (timestamp >= boundary.startMs) return boundary.key
   }

--- a/src/utils/historyDateGroups.ts
+++ b/src/utils/historyDateGroups.ts
@@ -1,0 +1,96 @@
+import type { BrowseHistoryItem } from '@/services/JmcomicTypes'
+
+export type BrowseGroupKey =
+  | 'today'
+  | 'yesterday'
+  | 'thisWeek'
+  | 'thisMonth'
+  | 'lastThreeMonths'
+  | 'lastSixMonths'
+  | 'thisYear'
+  | 'earlier'
+
+export interface BrowseHistoryGroup {
+  key: BrowseGroupKey
+  label: string
+  items: BrowseHistoryItem[]
+}
+
+export const BROWSE_GROUP_DEFINITIONS = [
+  { key: 'today', label: '今天' },
+  { key: 'yesterday', label: '昨天' },
+  { key: 'thisWeek', label: '本周' },
+  { key: 'thisMonth', label: '本月' },
+  { key: 'lastThreeMonths', label: '3个月内' },
+  { key: 'lastSixMonths', label: '6个月内' },
+  { key: 'thisYear', label: '今年' },
+  { key: 'earlier', label: '更早' },
+] as const satisfies ReadonlyArray<{ key: BrowseGroupKey; label: string }>
+
+interface BrowseGroupBoundary {
+  key: Exclude<BrowseGroupKey, 'earlier'>
+  startMs: number
+}
+
+function startOfLocalDay(year: number, month: number, date: number): number {
+  return new Date(year, month, date).getTime()
+}
+
+function startOfRollingMonth(reference: Date, monthsAgo: number): number {
+  const monthStart = new Date(reference.getFullYear(), reference.getMonth() - monthsAgo, 1)
+  const lastDay = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 0).getDate()
+  const date = Math.min(reference.getDate(), lastDay)
+  return startOfLocalDay(monthStart.getFullYear(), monthStart.getMonth(), date)
+}
+
+function buildBoundaries(nowMs: number): BrowseGroupBoundary[] {
+  const reference = new Date(nowMs)
+  const year = reference.getFullYear()
+  const month = reference.getMonth()
+  const date = reference.getDate()
+  const todayStart = startOfLocalDay(year, month, date)
+  const daysSinceMonday = (reference.getDay() + 6) % 7
+
+  return [
+    { key: 'today', startMs: todayStart },
+    { key: 'yesterday', startMs: startOfLocalDay(year, month, date - 1) },
+    {
+      key: 'thisWeek',
+      startMs: startOfLocalDay(year, month, date - daysSinceMonday),
+    },
+    { key: 'thisMonth', startMs: startOfLocalDay(year, month, 1) },
+    { key: 'lastThreeMonths', startMs: startOfRollingMonth(reference, 3) },
+    { key: 'lastSixMonths', startMs: startOfRollingMonth(reference, 6) },
+    { key: 'thisYear', startMs: startOfLocalDay(year, 0, 1) },
+  ]
+}
+
+function getGroupKey(
+  timestamp: number,
+  boundaries: readonly BrowseGroupBoundary[],
+): BrowseGroupKey {
+  for (const boundary of boundaries) {
+    if (timestamp >= boundary.startMs) return boundary.key
+  }
+  return 'earlier'
+}
+
+export function groupBrowseHistory(
+  items: readonly BrowseHistoryItem[],
+  nowMs: number = Date.now(),
+): BrowseHistoryGroup[] {
+  const boundaries = buildBoundaries(nowMs)
+  const itemsByKey = new Map<BrowseGroupKey, BrowseHistoryItem[]>()
+
+  for (const item of items) {
+    const key = getGroupKey(item.timestamp, boundaries)
+    const groupItems = itemsByKey.get(key)
+    if (groupItems) groupItems.push(item)
+    else itemsByKey.set(key, [item])
+  }
+
+  return BROWSE_GROUP_DEFINITIONS.flatMap(({ key, label }) => {
+    const groupItems = itemsByKey.get(key)
+    return groupItems ? [{ key, label, items: groupItems }] : []
+  })
+}

--- a/src/views/HistoryPage.vue
+++ b/src/views/HistoryPage.vue
@@ -36,41 +36,73 @@
           <template v-else>
             <div class="section-header">
               <span class="section-title">共 {{ browseItems.length }} 条记录</span>
-              <button class="clear-btn" @click="confirmClearBrowse">清空</button>
+              <button type="button" class="clear-btn" @click="confirmClearBrowse">清空</button>
             </div>
             <TransitionGroup name="history-list" tag="div" class="card-list">
-              <template v-for="group in browseGroups" :key="group.label">
-                <div class="date-group-header">{{ group.label }}</div>
-                <div
-                  v-for="item in group.items"
-                  :key="item.timestamp"
-                  class="browse-card"
-                  @click="openAlbum(item)"
-                >
-                  <div class="card-cover-wrap">
-                    <img :src="item.coverUrl" class="card-cover" alt="" loading="lazy" />
-                  </div>
-                  <div class="card-body">
-                    <h3 class="card-title">{{ item.albumTitle }}</h3>
-                    <div class="card-id">ID: {{ item.albumId }}</div>
-                    <div class="card-meta">作者：{{ item.authors }}</div>
-                    <div class="card-meta">{{ formatRelativeTime(item.timestamp) }}</div>
-                    <div v-if="item.chapterTitle" class="card-chapter">
-                      <IonIcon :icon="bookOutline" class="chapter-icon" />
-                      <span>{{ item.chapterTitle }}</span>
+              <section v-for="group in browseGroups" :key="group.key" class="date-group">
+                <h2 class="date-group-heading">
+                  <button
+                    :id="browseGroupToggleId(group.key)"
+                    type="button"
+                    class="date-group-toggle"
+                    :aria-expanded="!isBrowseGroupCollapsed(group.key)"
+                    :aria-controls="browseGroupContentId(group.key)"
+                    :aria-label="`${isBrowseGroupCollapsed(group.key) ? '展开' : '收起'}${group.label}`"
+                    @click="toggleBrowseGroup(group.key)"
+                  >
+                    <span>{{ group.label }}</span>
+                    <IonIcon
+                      class="date-group-toggle-icon"
+                      :class="{ collapsed: isBrowseGroupCollapsed(group.key) }"
+                      :icon="chevronDownOutline"
+                      aria-hidden="true"
+                    />
+                  </button>
+                </h2>
+                <Transition name="history-drawer">
+                  <div
+                    v-if="!isBrowseGroupCollapsed(group.key)"
+                    :id="browseGroupContentId(group.key)"
+                    class="date-group-content"
+                    role="region"
+                    :aria-labelledby="browseGroupToggleId(group.key)"
+                  >
+                    <div class="date-group-content-inner">
+                      <TransitionGroup name="history-list" tag="div" class="date-group-cards">
+                        <div
+                          v-for="item in group.items"
+                          :key="item.id"
+                          class="browse-card"
+                          @click="openAlbum(item)"
+                        >
+                          <div class="card-cover-wrap">
+                            <img :src="item.coverUrl" class="card-cover" alt="" loading="lazy" />
+                          </div>
+                          <div class="card-body">
+                            <h3 class="card-title">{{ item.albumTitle }}</h3>
+                            <div class="card-id">ID: {{ item.albumId }}</div>
+                            <div class="card-meta">作者：{{ item.authors }}</div>
+                            <div class="card-meta">{{ formatRelativeTime(item.timestamp) }}</div>
+                            <div v-if="item.chapterTitle" class="card-chapter">
+                              <IonIcon :icon="bookOutline" class="chapter-icon" />
+                              <span>{{ item.chapterTitle }}</span>
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            class="card-more-btn"
+                            :class="{ active: contextMenu?.item.id === item.id }"
+                            aria-label="更多操作"
+                            @click.stop="openContextMenu(item, $event)"
+                          >
+                            <IonIcon :icon="ellipsisVertical" />
+                          </button>
+                        </div>
+                      </TransitionGroup>
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    class="card-more-btn"
-                    :class="{ active: contextMenu?.item.id === item.id }"
-                    aria-label="更多操作"
-                    @click.stop="openContextMenu(item, $event)"
-                  >
-                    <IonIcon :icon="ellipsisVertical" />
-                  </button>
-                </div>
-              </template>
+                </Transition>
+              </section>
             </TransitionGroup>
           </template>
         </div>
@@ -84,12 +116,12 @@
           <template v-else>
             <div class="section-header">
               <span class="section-title">共 {{ parseItems.length }} 条记录</span>
-              <button class="clear-btn" @click="confirmClearParse">清空</button>
+              <button type="button" class="clear-btn" @click="confirmClearParse">清空</button>
             </div>
             <TransitionGroup name="history-list" tag="div" class="card-list">
               <div
                 v-for="item in parseItems"
-                :key="item.timestamp"
+                :key="item.id"
                 class="parse-card"
                 @click="openParseItem(item)"
               >
@@ -136,12 +168,13 @@
 <script setup lang="ts">
 defineOptions({ name: 'HistoryPage' })
 
-import { computed, onMounted, ref } from 'vue'
+import { computed, onActivated, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { IonContent, IonIcon, IonPage } from '@ionic/vue'
 import { createAppAlert } from '@/services/AppAlertService'
 import {
   bookOutline,
+  chevronDownOutline,
   copyOutline,
   documentTextOutline,
   ellipsisVertical,
@@ -151,6 +184,8 @@ import {
 } from 'ionicons/icons'
 import { HistoryService } from '@/services/HistoryService'
 import type { BrowseHistoryItem, ParseHistoryItem } from '@/services/JmcomicTypes'
+import { groupBrowseHistory } from '@/utils/historyDateGroups'
+import type { BrowseGroupKey } from '@/utils/historyDateGroups'
 import MenuToggleButton from '@/components/common/MenuToggleButton.vue'
 import CardContextMenu from '@/components/common/CardContextMenu.vue'
 
@@ -164,55 +199,68 @@ const parseItems = ref<ParseHistoryItem[]>([])
 const browseHasMore = ref(true)
 const parseHasMore = ref(true)
 const isLoadingMore = ref(false)
+const groupingNow = ref(Date.now())
+const collapsedBrowseGroups = ref<Set<BrowseGroupKey>>(new Set())
 
-interface BrowseGroup {
-  label: string
-  items: BrowseHistoryItem[]
+const browseGroups = computed(() => groupBrowseHistory(browseItems.value, groupingNow.value))
+
+function browseGroupToggleId(key: BrowseGroupKey): string {
+  return `history-group-toggle-${key}`
 }
 
-const browseGroups = computed<BrowseGroup[]>(() => {
-  const now = new Date()
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
-  const yesterdayStart = todayStart - 86_400_000
-  const dayOfWeek = now.getDay() || 7
-  const weekStart = todayStart - (dayOfWeek - 1) * 86_400_000
+function browseGroupContentId(key: BrowseGroupKey): string {
+  return `history-group-content-${key}`
+}
 
-  const groups: Record<string, BrowseHistoryItem[]> = {
-    今天: [],
-    昨天: [],
-    本周: [],
-    更早: [],
+function isBrowseGroupCollapsed(key: BrowseGroupKey): boolean {
+  return collapsedBrowseGroups.value.has(key)
+}
+
+function isContextMenuInBrowseGroup(key: BrowseGroupKey): boolean {
+  const menu = contextMenu.value
+  if (!menu || menu.type !== 'browse') return false
+  return browseGroups.value.some(
+    (group) => group.key === key && group.items.some((item) => item.id === menu.item.id),
+  )
+}
+
+function toggleBrowseGroup(key: BrowseGroupKey) {
+  const next = new Set(collapsedBrowseGroups.value)
+  if (next.has(key)) next.delete(key)
+  else {
+    if (isContextMenuInBrowseGroup(key)) closeContextMenu()
+    next.add(key)
   }
+  collapsedBrowseGroups.value = next
+}
 
-  for (const item of browseItems.value) {
-    if (item.timestamp >= todayStart) {
-      groups['今天'].push(item)
-    } else if (item.timestamp >= yesterdayStart) {
-      groups['昨天'].push(item)
-    } else if (item.timestamp >= weekStart) {
-      groups['本周'].push(item)
-    } else {
-      groups['更早'].push(item)
-    }
-  }
+function pruneCollapsedBrowseGroups() {
+  const visibleKeys = new Set(browseGroups.value.map((group) => group.key))
+  const next = new Set([...collapsedBrowseGroups.value].filter((key) => visibleKeys.has(key)))
+  if (next.size !== collapsedBrowseGroups.value.size) collapsedBrowseGroups.value = next
+}
 
-  return (Object.entries(groups) as [string, BrowseHistoryItem[]][])
-    .filter(([, items]) => items.length > 0)
-    .map(([label, items]) => ({ label, items }))
-})
+function refreshBrowseGrouping() {
+  groupingNow.value = Date.now()
+}
 
 async function loadBrowse() {
   browseItems.value = await HistoryService.getBrowseHistory(PAGE_SIZE, 0)
   browseHasMore.value = browseItems.value.length === PAGE_SIZE
+  refreshBrowseGrouping()
 }
 
 async function loadMoreBrowse() {
   if (isLoadingMore.value || !browseHasMore.value) return
   isLoadingMore.value = true
-  const batch = await HistoryService.getBrowseHistory(PAGE_SIZE, browseItems.value.length)
-  if (batch.length > 0) browseItems.value.push(...batch)
-  browseHasMore.value = batch.length === PAGE_SIZE
-  isLoadingMore.value = false
+  try {
+    const batch = await HistoryService.getBrowseHistory(PAGE_SIZE, browseItems.value.length)
+    if (batch.length > 0) browseItems.value.push(...batch)
+    browseHasMore.value = batch.length === PAGE_SIZE
+  } finally {
+    refreshBrowseGrouping()
+    isLoadingMore.value = false
+  }
 }
 
 async function loadParse() {
@@ -251,6 +299,10 @@ onMounted(async () => {
     scrollEl.value = (await (contentEl as any).getScrollElement()) as HTMLElement
   }
   await loadBrowse()
+})
+
+onActivated(() => {
+  refreshBrowseGrouping()
 })
 
 function openAlbum(item: BrowseHistoryItem) {
@@ -357,6 +409,8 @@ async function handleMenuDelete() {
           if (isBrowse) {
             await HistoryService.deleteBrowseItem(m.item.id)
             browseItems.value = browseItems.value.filter((i) => i.id !== m.item.id)
+            refreshBrowseGrouping()
+            pruneCollapsedBrowseGroups()
           } else {
             await HistoryService.deleteParseItem(m.item.id)
             parseItems.value = parseItems.value.filter((i) => i.id !== m.item.id)
@@ -379,7 +433,10 @@ async function confirmClearBrowse() {
         role: 'destructive',
         handler: async () => {
           await HistoryService.clearBrowseHistory()
+          closeContextMenu()
           browseItems.value = []
+          collapsedBrowseGroups.value = new Set()
+          refreshBrowseGrouping()
         },
       },
     ],
@@ -512,21 +569,84 @@ function formatRelativeTime(timestamp: number): string {
   background: #ffeaea;
 }
 
-/* Date group header */
-.date-group-header {
-  padding: 16px 4px 8px;
-  font-size: 13px;
-  font-weight: 600;
-  color: #8a6048;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
 /* Card list */
 .card-list {
   display: flex;
   flex-direction: column;
+  gap: 0;
+}
+
+.date-group + .date-group {
+  margin-top: 4px;
+}
+
+.date-group-heading {
+  margin: 0;
+}
+
+.date-group-toggle {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 4px 8px;
+  border: 0;
+  background: transparent;
+  color: #8a6048;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.date-group-toggle:focus-visible {
+  outline: 2px solid #e8843c;
+  outline-offset: 1px;
+  border-radius: 6px;
+}
+
+.date-group-toggle-icon {
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: 16px;
+  transition: transform 0.24s ease;
+}
+
+.date-group-toggle-icon.collapsed {
+  transform: rotate(-90deg);
+}
+
+.date-group-content {
+  display: grid;
+  grid-template-rows: 1fr;
+  overflow: hidden;
+}
+
+.date-group-content-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.date-group-cards {
+  display: flex;
+  flex-direction: column;
   gap: 6px;
+}
+
+.history-drawer-enter-active,
+.history-drawer-leave-active {
+  transition:
+    grid-template-rows 0.24s ease,
+    opacity 0.18s ease;
+}
+
+.history-drawer-enter-from,
+.history-drawer-leave-to {
+  grid-template-rows: 0fr;
+  opacity: 0;
 }
 
 /* Browse card */
@@ -745,5 +865,16 @@ function formatRelativeTime(timestamp: number): string {
 
 .history-list-move {
   transition: transform 0.28s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .date-group-toggle-icon,
+  .history-drawer-enter-active,
+  .history-drawer-leave-active,
+  .history-list-enter-active,
+  .history-list-leave-active,
+  .history-list-move {
+    transition-duration: 0.01ms;
+  }
 }
 </style>

--- a/tests/unit/HistoryPage.test.ts
+++ b/tests/unit/HistoryPage.test.ts
@@ -1,13 +1,15 @@
 /* eslint-disable vue/one-component-per-file -- test-only Ionic fixtures */
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { BrowseHistoryItem } from '@/services/JmcomicTypes'
 
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
+  createAppAlert: vi.fn(),
   getBrowseHistory: vi.fn(),
   getParseHistory: vi.fn(),
+  clearBrowseHistory: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
@@ -35,11 +37,17 @@ vi.mock('@ionic/vue', () => {
 
 vi.mock('ionicons/icons', () => ({
   bookOutline: 'book',
+  chevronDownOutline: 'chevron-down',
   copyOutline: 'copy',
   documentTextOutline: 'document-text',
   ellipsisVertical: 'ellipsis-vertical',
+  informationCircleOutline: 'information-circle',
   timeOutline: 'time',
   trashOutline: 'trash',
+}))
+
+vi.mock('@/services/AppAlertService', () => ({
+  createAppAlert: mocks.createAppAlert,
 }))
 
 vi.mock('@/services/HistoryService', () => ({
@@ -48,7 +56,7 @@ vi.mock('@/services/HistoryService', () => ({
     getParseHistory: mocks.getParseHistory,
     deleteBrowseItem: vi.fn(),
     deleteParseItem: vi.fn(),
-    clearBrowseHistory: vi.fn(),
+    clearBrowseHistory: mocks.clearBrowseHistory,
     clearParseHistory: vi.fn(),
   },
 }))
@@ -57,9 +65,30 @@ vi.mock('@/components/common/MenuToggleButton.vue', () => ({
   default: { name: 'MenuToggleButton', render: () => null },
 }))
 
+vi.mock('@/components/common/CardContextMenu.vue', () => ({
+  default: defineComponent({
+    name: 'CardContextMenu',
+    props: {
+      visible: { type: Boolean, default: false },
+      anchor: { type: Object, default: null },
+      actions: { type: Array, default: () => [] },
+    },
+    setup(props) {
+      return () =>
+        h('div', {
+          class: 'card-context-menu',
+          'data-visible': props.visible ? 'true' : 'false',
+        })
+    },
+  }),
+}))
+
 import HistoryPage from '@/views/HistoryPage.vue'
 
-const makeBrowseItem = (chapterId: string): BrowseHistoryItem => ({
+const makeBrowseItem = (
+  chapterId = '',
+  overrides: Partial<BrowseHistoryItem> = {},
+): BrowseHistoryItem => ({
   id: 1,
   albumId: '100',
   albumTitle: '测试本子',
@@ -68,13 +97,30 @@ const makeBrowseItem = (chapterId: string): BrowseHistoryItem => ({
   chapterId,
   chapterTitle: chapterId ? '第二话' : '',
   timestamp: Date.now(),
+  ...overrides,
 })
 
 beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2025, 6, 16, 12))
   vi.clearAllMocks()
   mocks.routerPush.mockResolvedValue(undefined)
+  mocks.createAppAlert.mockResolvedValue({ present: vi.fn().mockResolvedValue(undefined) })
+  mocks.clearBrowseHistory.mockResolvedValue(undefined)
+  mocks.getBrowseHistory.mockResolvedValue([])
   mocks.getParseHistory.mockResolvedValue([])
 })
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+async function mountHistory(items: BrowseHistoryItem[]) {
+  mocks.getBrowseHistory.mockResolvedValue(items)
+  const wrapper = mount(HistoryPage)
+  await flushPromises()
+  return wrapper
+}
 
 describe('HistoryPage 详情跳转', () => {
   test('历史记录有章节 ID 时定位到对应章节', async () => {
@@ -111,6 +157,120 @@ describe('HistoryPage 详情跳转', () => {
         authors: '作者甲,作者乙',
       },
     })
+    wrapper.unmount()
+  })
+})
+
+describe('HistoryPage 浏览历史分组', () => {
+  test('渲染八组中的非空分组并保持稳定顺序', async () => {
+    const wrapper = await mountHistory([
+      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
+      makeBrowseItem('', { id: 2, timestamp: new Date(2025, 6, 15, 10).getTime() }),
+      makeBrowseItem('', { id: 3, timestamp: new Date(2025, 6, 14, 10).getTime() }),
+      makeBrowseItem('', { id: 4, timestamp: new Date(2025, 6, 1, 10).getTime() }),
+      makeBrowseItem('', { id: 5, timestamp: new Date(2025, 3, 16, 10).getTime() }),
+      makeBrowseItem('', { id: 6, timestamp: new Date(2025, 0, 16, 10).getTime() }),
+      makeBrowseItem('', { id: 7, timestamp: new Date(2024, 11, 31, 10).getTime() }),
+    ])
+
+    expect(wrapper.findAll('.date-group-toggle').map((button) => button.text())).toEqual([
+      '今天',
+      '昨天',
+      '本周',
+      '本月',
+      '3个月内',
+      '6个月内',
+      '更早',
+    ])
+    expect(wrapper.findAll('.browse-card')).toHaveLength(7)
+    wrapper.unmount()
+  })
+
+  test('文本和图标共享可访问按钮，独立切换并同步 region 状态', async () => {
+    const wrapper = await mountHistory([
+      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
+      makeBrowseItem('', { id: 2, timestamp: new Date(2025, 6, 15, 10).getTime() }),
+    ])
+    const todayToggle = wrapper.get('#history-group-toggle-today')
+    const todayContentId = 'history-group-content-today'
+
+    expect(todayToggle.element.tagName).toBe('BUTTON')
+    expect(todayToggle.text()).toBe('今天')
+    expect(todayToggle.find('.date-group-toggle-icon').attributes('aria-hidden')).toBe('true')
+    expect(todayToggle.attributes('aria-expanded')).toBe('true')
+    expect(todayToggle.attributes('aria-controls')).toBe(todayContentId)
+    expect(wrapper.get(`#${todayContentId}`).attributes('role')).toBe('region')
+    expect(wrapper.get(`#${todayContentId}`).attributes('aria-labelledby')).toBe(
+      'history-group-toggle-today',
+    )
+
+    await todayToggle.trigger('click')
+
+    expect(todayToggle.attributes('aria-expanded')).toBe('false')
+    expect(todayToggle.find('.date-group-toggle-icon').classes()).toContain('collapsed')
+    expect(wrapper.find(`#${todayContentId}`).exists()).toBe(false)
+    expect(wrapper.get('#history-group-toggle-yesterday').attributes('aria-expanded')).toBe('true')
+
+    await todayToggle.trigger('click')
+    await todayToggle.trigger('click')
+    await todayToggle.trigger('click')
+
+    expect(todayToggle.attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find(`#${todayContentId}`).exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('折叠包含上下文菜单的分组时先关闭菜单', async () => {
+    const wrapper = await mountHistory([
+      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
+    ])
+
+    await wrapper.get('.card-more-btn').trigger('click')
+    expect(wrapper.get('.card-context-menu').attributes('data-visible')).toBe('true')
+
+    await wrapper.get('#history-group-toggle-today').trigger('click')
+
+    expect(wrapper.get('.card-context-menu').attributes('data-visible')).toBe('false')
+    wrapper.unmount()
+  })
+
+  test('切换解析历史再返回时保留分组折叠状态', async () => {
+    const wrapper = await mountHistory([
+      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
+    ])
+
+    await wrapper.get('#history-group-toggle-today').trigger('click')
+    await wrapper.get('.tab-btn').at(1).trigger('click')
+    await wrapper.get('.tab-btn').at(0).trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('false')
+    wrapper.unmount()
+  })
+
+  test('清空浏览历史后重新出现的分组默认展开', async () => {
+    const items = [makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() })]
+    const present = vi.fn().mockResolvedValue(undefined)
+    mocks.createAppAlert.mockImplementation(
+      async (options: { buttons: Array<{ handler?: () => void | Promise<void> }> }) => {
+        await options.buttons[1]?.handler?.()
+        return { present }
+      },
+    )
+    const wrapper = await mountHistory(items)
+
+    await wrapper.get('#history-group-toggle-today').trigger('click')
+    await wrapper.get('.clear-btn').trigger('click')
+    await flushPromises()
+    expect(mocks.clearBrowseHistory).toHaveBeenCalledOnce()
+
+    mocks.getBrowseHistory.mockResolvedValue(items)
+    await wrapper.get('.tab-btn').at(1).trigger('click')
+    await wrapper.get('.tab-btn').at(0).trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('true')
+    expect(present).toHaveBeenCalledOnce()
     wrapper.unmount()
   })
 })

--- a/tests/unit/HistoryPage.test.ts
+++ b/tests/unit/HistoryPage.test.ts
@@ -215,8 +215,8 @@ describe('HistoryPage 浏览历史分组', () => {
     await todayToggle.trigger('click')
     await todayToggle.trigger('click')
 
-    expect(todayToggle.attributes('aria-expanded')).toBe('false')
-    expect(wrapper.find(`#${todayContentId}`).exists()).toBe(false)
+    expect(todayToggle.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find(`#${todayContentId}`).exists()).toBe(true)
     wrapper.unmount()
   })
 
@@ -240,8 +240,9 @@ describe('HistoryPage 浏览历史分组', () => {
     ])
 
     await wrapper.get('#history-group-toggle-today').trigger('click')
-    await wrapper.get('.tab-btn').at(1).trigger('click')
-    await wrapper.get('.tab-btn').at(0).trigger('click')
+    const tabButtons = wrapper.findAll('.tab-btn')
+    await tabButtons[1].trigger('click')
+    await tabButtons[0].trigger('click')
     await flushPromises()
 
     expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('false')
@@ -265,8 +266,9 @@ describe('HistoryPage 浏览历史分组', () => {
     expect(mocks.clearBrowseHistory).toHaveBeenCalledOnce()
 
     mocks.getBrowseHistory.mockResolvedValue(items)
-    await wrapper.get('.tab-btn').at(1).trigger('click')
-    await wrapper.get('.tab-btn').at(0).trigger('click')
+    const tabButtons = wrapper.findAll('.tab-btn')
+    await tabButtons[1].trigger('click')
+    await tabButtons[0].trigger('click')
     await flushPromises()
 
     expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('true')

--- a/tests/unit/historyDateGroups.test.ts
+++ b/tests/unit/historyDateGroups.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'vitest'
+import type { BrowseHistoryItem } from '@/services/JmcomicTypes'
+import { groupBrowseHistory } from '@/utils/historyDateGroups'
+
+function localDate(
+  year: number,
+  month: number,
+  date: number,
+  hour = 12,
+  minute = 0,
+  second = 0,
+  millisecond = 0,
+): number {
+  return new Date(year, month - 1, date, hour, minute, second, millisecond).getTime()
+}
+
+function makeItem(id: number, timestamp: number): BrowseHistoryItem {
+  return {
+    id,
+    albumId: `${id}`,
+    albumTitle: `本子 ${id}`,
+    coverUrl: '',
+    authors: '',
+    chapterId: '',
+    chapterTitle: '',
+    timestamp,
+  }
+}
+
+function groupKeyFor(timestamp: number, nowMs: number) {
+  return groupBrowseHistory([makeItem(1, timestamp)], nowMs)[0]?.key
+}
+
+describe('groupBrowseHistory', () => {
+  test('按固定顺序返回非空分组并保留组内输入顺序', () => {
+    const now = localDate(2025, 7, 16)
+    const items = [
+      makeItem(1, localDate(2025, 7, 16, 10)),
+      makeItem(2, localDate(2025, 7, 16, 9)),
+      makeItem(3, localDate(2025, 7, 15, 12)),
+      makeItem(4, localDate(2025, 7, 14, 12)),
+      makeItem(5, localDate(2025, 7, 1, 12)),
+      makeItem(6, localDate(2025, 4, 16, 12)),
+      makeItem(7, localDate(2025, 1, 16, 12)),
+      makeItem(8, localDate(2024, 12, 31, 12)),
+    ]
+
+    const groups = groupBrowseHistory(items, now)
+
+    expect(groups.map((group) => group.key)).toEqual([
+      'today',
+      'yesterday',
+      'thisWeek',
+      'thisMonth',
+      'lastThreeMonths',
+      'lastSixMonths',
+      'earlier',
+    ])
+    expect(groups.flatMap((group) => group.items.map((item) => item.id))).toEqual(
+      items.map((item) => item.id),
+    )
+    expect(groups.find((group) => group.key === 'today')?.items.map((item) => item.id)).toEqual([
+      1, 2,
+    ])
+  })
+
+  test('在每个边界恰好命中较新的分组，前一毫秒落入下一个分组', () => {
+    const now = localDate(2025, 7, 16, 15)
+    const boundaries = [
+      ['today', localDate(2025, 7, 16, 0), 'yesterday'],
+      ['yesterday', localDate(2025, 7, 15, 0), 'thisWeek'],
+      ['thisWeek', localDate(2025, 7, 14, 0), 'thisMonth'],
+      ['thisMonth', localDate(2025, 7, 1, 0), 'lastThreeMonths'],
+      ['lastThreeMonths', localDate(2025, 4, 16, 0), 'lastSixMonths'],
+      ['lastSixMonths', localDate(2025, 1, 16, 0), 'thisYear'],
+      ['thisYear', localDate(2025, 1, 1, 0), 'earlier'],
+    ] as const
+
+    for (const [key, start, previousKey] of boundaries) {
+      expect(groupKeyFor(start, now)).toBe(key)
+      expect(groupKeyFor(start - 1, now), `${key} 前一毫秒`).toBe(previousKey)
+    }
+  })
+
+  test('周一优先将周日归入昨天，并支持跨月周', () => {
+    const monday = localDate(2025, 3, 10)
+    expect(groupKeyFor(localDate(2025, 3, 9, 23, 59), monday)).toBe('yesterday')
+    expect(groupKeyFor(localDate(2025, 3, 8, 23, 59), monday)).toBe('thisMonth')
+
+    const aprilReference = localDate(2025, 4, 2)
+    expect(groupKeyFor(localDate(2025, 3, 31), aprilReference)).toBe('thisWeek')
+  })
+
+  test('按日历月计算滚动窗口并在月末夹断日期', () => {
+    const may31 = localDate(2026, 5, 31)
+    expect(groupKeyFor(localDate(2026, 2, 28, 0), may31)).toBe('lastThreeMonths')
+    expect(groupKeyFor(localDate(2026, 2, 27, 23, 59, 59, 999), may31)).toBe('lastSixMonths')
+
+    const leapYearMay31 = localDate(2024, 5, 31)
+    expect(groupKeyFor(localDate(2024, 2, 29, 0), leapYearMay31)).toBe('lastThreeMonths')
+    expect(groupKeyFor(localDate(2024, 2, 28, 23, 59, 59, 999), leapYearMay31)).toBe(
+      'lastSixMonths',
+    )
+  })
+
+  test('跨年时先命中滚动窗口，剩余本年数据归入今年', () => {
+    const yearEnd = localDate(2025, 12, 31)
+    expect(groupKeyFor(localDate(2025, 6, 30, 0), yearEnd)).toBe('lastSixMonths')
+    expect(groupKeyFor(localDate(2025, 6, 29), yearEnd)).toBe('thisYear')
+    expect(groupKeyFor(localDate(2024, 12, 31), yearEnd)).toBe('earlier')
+  })
+
+  test('有限未来时间归入今天，无效时间保持更早兼容行为', () => {
+    const now = localDate(2025, 7, 16)
+    const groups = groupBrowseHistory(
+      [makeItem(1, now + 2 * 86_400_000), makeItem(2, Number.NaN)],
+      now,
+    )
+
+    expect(groups.map((group) => [group.key, group.items.map((item) => item.id)])).toEqual([
+      ['today', [1]],
+      ['earlier', [2]],
+    ])
+  })
+
+  test('日历边界不依赖固定 24 小时回推', () => {
+    const afterDstReference = localDate(2024, 3, 12)
+    const previousLocalDay = localDate(2024, 3, 10, 23, 30)
+
+    expect(groupKeyFor(previousLocalDay, afterDstReference)).toBe('thisMonth')
+  })
+})

--- a/tests/unit/historyDateGroups.test.ts
+++ b/tests/unit/historyDateGroups.test.ts
@@ -113,13 +113,18 @@ describe('groupBrowseHistory', () => {
   test('有限未来时间归入今天，无效时间保持更早兼容行为', () => {
     const now = localDate(2025, 7, 16)
     const groups = groupBrowseHistory(
-      [makeItem(1, now + 2 * 86_400_000), makeItem(2, Number.NaN)],
+      [
+        makeItem(1, now + 2 * 86_400_000),
+        makeItem(2, Number.NaN),
+        makeItem(3, Number.POSITIVE_INFINITY),
+        makeItem(4, Number.NEGATIVE_INFINITY),
+      ],
       now,
     )
 
     expect(groups.map((group) => [group.key, group.items.map((item) => item.id)])).toEqual([
       ['today', [1]],
-      ['earlier', [2]],
+      ['earlier', [2, 3, 4]],
     ])
   })
 


### PR DESCRIPTION
## Summary

ASTRA-5 adds collapsible browse-history date groups while preserving the existing history and parse-history flows.

- Adds eight fixed-order, mutually exclusive local-calendar buckets: today, yesterday, this week, this month, within 3 months, within 6 months, this year, and earlier.
- Adds per-group native buttons with `aria-expanded`, `aria-controls`, labelled regions, chevrons, focus styling, and grid-based collapse animation.
- Preserves collapse state through pagination and tab activation, closes stale context menus before content removal, and resets state on clear.
- Uses database item IDs for card keys and adds utility/component coverage for boundary, accessibility, interaction, and state behavior.

## Validation

- Passed Prettier formatting/check, staged whitespace validation, TypeScript transpilation syntax checks, and isolated typecheck for the new utility.
- Passed `historyDateGroups.test.ts`: 7 tests in the default timezone and `TZ=America/New_York`.
- `npm ci` is blocked by the existing lockfile omission of platform optional packages; the project-local formatter, lint, unit, typecheck, and build scripts could not start because dependencies are unavailable in this environment.

No close-intent keyword is included; this PR links to ASTRA-5 without closing the parent issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 浏览历史现按“今天、昨天、本周、本月”等日期分组展示。
  * 支持展开和折叠各日期分组，并保留折叠状态。
  * 分组具备更完善的无障碍关联与动画偏好支持。

* **改进**
  * 刷新、加载更多、删除或清空记录后，分组状态会自动更新。
  * 折叠分组时会自动关闭相关操作菜单。
  * 切换浏览与解析记录标签后，分组折叠状态保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->