### PR TITLE
ASTRA-11: 切换历史 Tab 时保留数据与滚动位置

### DIFF
--- a/src/views/HistoryPage.vue
+++ b/src/views/HistoryPage.vue
@@ -168,7 +168,7 @@
 <script setup lang="ts">
 defineOptions({ name: 'HistoryPage' })
 
-import { computed, onActivated, onMounted, ref } from 'vue'
+import { computed, nextTick, onActivated, onDeactivated, onMounted, reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { IonContent, IonIcon, IonPage } from '@ionic/vue'
 import { createAppAlert } from '@/services/AppAlertService'
@@ -193,12 +193,21 @@ const PAGE_SIZE = 50
 const router = useRouter()
 const contentRef = ref<InstanceType<typeof IonContent>>()
 const scrollEl = ref<HTMLElement | null>(null)
-const activeTab = ref<'browse' | 'parse'>('browse')
+type HistoryTab = 'browse' | 'parse'
+
+const activeTab = ref<HistoryTab>('browse')
 const browseItems = ref<BrowseHistoryItem[]>([])
 const parseItems = ref<ParseHistoryItem[]>([])
 const browseHasMore = ref(true)
 const parseHasMore = ref(true)
-const isLoadingMore = ref(false)
+const loadingMoreByTab = reactive<Record<HistoryTab, boolean>>({ browse: false, parse: false })
+const tabLoaded = reactive<Record<HistoryTab, boolean>>({ browse: false, parse: false })
+const tabLoadPromises: Record<HistoryTab, Promise<void> | null> = {
+  browse: null,
+  parse: null,
+}
+const tabRequestGeneration = reactive<Record<HistoryTab, number>>({ browse: 0, parse: 0 })
+const tabScrollPositions = reactive<Record<HistoryTab, number>>({ browse: 0, parse: 0 })
 const groupingNow = ref(Date.now())
 const collapsedBrowseGroups = ref<Set<BrowseGroupKey>>(new Set())
 
@@ -244,40 +253,70 @@ function refreshBrowseGrouping() {
   groupingNow.value = Date.now()
 }
 
-async function loadBrowse() {
-  browseItems.value = await HistoryService.getBrowseHistory(PAGE_SIZE, 0)
-  browseHasMore.value = browseItems.value.length === PAGE_SIZE
+type IonContentElement = HTMLElement & {
+  getScrollElement?: () => Promise<HTMLElement | null>
+}
+
+async function resolveScrollElement(): Promise<HTMLElement | null> {
+  if (scrollEl.value) return scrollEl.value
+  const contentEl = contentRef.value?.$el as IonContentElement | undefined
+  if (!contentEl?.getScrollElement) return null
+  scrollEl.value = await contentEl.getScrollElement()
+  return scrollEl.value
+}
+
+async function loadBrowse(generation = tabRequestGeneration.browse) {
+  const items = await HistoryService.getBrowseHistory(PAGE_SIZE, 0)
+  if (generation !== tabRequestGeneration.browse) return
+  browseItems.value = items
+  browseHasMore.value = items.length === PAGE_SIZE
   refreshBrowseGrouping()
 }
 
 async function loadMoreBrowse() {
-  if (isLoadingMore.value || !browseHasMore.value) return
-  isLoadingMore.value = true
+  if (loadingMoreByTab.browse || !browseHasMore.value) return
+  loadingMoreByTab.browse = true
+  const generation = tabRequestGeneration.browse
   try {
     const batch = await HistoryService.getBrowseHistory(PAGE_SIZE, browseItems.value.length)
+    if (generation !== tabRequestGeneration.browse) return
     if (batch.length > 0) browseItems.value.push(...batch)
     browseHasMore.value = batch.length === PAGE_SIZE
   } finally {
-    refreshBrowseGrouping()
-    isLoadingMore.value = false
+    if (generation === tabRequestGeneration.browse) {
+      refreshBrowseGrouping()
+      loadingMoreByTab.browse = false
+    }
   }
 }
 
-async function loadParse() {
-  parseItems.value = await HistoryService.getParseHistory(PAGE_SIZE, 0)
-  parseHasMore.value = parseItems.value.length === PAGE_SIZE
+async function loadParse(generation = tabRequestGeneration.parse) {
+  const items = await HistoryService.getParseHistory(PAGE_SIZE, 0)
+  if (generation !== tabRequestGeneration.parse) return
+  parseItems.value = items
+  parseHasMore.value = items.length === PAGE_SIZE
 }
 
 async function loadMoreParse() {
-  if (isLoadingMore.value || !parseHasMore.value) return
-  isLoadingMore.value = true
-  const batch = await HistoryService.getParseHistory(PAGE_SIZE, parseItems.value.length)
-  if (batch.length > 0) parseItems.value.push(...batch)
-  parseHasMore.value = batch.length === PAGE_SIZE
-  isLoadingMore.value = false
+  if (loadingMoreByTab.parse || !parseHasMore.value) return
+  loadingMoreByTab.parse = true
+  const generation = tabRequestGeneration.parse
+  try {
+    const batch = await HistoryService.getParseHistory(PAGE_SIZE, parseItems.value.length)
+    if (generation !== tabRequestGeneration.parse) return
+    if (batch.length > 0) parseItems.value.push(...batch)
+    parseHasMore.value = batch.length === PAGE_SIZE
+  } finally {
+    if (generation === tabRequestGeneration.parse) loadingMoreByTab.parse = false
+  }
 }
 
-const onScroll = () => {
+const onScroll = (event: CustomEvent<{ scrollTop?: number }>) => {
+  const eventScrollTop = event.detail?.scrollTop
+  if (typeof eventScrollTop === 'number') {
+    tabScrollPositions[activeTab.value] = Math.max(0, eventScrollTop)
+  }
+
   const el = scrollEl.value
   if (!el) return
   const threshold = 200
@@ -287,22 +326,64 @@ const onScroll = () => {
   }
 }
 
+function saveActiveTabScrollPosition() {
+  const el = scrollEl.value
+  if (el) tabScrollPositions[activeTab.value] = Math.max(0, el.scrollTop)
+}
+
+async function restoreTabScrollPosition(tab: HistoryTab) {
+  await nextTick()
+  if (activeTab.value !== tab) return
+  const el = await resolveScrollElement()
+  if (!el || activeTab.value !== tab) return
+  el.scrollTop = Math.max(0, tabScrollPositions[tab])
+}
+
+function ensureTabLoaded(tab: HistoryTab): Promise<void> {
+  if (tabLoaded[tab]) return Promise.resolve()
+  if (tabLoadPromises[tab]) return tabLoadPromises[tab]!
+
+  const generation = tabRequestGeneration[tab]
+  const promise = (async () => {
+    try {
+      if (tab === 'browse') await loadBrowse(generation)
+      else await loadParse(generation)
+      if (generation === tabRequestGeneration[tab]) tabLoaded[tab] = true
+    } finally {
+      if (generation === tabRequestGeneration[tab]) tabLoadPromises[tab] = null
+    }
+  })()
+  tabLoadPromises[tab] = promise
+  return promise
+}
+
+function invalidateTab(tab: HistoryTab) {
+  tabRequestGeneration[tab] += 1
+  tabLoaded[tab] = false
+  tabLoadPromises[tab] = null
+  loadingMoreByTab[tab] = false
+}
+
 async function switchTab(tab: 'browse' | 'parse') {
+  if (activeTab.value === tab) return
+  saveActiveTabScrollPosition()
   activeTab.value = tab
-  if (tab === 'browse') await loadBrowse()
-  else await loadParse()
+  await ensureTabLoaded(tab)
+  await restoreTabScrollPosition(tab)
 }
 
 onMounted(async () => {
-  const contentEl = contentRef.value?.$el
-  if (contentEl && typeof (contentEl as any).getScrollElement === 'function') {
-    scrollEl.value = (await (contentEl as any).getScrollElement()) as HTMLElement
-  }
-  await loadBrowse()
+  await resolveScrollElement()
+  await ensureTabLoaded('browse')
 })
 
 onActivated(() => {
   refreshBrowseGrouping()
+  void restoreTabScrollPosition(activeTab.value)
+})
+
+onDeactivated(() => {
+  saveActiveTabScrollPosition()
 })
 
 function openAlbum(item: BrowseHistoryItem) {
@@ -432,9 +513,11 @@ async function confirmClearBrowse() {
         text: '清空',
         role: 'destructive',
         handler: async () => {
+          invalidateTab('browse')
           await HistoryService.clearBrowseHistory()
           closeContextMenu()
           browseItems.value = []
+          browseHasMore.value = true
           collapsedBrowseGroups.value = new Set()
           refreshBrowseGrouping()
         },
@@ -454,8 +537,10 @@ async function confirmClearParse() {
         text: '清空',
         role: 'destructive',
         handler: async () => {
+          invalidateTab('parse')
           await HistoryService.clearParseHistory()
           parseItems.value = []
+          parseHasMore.value = true
         },
       },
     ],

--- a/src/views/HistoryPage.vue
+++ b/src/views/HistoryPage.vue
@@ -208,6 +208,8 @@ const tabLoadPromises: Record<HistoryTab, Promise<void> | null> = {
 }
 const tabRequestGeneration = reactive<Record<HistoryTab, number>>({ browse: 0, parse: 0 })
 const tabScrollPositions = reactive<Record<HistoryTab, number>>({ browse: 0, parse: 0 })
+const isTabTransitioning = ref(false)
+let tabTransitionId = 0
 const groupingNow = ref(Date.now())
 const collapsedBrowseGroups = ref<Set<BrowseGroupKey>>(new Set())
 
@@ -274,7 +276,7 @@ async function loadBrowse(generation = tabRequestGeneration.browse) {
 }
 
 async function loadMoreBrowse() {
-  if (loadingMoreByTab.browse || !browseHasMore.value) return
+  if (!isTabReadyForPagination('browse') || loadingMoreByTab.browse || !browseHasMore.value) return
   loadingMoreByTab.browse = true
   const generation = tabRequestGeneration.browse
   try {
@@ -298,7 +300,7 @@ async function loadParse(generation = tabRequestGeneration.parse) {
 }
 
 async function loadMoreParse() {
-  if (loadingMoreByTab.parse || !parseHasMore.value) return
+  if (!isTabReadyForPagination('parse') || loadingMoreByTab.parse || !parseHasMore.value) return
   loadingMoreByTab.parse = true
   const generation = tabRequestGeneration.parse
   try {
@@ -312,18 +314,25 @@ async function loadMoreParse() {
 }
 
 const onScroll = (event: CustomEvent<{ scrollTop?: number }>) => {
+  const tab = activeTab.value
+  if (isTabTransitioning.value) return
+
   const eventScrollTop = event.detail?.scrollTop
-  if (typeof eventScrollTop === 'number') {
-    tabScrollPositions[activeTab.value] = Math.max(0, eventScrollTop)
-  }
+  if (typeof eventScrollTop === 'number') tabScrollPositions[tab] = Math.max(0, eventScrollTop)
+
+  if (!isTabReadyForPagination(tab)) return
 
   const el = scrollEl.value
   if (!el) return
   const threshold = 200
   if (el.scrollHeight - el.scrollTop - el.clientHeight < threshold) {
-    if (activeTab.value === 'browse') loadMoreBrowse()
+    if (tab === 'browse') loadMoreBrowse()
     else loadMoreParse()
   }
+}
+
+function isTabReadyForPagination(tab: HistoryTab): boolean {
+  return tabLoaded[tab] && tabLoadPromises[tab] === null
 }
 
 function saveActiveTabScrollPosition() {
@@ -337,6 +346,16 @@ async function restoreTabScrollPosition(tab: HistoryTab) {
   const el = await resolveScrollElement()
   if (!el || activeTab.value !== tab) return
   el.scrollTop = Math.max(0, tabScrollPositions[tab])
+}
+
+function beginTabTransition(): number {
+  const id = ++tabTransitionId
+  isTabTransitioning.value = true
+  return id
+}
+
+function endTabTransition(id: number) {
+  if (id === tabTransitionId) isTabTransitioning.value = false
 }
 
 function ensureTabLoaded(tab: HistoryTab): Promise<void> {
@@ -364,12 +383,18 @@ function invalidateTab(tab: HistoryTab) {
   loadingMoreByTab[tab] = false
 }
 
-async function switchTab(tab: 'browse' | 'parse') {
+async function switchTab(tab: HistoryTab) {
   if (activeTab.value === tab) return
-  saveActiveTabScrollPosition()
+  const wasTransitioning = isTabTransitioning.value
+  const transitionId = beginTabTransition()
+  if (!wasTransitioning) saveActiveTabScrollPosition()
   activeTab.value = tab
-  await ensureTabLoaded(tab)
-  await restoreTabScrollPosition(tab)
+  try {
+    await ensureTabLoaded(tab)
+    await restoreTabScrollPosition(tab)
+  } finally {
+    endTabTransition(transitionId)
+  }
 }
 
 onMounted(async () => {
@@ -379,7 +404,14 @@ onMounted(async () => {
 
 onActivated(() => {
   refreshBrowseGrouping()
-  void restoreTabScrollPosition(activeTab.value)
+  const transitionId = beginTabTransition()
+  void (async () => {
+    try {
+      await restoreTabScrollPosition(activeTab.value)
+    } finally {
+      endTabTransition(transitionId)
+    }
+  })()
 })
 
 onDeactivated(() => {

--- a/tests/unit/HistoryPage.test.ts
+++ b/tests/unit/HistoryPage.test.ts
@@ -127,6 +127,14 @@ const makeParseItem = (id = 1, overrides: Partial<ParseHistoryItem> = {}): Parse
   ...overrides,
 })
 
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date(2025, 6, 16, 12))
@@ -150,6 +158,12 @@ async function mountHistory(items: BrowseHistoryItem[]) {
   const wrapper = mount(HistoryPage)
   await flushPromises()
   return wrapper
+}
+
+const settle = async () => {
+  await flushPromises()
+  await nextTick()
+  await flushPromises()
 }
 
 describe('HistoryPage 详情跳转', () => {
@@ -308,6 +322,107 @@ describe('HistoryPage 浏览历史分组', () => {
 })
 
 describe('HistoryPage Tab 生命周期', () => {
+  test('浏览首屏请求 pending 时近底部滚动不会启动第二个 offset 0 请求', async () => {
+    const browseRequest = deferred<BrowseHistoryItem[]>()
+    mocks.getBrowseHistory.mockReturnValue(browseRequest.promise)
+
+    const wrapper = mount(HistoryPage)
+    await flushPromises()
+
+    const scrollElement = wrapper.get('main').element as HTMLElement
+    Object.defineProperties(scrollElement, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 600 },
+    })
+    scrollElement.scrollTop = 250
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
+    await flushPromises()
+
+    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(1)
+    expect(mocks.getBrowseHistory).toHaveBeenCalledWith(50, 0)
+
+    browseRequest.resolve([makeBrowseItem('', { id: 101 }), makeBrowseItem('', { id: 102 })])
+    await settle()
+
+    expect(wrapper.findAll('.browse-card')).toHaveLength(2)
+    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  test('解析首屏 pending 时切换期间滚动不会重复请求，并恢复目标位置', async () => {
+    const parseRequest = deferred<ParseHistoryItem[]>()
+    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('', { id: 10 })])
+    mocks.getParseHistory.mockReturnValue(parseRequest.promise)
+
+    const wrapper = mount(HistoryPage)
+    await settle()
+
+    const scrollElement = wrapper.get('main').element as HTMLElement
+    Object.defineProperties(scrollElement, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 600 },
+    })
+    scrollElement.scrollTop = 420
+    const tabButtons = wrapper.findAll('.tab-btn')
+    await tabButtons[1].trigger('click')
+    await nextTick()
+    scrollElement.scrollTop = 420
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 420 } }))
+    await flushPromises()
+
+    expect(mocks.getParseHistory).toHaveBeenCalledTimes(1)
+    expect(mocks.getParseHistory).toHaveBeenCalledWith(50, 0)
+
+    parseRequest.resolve([
+      makeParseItem(201, { text: '首次解析' }),
+      makeParseItem(202, { text: '第二次解析' }),
+    ])
+    await settle()
+
+    expect(wrapper.findAll('.parse-card')).toHaveLength(2)
+    expect(wrapper.findAll('.parse-card').map((card) => card.text())).toEqual([
+      '首次解析单个解析刚刚',
+      '第二次解析单个解析刚刚',
+    ])
+    expect(scrollElement.scrollTop).toBe(0)
+    expect(mocks.getParseHistory).toHaveBeenCalledTimes(1)
+
+    await tabButtons[0].trigger('click')
+    await settle()
+    expect(scrollElement.scrollTop).toBe(420)
+    wrapper.unmount()
+  })
+
+  test('快速来回切换时旧的首屏任务不会恢复错误 Tab 的滚动位置', async () => {
+    const parseRequest = deferred<ParseHistoryItem[]>()
+    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('', { id: 1 })])
+    mocks.getParseHistory.mockReturnValue(parseRequest.promise)
+
+    const wrapper = mount(HistoryPage)
+    await settle()
+    const scrollElement = wrapper.get('main').element as HTMLElement
+    scrollElement.scrollTop = 420
+    const tabButtons = wrapper.findAll('.tab-btn')
+
+    await tabButtons[1].trigger('click')
+    await nextTick()
+    await tabButtons[0].trigger('click')
+    await settle()
+
+    expect(wrapper.get('.tab-btn.active').text()).toBe('浏览历史')
+    expect(scrollElement.scrollTop).toBe(420)
+
+    parseRequest.resolve([makeParseItem(301, { text: '延迟解析' })])
+    await settle()
+    expect(wrapper.get('.tab-btn.active').text()).toBe('浏览历史')
+    expect(scrollElement.scrollTop).toBe(420)
+
+    await tabButtons[1].trigger('click')
+    await settle()
+    expect(scrollElement.scrollTop).toBe(0)
+    wrapper.unmount()
+  })
+
   test('每个 Tab 只在首次进入时加载并保留分页数据', async () => {
     const firstPage = Array.from({ length: 50 }, (_, index) =>
       makeBrowseItem('', { id: index + 1 }),

--- a/tests/unit/HistoryPage.test.ts
+++ b/tests/unit/HistoryPage.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable vue/one-component-per-file -- test-only Ionic fixtures */
 import { flushPromises, mount } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
+import { KeepAlive, defineComponent, h, nextTick, onMounted, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import type { BrowseHistoryItem } from '@/services/JmcomicTypes'
+import type { BrowseHistoryItem, ParseHistoryItem } from '@/services/JmcomicTypes'
 
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
@@ -10,6 +10,9 @@ const mocks = vi.hoisted(() => ({
   getBrowseHistory: vi.fn(),
   getParseHistory: vi.fn(),
   clearBrowseHistory: vi.fn(),
+  clearParseHistory: vi.fn(),
+  deleteBrowseItem: vi.fn(),
+  deleteParseItem: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
@@ -27,7 +30,19 @@ vi.mock('@ionic/vue', () => {
 
   return {
     alertController: { create: vi.fn() },
-    IonContent: withSlot('IonContent', 'main'),
+    IonContent: defineComponent({
+      name: 'IonContent',
+      setup(_, { attrs, slots }) {
+        const elementRef = ref<HTMLElement | null>(null)
+        onMounted(() => {
+          const element = elementRef.value as HTMLElement & {
+            getScrollElement: () => Promise<HTMLElement | null>
+          }
+          element.getScrollElement = async () => element
+        })
+        return () => h('main', { ...attrs, ref: elementRef }, slots.default?.())
+      },
+    }),
     IonHeader: withSlot('IonHeader', 'header'),
     IonIcon: withSlot('IonIcon', 'span'),
     IonPage: withSlot('IonPage'),
@@ -54,10 +69,10 @@ vi.mock('@/services/HistoryService', () => ({
   HistoryService: {
     getBrowseHistory: mocks.getBrowseHistory,
     getParseHistory: mocks.getParseHistory,
-    deleteBrowseItem: vi.fn(),
-    deleteParseItem: vi.fn(),
+    deleteBrowseItem: mocks.deleteBrowseItem,
+    deleteParseItem: mocks.deleteParseItem,
     clearBrowseHistory: mocks.clearBrowseHistory,
-    clearParseHistory: vi.fn(),
+    clearParseHistory: mocks.clearParseHistory,
   },
 }))
 
@@ -73,11 +88,15 @@ vi.mock('@/components/common/CardContextMenu.vue', () => ({
       anchor: { type: Object, default: null },
       actions: { type: Array, default: () => [] },
     },
-    setup(props) {
+    emits: ['select'],
+    setup(props, { emit }) {
       return () =>
         h('div', {
           class: 'card-context-menu',
           'data-visible': props.visible ? 'true' : 'false',
+          onClick: () => {
+            if (props.visible) emit('select', 'delete')
+          },
         })
     },
   }),
@@ -100,6 +119,14 @@ const makeBrowseItem = (
   ...overrides,
 })
 
+const makeParseItem = (id = 1, overrides: Partial<ParseHistoryItem> = {}): ParseHistoryItem => ({
+  id,
+  text: '12345',
+  mode: 'single-mode',
+  timestamp: Date.now(),
+  ...overrides,
+})
+
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date(2025, 6, 16, 12))
@@ -107,6 +134,9 @@ beforeEach(() => {
   mocks.routerPush.mockResolvedValue(undefined)
   mocks.createAppAlert.mockResolvedValue({ present: vi.fn().mockResolvedValue(undefined) })
   mocks.clearBrowseHistory.mockResolvedValue(undefined)
+  mocks.clearParseHistory.mockResolvedValue(undefined)
+  mocks.deleteBrowseItem.mockResolvedValue(undefined)
+  mocks.deleteParseItem.mockResolvedValue(undefined)
   mocks.getBrowseHistory.mockResolvedValue([])
   mocks.getParseHistory.mockResolvedValue([])
 })
@@ -272,6 +302,126 @@ describe('HistoryPage 浏览历史分组', () => {
     await flushPromises()
 
     expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('true')
+    expect(present).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+})
+
+describe('HistoryPage Tab 生命周期', () => {
+  test('每个 Tab 只在首次进入时加载并保留分页数据', async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) =>
+      makeBrowseItem('', { id: index + 1 }),
+    )
+    const secondPage = Array.from({ length: 50 }, (_, index) =>
+      makeBrowseItem('', { id: index + 51 }),
+    )
+    mocks.getBrowseHistory.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage)
+    mocks.getParseHistory.mockResolvedValueOnce([makeParseItem()])
+
+    const wrapper = mount(HistoryPage)
+    await flushPromises()
+
+    const scrollElement = wrapper.get('main').element as HTMLElement
+    Object.defineProperties(scrollElement, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 600 },
+    })
+    scrollElement.scrollTop = 250
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
+    await flushPromises()
+
+    expect(mocks.getBrowseHistory).toHaveBeenNthCalledWith(2, 50, 50)
+    expect(wrapper.findAll('.browse-card')).toHaveLength(100)
+
+    const tabButtons = wrapper.findAll('.tab-btn')
+    await tabButtons[1].trigger('click')
+    await flushPromises()
+    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
+
+    await tabButtons[0].trigger('click')
+    await flushPromises()
+    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(2)
+    expect(wrapper.findAll('.browse-card')).toHaveLength(100)
+
+    await tabButtons[1].trigger('click')
+    await flushPromises()
+    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  test('两个 Tab 分别恢复滚动位置，并在 KeepAlive 返回时保留状态', async () => {
+    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('', { id: 1 })])
+    mocks.getParseHistory.mockResolvedValue([makeParseItem()])
+    const showHistory = ref(true)
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(KeepAlive, null, [
+            showHistory.value
+              ? h(HistoryPage, { key: 'history' })
+              : h('div', { class: 'other-page' }),
+          ])
+      },
+    })
+
+    const wrapper = mount(Host)
+    await flushPromises()
+    const historyWrapper = wrapper.findComponent(HistoryPage)
+    const scrollElement = historyWrapper.get('main').element as HTMLElement
+    const tabButtons = historyWrapper.findAll('.tab-btn')
+
+    scrollElement.scrollTop = 420
+    await tabButtons[1].trigger('click')
+    await flushPromises()
+    expect(scrollElement.scrollTop).toBe(0)
+
+    scrollElement.scrollTop = 180
+    await tabButtons[0].trigger('click')
+    await flushPromises()
+    expect(scrollElement.scrollTop).toBe(420)
+
+    await tabButtons[1].trigger('click')
+    await flushPromises()
+    expect(scrollElement.scrollTop).toBe(180)
+
+    showHistory.value = false
+    await nextTick()
+    scrollElement.scrollTop = 0
+    showHistory.value = true
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.findComponent(HistoryPage).get('.tab-btn.active').text()).toBe('解析历史')
+    expect(scrollElement.scrollTop).toBe(180)
+    expect(mocks.getBrowseHistory).toHaveBeenCalledOnce()
+    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  test('删除记录即时更新列表且切换 Tab 不重新加载已缓存数据', async () => {
+    const item = makeBrowseItem('', { id: 7 })
+    const present = vi.fn().mockResolvedValue(undefined)
+    mocks.getBrowseHistory.mockResolvedValue([item])
+    mocks.createAppAlert.mockImplementation(
+      async (options: { buttons: Array<{ handler?: () => void | Promise<void> }> }) => {
+        await options.buttons[1]?.handler?.()
+        return { present }
+      },
+    )
+    const wrapper = await mountHistory([item])
+
+    await wrapper.get('.card-more-btn').trigger('click')
+    await wrapper.get('.card-context-menu').trigger('click')
+    await flushPromises()
+
+    expect(mocks.deleteBrowseItem).toHaveBeenCalledWith(item.id)
+    expect(wrapper.findAll('.browse-card')).toHaveLength(0)
+
+    const tabButtons = wrapper.findAll('.tab-btn')
+    await tabButtons[1].trigger('click')
+    await tabButtons[0].trigger('click')
+    await flushPromises()
+    expect(mocks.getBrowseHistory).toHaveBeenCalledOnce()
     expect(present).toHaveBeenCalledOnce()
     wrapper.unmount()
   })


### PR DESCRIPTION
## 变更内容

- 历史页按 Tab 进行首次按需加载；同一页面生命周期内切回时不重复请求，也不重置已加载的分页数据、是否还有下一页、折叠状态或上下文菜单。
- 浏览历史与解析历史分别保存和恢复滚动位置，并在 KeepAlive 页面返回时保留当前 Tab、滚动位置和交互状态；重新创建页面实例时沿用现有导航生命周期重新加载。
- 首屏请求未完成或 Tab 尚未 ready 时，`ion-scroll` 和分页入口都会按对应 Tab 的 `tabLoaded`、首屏 Promise、分页状态及 generation 进行隔离，阻止同一代重复的 offset 0 请求。
- 切换和恢复期间使用带序号的短生命周期 guard，忽略布局诱发的滚动事件；快速来回切换时不会保存尚未渲染容器的旧偏移，也不会由旧异步任务恢复错误 Tab。
- 删除记录继续即时更新当前列表；清空记录会使对应 Tab 缓存失效、清空本地数据并重置分页边界，下一次切回从 offset 0 刷新，同时阻止旧请求回写。
- 补充覆盖浏览/解析首屏 deferred 竞态、分页重复请求、目标滚动位置恢复、快速切换、KeepAlive 返回、删除和清空刷新行为的单元测试。

## 验证

- `NODE_OPTIONS='--localstorage-file=.vitest-localstorage.json' npm run test:unit`：43 个测试文件、261 个测试全部通过。
- `npm run test:unit -- tests/unit/HistoryPage.test.ts`：13 个测试全部通过。
- `npm run lint`：通过。
- `npx prettier --check src/views/HistoryPage.vue tests/unit/HistoryPage.test.ts`：通过。
- `git diff --check`：通过。
- 上一提交 `3f83a45` 的 GitHub Frontend、Build、Android、Instrumentation 和 CodeRabbit 检查均通过；本次修复已推送到同一 PR，等待最新提交 CI 更新。

## 兼容性

- 未修改 `HistoryService`、SQLite Bridge 或路由公共契约；数据加载和删除/清空 API 保持不变。
- 同一缓存页面实例继续保留现有状态；前进导航创建新页面实例时仍会重新加载最新历史数据。
- 未引入新的持久化数据格式或迁移路径。

ASTRA-11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 浏览历史与解析历史标签页首次访问时加载数据，切换时复用已加载内容。
  * 分别保存并恢复各标签页的滚动位置，提升切换及返回页面时的浏览体验。
  * 清空或删除历史记录后即时更新列表，并正确刷新对应标签页数据。

* **问题修复**
  * 修复首屏加载、滚动分页及快速切换期间的重复请求和过期数据问题。

* **测试**
  * 新增分页去重、数据缓存、滚动恢复、KeepAlive 返回及删除操作测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
