### PR TITLE
ASTRA-14：优化历史分组导航、计数与展开性能

### DIFF
--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/HistoryPluginContractInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/HistoryPluginContractInstrumentedTest.java
@@ -215,7 +215,7 @@ public class HistoryPluginContractInstrumentedTest {
     }
 
     @Test
-    public void allHistoryMethodsRemainNonKeepAlive() {
+    public void allHistoryMethodsRemainNonKeepAlive() throws Exception {
         RecordingPluginCall getBrowse = call("getBrowseHistory");
         RecordingPluginCall getBrowseOverview = call(
             "getBrowseHistoryOverview", "ranges", validRanges());

--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/HistoryPluginContractInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/HistoryPluginContractInstrumentedTest.java
@@ -1,6 +1,7 @@
 package io.github.jukomu.bridge;
 
 import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.getcapacitor.JSObject;
 import io.github.jukomu.bridge.handler.HistoryPluginHandler;
@@ -89,6 +90,70 @@ public class HistoryPluginContractInstrumentedTest {
     }
 
     @Test
+    public void browseOverviewAndRangePaginationUseAllRowsAndStableIdOrder() throws Exception {
+        plugin.recordBrowse(call("recordBrowse", "albumId", "album-1"));
+        plugin.recordBrowse(call("recordBrowse", "albumId", "album-2"));
+        plugin.recordBrowse(call("recordBrowse", "albumId", "album-3"));
+
+        RecordingPluginCall allRows = call("getBrowseHistory", "limit", 0);
+        plugin.getBrowseHistory(allRows);
+        JSONArray items = allRows.resolvedData.getJSONArray("items");
+        assertEquals(3, items.length());
+        long firstId = items.getJSONObject(0).getLong("id");
+        long secondId = items.getJSONObject(1).getLong("id");
+        long thirdId = items.getJSONObject(2).getLong("id");
+
+        HistoryStore store = HistoryStore.getInstance(context);
+        SQLiteDatabase db = store.getWritableDatabase();
+        db.execSQL("UPDATE browse_history SET timestamp = ? WHERE id = ?",
+            new Object[]{100L, firstId});
+        db.execSQL("UPDATE browse_history SET timestamp = ? WHERE id = ?",
+            new Object[]{100L, secondId});
+        db.execSQL("UPDATE browse_history SET timestamp = ? WHERE id = ?",
+            new Object[]{50L, thirdId});
+
+        JSONArray ranges = new JSONArray();
+        ranges.put(range("today", 100L, null));
+        ranges.put(range("yesterday", 50L, 100L));
+        ranges.put(range("thisWeek", 0L, 50L));
+        ranges.put(range("thisMonth", 0L, 0L));
+        ranges.put(range("lastThreeMonths", 0L, 0L));
+        ranges.put(range("lastSixMonths", 0L, 0L));
+        ranges.put(range("thisYear", 0L, 0L));
+        ranges.put(range("earlier", null, 0L));
+
+        RecordingPluginCall overview = call("getBrowseHistoryOverview", "ranges", ranges);
+        plugin.getBrowseHistoryOverview(overview);
+        assertEquals(3L, overview.resolvedData.getLong("totalCount"));
+        JSONObject groupCounts = overview.resolvedData.getJSONObject("groupCounts");
+        assertEquals(2L, groupCounts.getLong("today"));
+        assertEquals(1L, groupCounts.getLong("yesterday"));
+        assertEquals(0L, groupCounts.getLong("thisYear"));
+
+        RecordingPluginCall firstPage = call(
+            "getBrowseHistory", "limit", 1, "offset", 0,
+            "startInclusive", 100L);
+        plugin.getBrowseHistory(firstPage);
+        assertEquals(Math.max(firstId, secondId), firstPage.resolvedData.getJSONArray("items")
+            .getJSONObject(0).getLong("id"));
+
+        RecordingPluginCall secondPage = call(
+            "getBrowseHistory", "limit", 1, "offset", 1,
+            "startInclusive", 100L);
+        plugin.getBrowseHistory(secondPage);
+        assertEquals(Math.min(firstId, secondId), secondPage.resolvedData.getJSONArray("items")
+            .getJSONObject(0).getLong("id"));
+
+        RecordingPluginCall yesterday = call(
+            "getBrowseHistory", "limit", 10, "offset", 0,
+            "startInclusive", 50L, "endExclusive", 100L);
+        plugin.getBrowseHistory(yesterday);
+        assertEquals(1, yesterday.resolvedData.getJSONArray("items").length());
+        assertEquals(thirdId, yesterday.resolvedData.getJSONArray("items")
+            .getJSONObject(0).getLong("id"));
+    }
+
+    @Test
     public void deleteAndClearMethodsKeepTheirSuccessContract() throws Exception {
         plugin.recordBrowse(call("recordBrowse", "albumId", "album-1"));
         plugin.recordBrowse(call("recordBrowse", "albumId", "album-2"));
@@ -152,6 +217,8 @@ public class HistoryPluginContractInstrumentedTest {
     @Test
     public void allHistoryMethodsRemainNonKeepAlive() {
         RecordingPluginCall getBrowse = call("getBrowseHistory");
+        RecordingPluginCall getBrowseOverview = call(
+            "getBrowseHistoryOverview", "ranges", validRanges());
         RecordingPluginCall record = call("recordBrowse");
         RecordingPluginCall clearBrowse = call("clearBrowseHistory");
         RecordingPluginCall deleteBrowse = call("deleteBrowseItem");
@@ -161,6 +228,7 @@ public class HistoryPluginContractInstrumentedTest {
         RecordingPluginCall deleteParse = call("deleteParseItem");
 
         plugin.getBrowseHistory(getBrowse);
+        plugin.getBrowseHistoryOverview(getBrowseOverview);
         plugin.recordBrowse(record);
         plugin.clearBrowseHistory(clearBrowse);
         plugin.deleteBrowseItem(deleteBrowse);
@@ -169,7 +237,7 @@ public class HistoryPluginContractInstrumentedTest {
         plugin.clearParseHistory(clearParse);
         plugin.deleteParseItem(deleteParse);
 
-        assertNotKeptAlive(getBrowse, record, clearBrowse, deleteBrowse,
+        assertNotKeptAlive(getBrowse, getBrowseOverview, record, clearBrowse, deleteBrowse,
             getParse, addParse, clearParse, deleteParse);
     }
 
@@ -179,6 +247,27 @@ public class HistoryPluginContractInstrumentedTest {
             data.put((String) entries[index], entries[index + 1]);
         }
         return new RecordingPluginCall(methodName, data);
+    }
+
+    private static JSONObject range(String key, Long startInclusive, Long endExclusive)
+        throws Exception {
+        return new JSONObject()
+            .put("key", key)
+            .put("startInclusive", startInclusive == null ? JSONObject.NULL : startInclusive)
+            .put("endExclusive", endExclusive == null ? JSONObject.NULL : endExclusive);
+    }
+
+    private static JSONArray validRanges() throws Exception {
+        JSONArray ranges = new JSONArray();
+        ranges.put(range("today", null, null));
+        ranges.put(range("yesterday", null, null));
+        ranges.put(range("thisWeek", null, null));
+        ranges.put(range("thisMonth", null, null));
+        ranges.put(range("lastThreeMonths", null, null));
+        ranges.put(range("lastSixMonths", null, null));
+        ranges.put(range("thisYear", null, null));
+        ranges.put(range("earlier", null, null));
+        return ranges;
     }
 
     private static void assertSuccess(RecordingPluginCall call) throws Exception {

--- a/android/app/src/androidTest/java/io/github/jukomu/data/DatabaseMigrationTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/data/DatabaseMigrationTest.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import androidx.test.platform.app.InstrumentationRegistry;
 import io.github.jukomu.feature.favorite.data.FavoriteStore;
+import io.github.jukomu.feature.history.data.HistoryStore;
 import io.github.jukomu.platform.persistence.SettingsStore;
 import org.junit.Test;
 
@@ -85,6 +86,42 @@ public class DatabaseMigrationTest {
                 db,
                 "SELECT album_id FROM offline_favorites WHERE folder_id = ?",
                 new String[]{"folder-1"}));
+        } finally {
+            db.close();
+        }
+    }
+
+    @Test
+    public void historyUpgradeFromV2PreservesRowsAndCreatesBrowseIndex() throws Exception {
+        SQLiteDatabase db = SQLiteDatabase.create(null);
+        try {
+            db.execSQL("CREATE TABLE browse_history ("
+                + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                + "album_id TEXT NOT NULL,"
+                + "album_title TEXT NOT NULL,"
+                + "cover_url TEXT NOT NULL DEFAULT '',"
+                + "authors TEXT NOT NULL DEFAULT '',"
+                + "chapter_id TEXT NOT NULL DEFAULT '',"
+                + "chapter_title TEXT NOT NULL DEFAULT '',"
+                + "timestamp INTEGER NOT NULL)");
+            db.execSQL("CREATE TABLE parse_history ("
+                + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                + "text TEXT NOT NULL,"
+                + "timestamp INTEGER NOT NULL,"
+                + "mode TEXT NOT NULL DEFAULT 'single-mode')");
+            db.execSQL("INSERT INTO browse_history "
+                + "(album_id, album_title, timestamp) VALUES (?, ?, ?)",
+                new Object[]{"album-1", "title", 123L});
+
+            HistoryStore store = newStore(HistoryStore.class);
+            store.onUpgrade(db, 2, 3);
+
+            assertEquals(1, queryInt(db, "SELECT COUNT(*) FROM browse_history", null));
+            assertEquals(1, queryInt(db,
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' "
+                    + "AND name = 'idx_browse_history_timestamp_id'", null));
+            assertEquals("album-1", queryString(db,
+                "SELECT album_id FROM browse_history", null));
         } finally {
             db.close();
         }

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -763,6 +763,11 @@ public class JmcomicPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void getBrowseHistoryOverview(PluginCall call) {
+        historyHandler.getBrowseHistoryOverview(call);
+    }
+
+    @PluginMethod
     public void recordBrowse(PluginCall call) {
         historyHandler.recordBrowse(call);
     }

--- a/android/app/src/main/java/io/github/jukomu/bridge/handler/HistoryPluginHandler.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/handler/HistoryPluginHandler.java
@@ -2,6 +2,7 @@ package io.github.jukomu.bridge.handler;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import io.github.jukomu.feature.history.data.HistoryStore;
@@ -20,17 +21,36 @@ public final class HistoryPluginHandler {
     }
 
     /**
-     * 查询浏览历史；缺省分页参数均为 0，结果包含当前页 {@code items} 和全量
-     * {@code totalCount}。
+     * 查询浏览历史；缺省分页参数均为 0，结果包含当前页 {@code items} 和查询范围内的
+     * {@code totalCount}。时间边界为可选的左闭右开区间。
      */
     public void getBrowseHistory(PluginCall call) {
         try {
             int limit = call.getInt("limit", 0);
             int offset = call.getInt("offset", 0);
-            JSONObject data = historyStore.getBrowseHistory(limit, offset);
+            Long startInclusive = optionalLong(call, "startInclusive");
+            Long endExclusive = optionalLong(call, "endExclusive");
+            JSONObject data = historyStore.getBrowseHistory(
+                limit, offset, startInclusive, endExclusive);
             JSObject result = new JSObject();
             result.put("items", data.optJSONArray("items"));
             result.put("totalCount", data.optLong("totalCount", 0L));
+            call.resolve(result);
+        } catch (Exception error) {
+            call.reject(error.getMessage(), error);
+        }
+    }
+
+    /**
+     * 查询浏览历史概览；时间分组边界由前端生成后原样传入，Store 只负责聚合统计。
+     */
+    public void getBrowseHistoryOverview(PluginCall call) {
+        try {
+            JSONArray ranges = call.getData().getJSONArray("ranges");
+            JSONObject data = historyStore.getBrowseHistoryOverview(ranges);
+            JSObject result = new JSObject();
+            result.put("totalCount", data.getLong("totalCount"));
+            result.put("groupCounts", data.getJSONObject("groupCounts"));
             call.resolve(result);
         } catch (Exception error) {
             call.reject(error.getMessage(), error);
@@ -141,5 +161,20 @@ public final class HistoryPluginHandler {
         JSObject result = new JSObject();
         result.put("success", true);
         call.resolve(result);
+    }
+
+    private static Long optionalLong(PluginCall call, String key) throws Exception {
+        JSONObject data = call.getData();
+        if (!data.has(key) || data.isNull(key)) return null;
+        Object value = data.get(key);
+        if (!(value instanceof Number)) {
+            throw new IllegalArgumentException(key + " must be a finite integer");
+        }
+        double numericValue = ((Number) value).doubleValue();
+        if (!Double.isFinite(numericValue) || numericValue != Math.rint(numericValue)
+            || numericValue < Long.MIN_VALUE || numericValue > Long.MAX_VALUE) {
+            throw new IllegalArgumentException(key + " must be a finite integer");
+        }
+        return ((Number) value).longValue();
     }
 }

--- a/android/app/src/main/java/io/github/jukomu/feature/history/data/HistoryStore.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/history/data/HistoryStore.java
@@ -8,6 +8,10 @@ import android.database.sqlite.SQLiteOpenHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * 历史记录 SQLite 数据库。
  * <p>
@@ -17,7 +21,7 @@ import org.json.JSONObject;
 public class HistoryStore extends SQLiteOpenHelper {
 
     private static final String DB_NAME = "jq_history.db";
-    private static final int DB_VERSION = 2;
+    private static final int DB_VERSION = 3;
 
     private static final String TABLE_BROWSE = "browse_history";
     private static final String COL_ID = "id";
@@ -32,6 +36,12 @@ public class HistoryStore extends SQLiteOpenHelper {
     private static final String TABLE_PARSE = "parse_history";
     private static final String COL_TEXT = "text";
     private static final String COL_MODE = "mode";
+
+    private static final String BROWSE_INDEX = "idx_browse_history_timestamp_id";
+    private static final String[] BROWSE_GROUP_KEYS = {
+        "today", "yesterday", "thisWeek", "thisMonth",
+        "lastThreeMonths", "lastSixMonths", "thisYear", "earlier"
+    };
 
     private static HistoryStore instance;
 
@@ -65,12 +75,17 @@ public class HistoryStore extends SQLiteOpenHelper {
             + COL_TIMESTAMP + " INTEGER NOT NULL,"
             + COL_MODE + " TEXT NOT NULL DEFAULT 'single-mode'"
             + ")");
+
+        createBrowseHistoryIndex(db);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         if (oldVersion < 2) {
             db.execSQL("ALTER TABLE " + TABLE_PARSE + " ADD COLUMN " + COL_MODE + " TEXT NOT NULL DEFAULT 'single-mode'");
+        }
+        if (oldVersion < 3) {
+            createBrowseHistoryIndex(db);
         }
     }
 
@@ -128,23 +143,32 @@ public class HistoryStore extends SQLiteOpenHelper {
     }
 
     /**
-     * 获取浏览历史（按 timestamp DESC），支持 offset/limit 分页，并返回全量记录数。
+     * 获取浏览历史（按 timestamp DESC, id DESC），支持 offset/limit 分页，并返回全量记录数。
      */
     public JSONObject getBrowseHistory(int limit, int offset) {
+        return getBrowseHistory(limit, offset, null, null);
+    }
+
+    /**
+     * 获取指定时间范围内的浏览历史。范围使用左闭右开区间；空区间直接返回空页。
+     */
+    public JSONObject getBrowseHistory(int limit, int offset,
+                                       Long startInclusive, Long endExclusive) {
         JSONObject result = new JSONObject();
         JSONArray arr = new JSONArray();
         Cursor dataCursor = null;
         try {
             SQLiteDatabase db = getReadableDatabase();
-            long totalCount = countRows(TABLE_BROWSE);
+            RangeSelection range = buildRangeSelection(startInclusive, endExclusive);
+            long totalCount = countRows(TABLE_BROWSE, range.selection, range.args);
             String limitClause = limit > 0
                 ? (offset > 0 ? offset + "," + limit : String.valueOf(limit))
                 : null;
             dataCursor = db.query(TABLE_BROWSE,
                 new String[]{COL_ID, COL_ALBUM_ID, COL_ALBUM_TITLE, COL_COVER_URL, COL_AUTHORS,
                     COL_CHAPTER_ID, COL_CHAPTER_TITLE, COL_TIMESTAMP},
-                null, null, null, null,
-                COL_TIMESTAMP + " DESC",
+                range.selection, range.args, null, null,
+                COL_TIMESTAMP + " DESC, " + COL_ID + " DESC",
                 limitClause);
             while (dataCursor.moveToNext()) {
                 JSONObject obj = new JSONObject();
@@ -171,6 +195,67 @@ public class HistoryStore extends SQLiteOpenHelper {
         } finally {
             if (dataCursor != null) dataCursor.close();
         }
+        return result;
+    }
+
+    /**
+     * 使用一次条件聚合查询返回总数及各时间范围的记录数。
+     */
+    public JSONObject getBrowseHistoryOverview(JSONArray ranges) throws Exception {
+        if (ranges == null || ranges.length() != BROWSE_GROUP_KEYS.length) {
+            throw new IllegalArgumentException("ranges must contain exactly eight groups");
+        }
+
+        ArrayList<BrowseRange> parsedRanges = new ArrayList<>();
+        Set<String> seenKeys = new HashSet<>();
+        for (int index = 0; index < ranges.length(); index++) {
+            JSONObject rangeObject = ranges.getJSONObject(index);
+            String key = rangeObject.optString("key", "").trim();
+            if (!isBrowseGroupKey(key) || !seenKeys.add(key)) {
+                throw new IllegalArgumentException("invalid or duplicate browse group key: " + key);
+            }
+            Long startInclusive = optionalLong(rangeObject, "startInclusive");
+            Long endExclusive = optionalLong(rangeObject, "endExclusive");
+            parsedRanges.add(new BrowseRange(key, startInclusive, endExclusive));
+        }
+        for (String key : BROWSE_GROUP_KEYS) {
+            if (!seenKeys.contains(key)) {
+                throw new IllegalArgumentException("missing browse group key: " + key);
+            }
+        }
+
+        StringBuilder query = new StringBuilder("SELECT COUNT(*)");
+        ArrayList<String> selectionArgs = new ArrayList<>();
+        for (int index = 0; index < parsedRanges.size(); index++) {
+            BrowseRange range = parsedRanges.get(index);
+            query.append(", SUM(CASE WHEN ");
+            RangeSelection selection = buildRangeSelection(range.startInclusive, range.endExclusive);
+            if (selection.selection == null) {
+                query.append("1=1");
+            } else {
+                query.append(selection.selection);
+                for (String arg : selection.args) selectionArgs.add(arg);
+            }
+            query.append(" THEN 1 ELSE 0 END) AS group_").append(index);
+        }
+        query.append(" FROM ").append(TABLE_BROWSE);
+
+        JSONObject result = new JSONObject();
+        JSONObject groupCounts = new JSONObject();
+        try (Cursor cursor = getReadableDatabase().rawQuery(
+            query.toString(), selectionArgs.toArray(new String[0]))) {
+            if (!cursor.moveToFirst()) {
+                throw new IllegalStateException("browse history overview query returned no row");
+            }
+            result.put("totalCount", cursor.getLong(0));
+            for (int index = 0; index < parsedRanges.size(); index++) {
+                groupCounts.put(parsedRanges.get(index).key, cursor.getLong(index + 1));
+            }
+        } catch (Exception error) {
+            android.util.Log.w("HistoryStore", "getBrowseHistoryOverview failed", error);
+            throw error;
+        }
+        result.put("groupCounts", groupCounts);
         return result;
     }
 
@@ -276,12 +361,84 @@ public class HistoryStore extends SQLiteOpenHelper {
     }
 
     private long countRows(String table) {
+        return countRows(table, null, null);
+    }
+
+    private long countRows(String table, String selection, String[] selectionArgs) {
         try (Cursor cursor = getReadableDatabase().rawQuery(
-            "SELECT COUNT(*) FROM " + table, null)) {
+            "SELECT COUNT(*) FROM " + table
+                + (selection == null ? "" : " WHERE " + selection), selectionArgs)) {
             return cursor.moveToFirst() ? cursor.getLong(0) : 0L;
         } catch (Exception e) {
             android.util.Log.w("HistoryStore", "countRows failed for " + table, e);
             return 0L;
+        }
+    }
+
+    private static void createBrowseHistoryIndex(SQLiteDatabase db) {
+        db.execSQL("CREATE INDEX IF NOT EXISTS " + BROWSE_INDEX + " ON " + TABLE_BROWSE
+            + " (" + COL_TIMESTAMP + " DESC, " + COL_ID + " DESC)");
+    }
+
+    private static boolean isBrowseGroupKey(String key) {
+        for (String validKey : BROWSE_GROUP_KEYS) {
+            if (validKey.equals(key)) return true;
+        }
+        return false;
+    }
+
+    private static Long optionalLong(JSONObject object, String key) throws Exception {
+        if (!object.has(key) || object.isNull(key)) return null;
+        Object value = object.get(key);
+        if (!(value instanceof Number)) {
+            throw new IllegalArgumentException(key + " must be a finite integer");
+        }
+        double numericValue = ((Number) value).doubleValue();
+        if (!Double.isFinite(numericValue) || numericValue != Math.rint(numericValue)
+            || numericValue < Long.MIN_VALUE || numericValue > Long.MAX_VALUE) {
+            throw new IllegalArgumentException(key + " must be a finite integer");
+        }
+        return ((Number) value).longValue();
+    }
+
+    private static RangeSelection buildRangeSelection(Long startInclusive, Long endExclusive) {
+        if (startInclusive != null && endExclusive != null && startInclusive >= endExclusive) {
+            return new RangeSelection("1=0", new String[0]);
+        }
+        if (startInclusive == null && endExclusive == null) {
+            return new RangeSelection(null, null);
+        }
+        if (startInclusive == null) {
+            return new RangeSelection(COL_TIMESTAMP + " < ?",
+                new String[]{String.valueOf(endExclusive)});
+        }
+        if (endExclusive == null) {
+            return new RangeSelection(COL_TIMESTAMP + " >= ?",
+                new String[]{String.valueOf(startInclusive)});
+        }
+        return new RangeSelection(COL_TIMESTAMP + " >= ? AND " + COL_TIMESTAMP + " < ?",
+            new String[]{String.valueOf(startInclusive), String.valueOf(endExclusive)});
+    }
+
+    private static final class BrowseRange {
+        private final String key;
+        private final Long startInclusive;
+        private final Long endExclusive;
+
+        private BrowseRange(String key, Long startInclusive, Long endExclusive) {
+            this.key = key;
+            this.startInclusive = startInclusive;
+            this.endExclusive = endExclusive;
+        }
+    }
+
+    private static final class RangeSelection {
+        private final String selection;
+        private final String[] args;
+
+        private RangeSelection(String selection, String[] args) {
+            this.selection = selection;
+            this.args = args;
         }
     }
 }

--- a/src/services/HistoryService.ts
+++ b/src/services/HistoryService.ts
@@ -1,4 +1,10 @@
-import type { BrowseHistoryItem, HistoryPageResult, ParseHistoryItem } from './JmcomicTypes'
+import type {
+  BrowseHistoryItem,
+  BrowseHistoryOverview,
+  BrowseHistoryRange,
+  HistoryPageResult,
+  ParseHistoryItem,
+} from './JmcomicTypes'
 import { JmcomicService } from './JmcomicService'
 
 // ---- localStorage 搜索历史（有界，500 条/上下文）----
@@ -60,12 +66,27 @@ export const HistoryService = {
   async getBrowseHistory(
     limit: number = 50,
     offset: number = 0,
+    range?: Pick<BrowseHistoryRange, 'startInclusive' | 'endExclusive'>,
   ): Promise<HistoryPageResult<BrowseHistoryItem> | null> {
     try {
-      const result = await JmcomicService.getBrowseHistory(limit, offset)
+      const result = await JmcomicService.getBrowseHistory(limit, offset, range)
       return {
         items: result.items as BrowseHistoryItem[],
         totalCount: result.totalCount,
+      }
+    } catch {
+      return null
+    }
+  },
+
+  async getBrowseHistoryOverview(
+    ranges: readonly BrowseHistoryRange[],
+  ): Promise<BrowseHistoryOverview | null> {
+    try {
+      const result = await JmcomicService.getBrowseHistoryOverview(ranges)
+      return {
+        totalCount: result.totalCount,
+        groupCounts: result.groupCounts,
       }
     } catch {
       return null

--- a/src/services/JmcomicTypes.ts
+++ b/src/services/JmcomicTypes.ts
@@ -416,6 +416,29 @@ export interface LatencyResult {
 
 // --- 历史记录 ---
 
+export type BrowseHistoryGroupKey =
+  | 'today'
+  | 'yesterday'
+  | 'thisWeek'
+  | 'thisMonth'
+  | 'lastThreeMonths'
+  | 'lastSixMonths'
+  | 'thisYear'
+  | 'earlier'
+
+export interface BrowseHistoryRange {
+  key: BrowseHistoryGroupKey
+  startInclusive: number | null
+  endExclusive: number | null
+}
+
+export type BrowseHistoryGroupCounts = Record<BrowseHistoryGroupKey, number>
+
+export interface BrowseHistoryOverview {
+  totalCount: number
+  groupCounts: BrowseHistoryGroupCounts
+}
+
 export interface HistoryPageResult<T> {
   items: T[]
   totalCount: number

--- a/src/services/jmcomic/JmcomicClient.ts
+++ b/src/services/jmcomic/JmcomicClient.ts
@@ -1,7 +1,9 @@
 import type {
   AlbumDetail,
   AllSettings,
+  BrowseHistoryOverview,
   BrowseHistoryItem,
+  BrowseHistoryRange,
   CacheCapacityInfo,
   CommentList,
   DomainStates,
@@ -189,7 +191,13 @@ export interface JmcomicClient {
   getBrowseHistory(options: {
     limit: number
     offset: number
+    startInclusive?: number | null
+    endExclusive?: number | null
   }): Promise<HistoryPageResult<BrowseHistoryItem>>
+
+  getBrowseHistoryOverview(options: {
+    ranges: readonly BrowseHistoryRange[]
+  }): Promise<BrowseHistoryOverview>
 
   recordBrowse(options: {
     albumId: string

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -1,5 +1,6 @@
 import { createAppAlert } from '@/services/AppAlertService'
 import type {
+  BrowseHistoryRange,
   BrowseHistoryItem,
   DownloadProgressEvent,
   FavoriteQuery,
@@ -347,8 +348,19 @@ export const JmcomicService = {
 
   // ========== 浏览历史 ==========
 
-  getBrowseHistory(limit: number, offset: number = 0) {
-    return native.getBrowseHistory({ limit, offset })
+  getBrowseHistory(
+    limit: number,
+    offset: number = 0,
+    range?: Pick<BrowseHistoryRange, 'startInclusive' | 'endExclusive'>,
+  ) {
+    return native.getBrowseHistory({
+      limit,
+      offset,
+      ...(range ? { startInclusive: range.startInclusive, endExclusive: range.endExclusive } : {}),
+    })
+  },
+  getBrowseHistoryOverview(ranges: readonly BrowseHistoryRange[]) {
+    return native.getBrowseHistoryOverview({ ranges })
   },
   recordBrowse(item: Omit<BrowseHistoryItem, 'id' | 'timestamp'>) {
     return native.recordBrowse(item)

--- a/src/utils/historyDateGroups.ts
+++ b/src/utils/historyDateGroups.ts
@@ -1,14 +1,10 @@
-import type { BrowseHistoryItem } from '@/services/JmcomicTypes'
+import type {
+  BrowseHistoryGroupKey,
+  BrowseHistoryItem,
+  BrowseHistoryRange,
+} from '@/services/JmcomicTypes'
 
-export type BrowseGroupKey =
-  | 'today'
-  | 'yesterday'
-  | 'thisWeek'
-  | 'thisMonth'
-  | 'lastThreeMonths'
-  | 'lastSixMonths'
-  | 'thisYear'
-  | 'earlier'
+export type BrowseGroupKey = BrowseHistoryGroupKey
 
 export interface BrowseHistoryGroup {
   key: BrowseGroupKey
@@ -30,6 +26,11 @@ export const BROWSE_GROUP_DEFINITIONS = [
 interface BrowseGroupBoundary {
   key: Exclude<BrowseGroupKey, 'earlier'>
   startMs: number
+}
+
+export interface BrowseHistoryGroupSnapshot {
+  nowMs: number
+  ranges: readonly BrowseHistoryRange[]
 }
 
 function startOfLocalDay(year: number, month: number, date: number): number {
@@ -65,14 +66,41 @@ function buildBoundaries(nowMs: number): BrowseGroupBoundary[] {
   ]
 }
 
-function getGroupKey(
-  timestamp: number,
-  boundaries: readonly BrowseGroupBoundary[],
-): BrowseGroupKey {
+function getMinimumStart(boundaries: readonly BrowseGroupBoundary[], endExclusive: number): number {
+  return Math.min(...boundaries.slice(0, endExclusive).map((boundary) => boundary.startMs))
+}
+
+export function createBrowseHistorySnapshot(
+  nowMs: number = Date.now(),
+): BrowseHistoryGroupSnapshot {
+  const candidate = new Date(nowMs).getTime()
+  const snapshotNowMs = Number.isFinite(candidate) ? nowMs : Date.now()
+  const boundaries = buildBoundaries(snapshotNowMs)
+  const ranges = BROWSE_GROUP_DEFINITIONS.map(({ key }) => {
+    if (key === 'earlier') {
+      return {
+        key,
+        startInclusive: null,
+        endExclusive: getMinimumStart(boundaries, boundaries.length),
+      }
+    }
+
+    const boundaryIndex = boundaries.findIndex((boundary) => boundary.key === key)
+    const startInclusive = boundaries[boundaryIndex]?.startMs ?? null
+    const endExclusive = boundaryIndex > 0 ? getMinimumStart(boundaries, boundaryIndex) : null
+    return { key, startInclusive, endExclusive }
+  })
+
+  return { nowMs: snapshotNowMs, ranges }
+}
+
+function getGroupKey(timestamp: number, snapshot: BrowseHistoryGroupSnapshot): BrowseGroupKey {
   if (!Number.isFinite(timestamp)) return 'earlier'
 
-  for (const boundary of boundaries) {
-    if (timestamp >= boundary.startMs) return boundary.key
+  for (const range of snapshot.ranges) {
+    if (range.startInclusive !== null && timestamp < range.startInclusive) continue
+    if (range.endExclusive !== null && timestamp >= range.endExclusive) continue
+    return range.key
   }
   return 'earlier'
 }
@@ -81,11 +109,11 @@ export function groupBrowseHistory(
   items: readonly BrowseHistoryItem[],
   nowMs: number = Date.now(),
 ): BrowseHistoryGroup[] {
-  const boundaries = buildBoundaries(nowMs)
+  const snapshot = createBrowseHistorySnapshot(nowMs)
   const itemsByKey = new Map<BrowseGroupKey, BrowseHistoryItem[]>()
 
   for (const item of items) {
-    const key = getGroupKey(item.timestamp, boundaries)
+    const key = getGroupKey(item.timestamp, snapshot)
     const groupItems = itemsByKey.get(key)
     if (groupItems) groupItems.push(item)
     else itemsByKey.set(key, [item])

--- a/src/views/HistoryPage.vue
+++ b/src/views/HistoryPage.vue
@@ -28,7 +28,15 @@
     <IonContent ref="contentRef" :scroll-events="true" @ion-scroll="onScroll">
       <div class="page-shell">
         <div v-if="activeTab === 'browse'" class="tab-content">
-          <div v-if="browseItems.length === 0" class="empty-state">
+          <div v-if="!browseOverviewLoaded && browseOverviewError" class="history-error">
+            <IonIcon :icon="timeOutline" class="empty-icon" />
+            <p>浏览历史加载失败</p>
+            <button type="button" class="retry-btn" @click="retryBrowseOverview">重试</button>
+          </div>
+          <div v-else-if="!browseOverviewLoaded" class="empty-state">
+            <IonSpinner name="dots" />
+          </div>
+          <div v-else-if="browseGroups.length === 0" class="empty-state">
             <IonIcon :icon="timeOutline" class="empty-icon" />
             <p>暂无浏览记录</p>
             <p class="empty-hint">开始浏览本子，记录将自动出现在这里</p>
@@ -38,7 +46,7 @@
               <span class="section-title">共 {{ browseTotalCount }} 条记录</span>
               <button type="button" class="clear-btn" @click="confirmClearBrowse">清空</button>
             </div>
-            <TransitionGroup name="history-list" tag="div" class="card-list">
+            <div class="card-list">
               <section v-for="group in browseGroups" :key="group.key" class="date-group">
                 <h2 class="date-group-heading">
                   <button
@@ -50,7 +58,10 @@
                     :aria-label="`${isBrowseGroupCollapsed(group.key) ? '展开' : '收起'}${group.label}`"
                     @click="toggleBrowseGroup(group.key)"
                   >
-                    <span>{{ group.label }}</span>
+                    <span>
+                      {{ group.label }}
+                      <span class="date-group-count">({{ group.totalCount }})</span>
+                    </span>
                     <IonIcon
                       class="date-group-toggle-icon"
                       :class="{ collapsed: isBrowseGroupCollapsed(group.key) }"
@@ -59,51 +70,65 @@
                     />
                   </button>
                 </h2>
-                <Transition name="history-drawer">
-                  <div
-                    v-if="!isBrowseGroupCollapsed(group.key)"
-                    :id="browseGroupContentId(group.key)"
-                    class="date-group-content"
-                    role="region"
-                    :aria-labelledby="browseGroupToggleId(group.key)"
-                  >
-                    <div class="date-group-content-inner">
-                      <TransitionGroup name="history-list" tag="div" class="date-group-cards">
-                        <div
-                          v-for="item in group.items"
-                          :key="item.id"
-                          class="browse-card"
-                          @click="openAlbum(item)"
-                        >
-                          <div class="card-cover-wrap">
-                            <img :src="item.coverUrl" class="card-cover" alt="" loading="lazy" />
-                          </div>
-                          <div class="card-body">
-                            <h3 class="card-title">{{ item.albumTitle }}</h3>
-                            <div class="card-id">ID: {{ item.albumId }}</div>
-                            <div class="card-meta">作者：{{ item.authors }}</div>
-                            <div class="card-meta">{{ formatRelativeTime(item.timestamp) }}</div>
-                            <div v-if="item.chapterTitle" class="card-chapter">
-                              <IonIcon :icon="bookOutline" class="chapter-icon" />
-                              <span>{{ item.chapterTitle }}</span>
-                            </div>
-                          </div>
-                          <button
-                            type="button"
-                            class="card-more-btn"
-                            :class="{ active: contextMenu?.item.id === item.id }"
-                            aria-label="更多操作"
-                            @click.stop="openContextMenu(item, $event)"
-                          >
-                            <IonIcon :icon="ellipsisVertical" />
-                          </button>
+                <div
+                  v-show="!isBrowseGroupCollapsed(group.key)"
+                  :id="browseGroupContentId(group.key)"
+                  class="date-group-content"
+                  role="region"
+                  :aria-labelledby="browseGroupToggleId(group.key)"
+                >
+                  <div class="date-group-content-inner">
+                    <div class="date-group-cards">
+                      <div
+                        v-for="item in group.items"
+                        :key="item.id"
+                        class="browse-card"
+                        @click="openAlbum(item)"
+                      >
+                        <div class="card-cover-wrap">
+                          <img :src="item.coverUrl" class="card-cover" alt="" loading="lazy" />
                         </div>
-                      </TransitionGroup>
+                        <div class="card-body">
+                          <h3 class="card-title">{{ item.albumTitle }}</h3>
+                          <div class="card-id">ID: {{ item.albumId }}</div>
+                          <div class="card-meta">作者：{{ item.authors }}</div>
+                          <div class="card-meta">{{ formatRelativeTime(item.timestamp) }}</div>
+                          <div v-if="item.chapterTitle" class="card-chapter">
+                            <IonIcon :icon="bookOutline" class="chapter-icon" />
+                            <span>{{ item.chapterTitle }}</span>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          class="card-more-btn"
+                          :class="{ active: contextMenu?.item.id === item.id }"
+                          aria-label="更多操作"
+                          @click.stop="openContextMenu(item, $event)"
+                        >
+                          <IonIcon :icon="ellipsisVertical" />
+                        </button>
+                      </div>
                     </div>
+                    <div
+                      :ref="(element) => setBrowseGroupSentinel(group.key, element)"
+                      class="browse-group-sentinel"
+                      aria-hidden="true"
+                    ></div>
+                    <div v-if="group.loading" class="browse-group-loader">
+                      <IonSpinner name="dots" />
+                    </div>
+                    <button
+                      v-else-if="group.error"
+                      type="button"
+                      class="browse-group-retry"
+                      @click="retryBrowseGroup(group.key)"
+                    >
+                      加载失败，点击重试
+                    </button>
                   </div>
-                </Transition>
+                </div>
               </section>
-            </TransitionGroup>
+            </div>
           </template>
         </div>
 
@@ -118,7 +143,7 @@
               <span class="section-title">共 {{ parseTotalCount }} 条记录</span>
               <button type="button" class="clear-btn" @click="confirmClearParse">清空</button>
             </div>
-            <TransitionGroup name="history-list" tag="div" class="card-list">
+            <TransitionGroup name="parse-history-list" tag="div" class="card-list">
               <div
                 v-for="item in parseItems"
                 :key="item.id"
@@ -154,7 +179,7 @@
           </template>
         </div>
 
-        <div v-if="loadingMoreByTab[activeTab]" class="history-list-loader">
+        <div v-if="activeTab === 'parse' && loadingMoreByTab.parse" class="history-list-loader">
           <IonSpinner name="dots" />
         </div>
       </div>
@@ -173,6 +198,7 @@
 defineOptions({ name: 'HistoryPage' })
 
 import { computed, nextTick, onActivated, onDeactivated, onMounted, reactive, ref } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import { useRouter } from 'vue-router'
 import { IonContent, IonIcon, IonPage, IonSpinner } from '@ionic/vue'
 import { createAppAlert } from '@/services/AppAlertService'
@@ -192,8 +218,8 @@ import type {
   HistoryPageResult,
   ParseHistoryItem,
 } from '@/services/JmcomicTypes'
-import { groupBrowseHistory } from '@/utils/historyDateGroups'
-import type { BrowseGroupKey } from '@/utils/historyDateGroups'
+import { BROWSE_GROUP_DEFINITIONS, createBrowseHistorySnapshot } from '@/utils/historyDateGroups'
+import type { BrowseGroupKey, BrowseHistoryGroupSnapshot } from '@/utils/historyDateGroups'
 import MenuToggleButton from '@/components/common/MenuToggleButton.vue'
 import CardContextMenu from '@/components/common/CardContextMenu.vue'
 
@@ -204,16 +230,14 @@ const scrollEl = ref<HTMLElement | null>(null)
 type HistoryTab = 'browse' | 'parse'
 
 const activeTab = ref<HistoryTab>('browse')
-const browseItems = ref<BrowseHistoryItem[]>([])
 const parseItems = ref<ParseHistoryItem[]>([])
 const browseTotalCount = ref(0)
 const parseTotalCount = ref(0)
-const browseHasMore = ref(true)
 const parseHasMore = ref(true)
 const loadingMoreByTab = reactive<Record<HistoryTab, boolean>>({ browse: false, parse: false })
 const tabLoaded = reactive<Record<HistoryTab, boolean>>({ browse: false, parse: false })
 const tabHasSnapshotMetadata = reactive<Record<HistoryTab, boolean>>({
-  browse: false,
+  browse: true,
   parse: false,
 })
 const tabLoadPromises: Record<HistoryTab, Promise<void> | null> = {
@@ -225,10 +249,59 @@ const tabScrollPositions = reactive<Record<HistoryTab, number>>({ browse: 0, par
 const isTabTransitioning = ref(false)
 let tabTransitionId = 0
 let wasDeactivated = false
-const groupingNow = ref(Date.now())
 const collapsedBrowseGroups = ref<Set<BrowseGroupKey>>(new Set())
 
-const browseGroups = computed(() => groupBrowseHistory(browseItems.value, groupingNow.value))
+interface BrowseGroupState {
+  key: BrowseGroupKey
+  label: string
+  startInclusive: number | null
+  endExclusive: number | null
+  items: BrowseHistoryItem[]
+  totalCount: number
+  offset: number
+  hasMore: boolean
+  loaded: boolean
+  loading: boolean
+  error: boolean
+  generation: number
+}
+
+function createBrowseGroupState(key: BrowseGroupKey, label: string): BrowseGroupState {
+  return {
+    key,
+    label,
+    startInclusive: null,
+    endExclusive: null,
+    items: [],
+    totalCount: 0,
+    offset: 0,
+    hasMore: false,
+    loaded: false,
+    loading: false,
+    error: false,
+    generation: 0,
+  }
+}
+
+const browseGroupStates = reactive(
+  Object.fromEntries(
+    BROWSE_GROUP_DEFINITIONS.map(({ key, label }) => [key, createBrowseGroupState(key, label)]),
+  ) as Record<BrowseGroupKey, BrowseGroupState>,
+)
+const browseSnapshot = ref<BrowseHistoryGroupSnapshot | null>(null)
+const browseOverviewLoaded = ref(false)
+const browseOverviewLoading = ref(false)
+const browseOverviewError = ref(false)
+const browseGroupPromises = new Map<BrowseGroupKey, Promise<void>>()
+const browseGroupSentinels = new Map<BrowseGroupKey, HTMLElement>()
+
+const browseGroups = computed(() => {
+  const snapshot = browseSnapshot.value
+  if (!snapshot) return []
+  return snapshot.ranges
+    .map((range) => browseGroupStates[range.key])
+    .filter((group) => group.totalCount > 0)
+})
 
 function browseGroupToggleId(key: BrowseGroupKey): string {
   return `history-group-toggle-${key}`
@@ -245,12 +318,10 @@ function isBrowseGroupCollapsed(key: BrowseGroupKey): boolean {
 function isContextMenuInBrowseGroup(key: BrowseGroupKey): boolean {
   const menu = contextMenu.value
   if (!menu || menu.type !== 'browse') return false
-  return browseGroups.value.some(
-    (group) => group.key === key && group.items.some((item) => item.id === menu.item.id),
-  )
+  return browseGroupStates[key].items.some((item) => item.id === menu.item.id)
 }
 
-function toggleBrowseGroup(key: BrowseGroupKey) {
+async function toggleBrowseGroup(key: BrowseGroupKey) {
   const next = new Set(collapsedBrowseGroups.value)
   if (next.has(key)) next.delete(key)
   else {
@@ -258,16 +329,14 @@ function toggleBrowseGroup(key: BrowseGroupKey) {
     next.add(key)
   }
   collapsedBrowseGroups.value = next
-}
-
-function pruneCollapsedBrowseGroups() {
-  const visibleKeys = new Set(browseGroups.value.map((group) => group.key))
-  const next = new Set([...collapsedBrowseGroups.value].filter((key) => visibleKeys.has(key)))
-  if (next.size !== collapsedBrowseGroups.value.size) collapsedBrowseGroups.value = next
-}
-
-function refreshBrowseGrouping() {
-  groupingNow.value = Date.now()
+  if (!next.has(key)) {
+    await nextTick()
+    const group = browseGroupStates[key]
+    if (group.totalCount > 0 && (!group.loaded || group.error)) {
+      void loadBrowseGroup(key)
+    }
+    void checkBrowseGroupSentinels()
+  }
 }
 
 type IonContentElement = HTMLElement & {
@@ -280,6 +349,14 @@ async function resolveScrollElement(): Promise<HTMLElement | null> {
   if (!contentEl?.getScrollElement) return null
   scrollEl.value = await contentEl.getScrollElement()
   return scrollEl.value
+}
+
+function setBrowseGroupSentinel(
+  key: BrowseGroupKey,
+  element: Element | ComponentPublicInstance | null,
+) {
+  if (element instanceof HTMLElement) browseGroupSentinels.set(key, element)
+  else browseGroupSentinels.delete(key)
 }
 
 interface NormalizedHistoryPage<T> extends HistoryPageResult<T> {
@@ -301,52 +378,192 @@ function normalizeHistoryPage<T>(
   }
 }
 
-function updateBrowseTotalCount(
-  totalCount: number,
-  hasMore = browseItems.value.length < totalCount,
-) {
-  browseTotalCount.value = Math.max(0, totalCount)
-  browseHasMore.value = hasMore
-}
-
 function updateParseTotalCount(totalCount: number, hasMore = parseItems.value.length < totalCount) {
   parseTotalCount.value = Math.max(0, totalCount)
   parseHasMore.value = hasMore
 }
 
-async function loadBrowse(generation = tabRequestGeneration.browse): Promise<boolean> {
-  const page = normalizeHistoryPage(await HistoryService.getBrowseHistory(PAGE_SIZE, 0))
-  if (!page || generation !== tabRequestGeneration.browse) return false
-  browseItems.value = page.items
-  tabHasSnapshotMetadata.browse = !page.legacyArray
-  updateBrowseTotalCount(
-    page.totalCount,
-    page.legacyArray ? page.items.length === PAGE_SIZE : page.items.length < page.totalCount,
-  )
-  refreshBrowseGrouping()
-  return true
+function getBrowseGroupCount(
+  groupCounts: Partial<Record<BrowseGroupKey, number>>,
+  key: BrowseGroupKey,
+): number {
+  const count = groupCounts[key]
+  return Number.isFinite(count) ? Math.max(0, count as number) : 0
 }
 
-async function loadMoreBrowse() {
-  if (!isTabReadyForPagination('browse') || loadingMoreByTab.browse || !browseHasMore.value) return
-  loadingMoreByTab.browse = true
-  const generation = tabRequestGeneration.browse
-  try {
-    const page = normalizeHistoryPage(
-      await HistoryService.getBrowseHistory(PAGE_SIZE, browseItems.value.length),
+function applyBrowseOverview(
+  snapshot: BrowseHistoryGroupSnapshot,
+  totalCount: number,
+  groupCounts: Partial<Record<BrowseGroupKey, number>>,
+) {
+  browseSnapshot.value = snapshot
+  browseTotalCount.value = Number.isFinite(totalCount) ? Math.max(0, totalCount) : 0
+
+  for (const range of snapshot.ranges) {
+    const group = browseGroupStates[range.key]
+    group.label = BROWSE_GROUP_DEFINITIONS.find((definition) => definition.key === range.key)!.label
+    group.startInclusive = range.startInclusive
+    group.endExclusive = range.endExclusive
+    group.totalCount = getBrowseGroupCount(groupCounts, range.key)
+    if (group.totalCount === 0) {
+      group.items.splice(0)
+      group.offset = 0
+      group.hasMore = false
+      group.loaded = false
+      group.loading = false
+      group.error = false
+    } else {
+      group.hasMore = group.offset < group.totalCount
+    }
+  }
+}
+
+function isBrowseGroupLoadCurrent(
+  key: BrowseGroupKey,
+  groupGeneration: number,
+  browseGeneration: number,
+): boolean {
+  return (
+    browseGeneration === tabRequestGeneration.browse &&
+    groupGeneration === browseGroupStates[key].generation
+  )
+}
+
+function loadBrowseGroup(
+  key: BrowseGroupKey,
+  options: {
+    reset?: boolean
+    targetCount?: number
+    browseGeneration?: number
+  } = {},
+): Promise<void> {
+  const existingPromise = browseGroupPromises.get(key)
+  if (existingPromise) return existingPromise
+
+  const group = browseGroupStates[key]
+  if (group.totalCount <= 0) return Promise.resolve()
+  if (!options.reset && group.loaded && !group.hasMore && !group.error) {
+    return Promise.resolve()
+  }
+
+  if (options.reset) {
+    group.generation += 1
+    group.items.splice(0)
+    group.offset = 0
+    group.loaded = false
+    group.hasMore = group.totalCount > 0
+    group.error = false
+  }
+
+  const groupGeneration = group.generation
+  const browseGeneration = options.browseGeneration ?? tabRequestGeneration.browse
+  const targetCount = Math.max(group.items.length + PAGE_SIZE, options.targetCount ?? 0)
+  const task = (async () => {
+    group.loading = true
+    group.error = false
+    try {
+      while (
+        isBrowseGroupLoadCurrent(key, groupGeneration, browseGeneration) &&
+        group.hasMore &&
+        group.items.length < targetCount
+      ) {
+        const page = normalizeHistoryPage(
+          await HistoryService.getBrowseHistory(PAGE_SIZE, group.offset, {
+            startInclusive: group.startInclusive,
+            endExclusive: group.endExclusive,
+          }),
+        )
+        if (!isBrowseGroupLoadCurrent(key, groupGeneration, browseGeneration)) return
+        if (!page) {
+          group.error = true
+          return
+        }
+
+        if (!page.legacyArray) group.totalCount = Math.max(0, page.totalCount)
+        const knownIds = new Set(group.items.map((item) => item.id))
+        for (const item of page.items) {
+          if (!knownIds.has(item.id)) {
+            group.items.push(item)
+            knownIds.add(item.id)
+          }
+        }
+        group.offset += page.items.length
+        group.loaded = true
+        group.hasMore = page.legacyArray
+          ? page.items.length === PAGE_SIZE
+          : page.items.length > 0 && group.offset < group.totalCount
+        if (page.items.length === 0) group.hasMore = false
+      }
+    } catch {
+      if (isBrowseGroupLoadCurrent(key, groupGeneration, browseGeneration)) group.error = true
+    } finally {
+      if (isBrowseGroupLoadCurrent(key, groupGeneration, browseGeneration)) {
+        group.loading = false
+      }
+    }
+
+    if (isBrowseGroupLoadCurrent(key, groupGeneration, browseGeneration)) {
+      await nextTick()
+      const scrollElement = await resolveScrollElement()
+      if (
+        activeTab.value === 'browse' &&
+        scrollElement &&
+        (scrollElement.clientHeight > 0 || scrollElement.scrollHeight > 0)
+      ) {
+        void checkBrowseGroupSentinels()
+      }
+    }
+  })()
+  browseGroupPromises.set(key, task)
+  void task.finally(() => {
+    if (browseGroupPromises.get(key) === task) browseGroupPromises.delete(key)
+  })
+  return task
+}
+
+function reloadBrowseGroup(
+  key: BrowseGroupKey,
+  targetCount: number,
+  browseGeneration: number,
+): Promise<void> {
+  return loadBrowseGroup(key, { reset: true, targetCount, browseGeneration })
+}
+
+function isSentinelNearViewport(sentinel: HTMLElement, scrollElement: HTMLElement): boolean {
+  const containerRect = scrollElement.getBoundingClientRect()
+  const sentinelRect = sentinel.getBoundingClientRect()
+  const top = sentinelRect.top - containerRect.top
+  const bottom = sentinelRect.bottom - containerRect.top
+  return top < scrollElement.clientHeight + 200 && bottom > -200
+}
+
+async function checkBrowseGroupSentinels() {
+  if (activeTab.value !== 'browse' || isTabTransitioning.value || !tabLoaded.browse) return
+  const scrollElement = await resolveScrollElement()
+  if (!scrollElement) return
+
+  const groups = browseGroups.value.slice(0, BROWSE_GROUP_DEFINITIONS.length)
+  const hasLayout = scrollElement.clientHeight > 0 || scrollElement.scrollHeight > 0
+  if (!hasLayout) {
+    const firstGroup = groups.find(
+      (group) =>
+        !isBrowseGroupCollapsed(group.key) &&
+        !group.loaded &&
+        !group.loading &&
+        !group.error &&
+        group.hasMore,
     )
-    if (!page || generation !== tabRequestGeneration.browse) return
-    if (page.items.length > 0) browseItems.value.push(...page.items)
-    updateBrowseTotalCount(
-      page.totalCount,
-      page.legacyArray
-        ? page.items.length === PAGE_SIZE
-        : browseItems.value.length < page.totalCount,
-    )
-  } finally {
-    if (generation === tabRequestGeneration.browse) {
-      refreshBrowseGrouping()
-      loadingMoreByTab.browse = false
+    if (firstGroup) void loadBrowseGroup(firstGroup.key)
+    return
+  }
+
+  for (const group of groups) {
+    if (isBrowseGroupCollapsed(group.key) || group.loading || group.error || !group.hasMore) {
+      continue
+    }
+    const sentinel = browseGroupSentinels.get(group.key)
+    if (sentinel && isSentinelNearViewport(sentinel, scrollElement)) {
+      void loadBrowseGroup(group.key)
     }
   }
 }
@@ -393,12 +610,16 @@ const onScroll = (event: CustomEvent<{ scrollTop?: number }>) => {
 
   if (!isTabReadyForPagination(tab)) return
 
+  if (tab === 'browse') {
+    void checkBrowseGroupSentinels()
+    return
+  }
+
   const el = scrollEl.value
   if (!el) return
   const threshold = 200
   if (el.scrollHeight - el.scrollTop - el.clientHeight < threshold) {
-    if (tab === 'browse') void loadMoreBrowse().catch(() => undefined)
-    else void loadMoreParse().catch(() => undefined)
+    void loadMoreParse().catch(() => undefined)
   }
 }
 
@@ -429,15 +650,83 @@ function endTabTransition(id: number) {
   if (id === tabTransitionId) isTabTransitioning.value = false
 }
 
-function ensureTabLoaded(tab: HistoryTab): Promise<void> {
+async function loadBrowseOverview(
+  generation: number,
+  reloadGroupCounts?: ReadonlyMap<BrowseGroupKey, number>,
+): Promise<boolean> {
+  const nowMs = Date.now()
+  const snapshot = createBrowseHistorySnapshot(nowMs)
+  browseOverviewLoading.value = true
+  try {
+    const overview = await HistoryService.getBrowseHistoryOverview(snapshot.ranges)
+    if (!overview) {
+      if (generation === tabRequestGeneration.browse && !browseOverviewLoaded.value) {
+        browseOverviewError.value = true
+      }
+      return false
+    }
+    if (generation !== tabRequestGeneration.browse) return false
+
+    applyBrowseOverview(snapshot, overview.totalCount, overview.groupCounts ?? {})
+    browseOverviewLoaded.value = true
+    browseOverviewError.value = false
+
+    if (reloadGroupCounts) {
+      const reloads: Promise<void>[] = []
+      for (const [key, targetCount] of reloadGroupCounts) {
+        const group = browseGroupStates[key]
+        if (targetCount > 0 && group.totalCount > 0) {
+          reloads.push(reloadBrowseGroup(key, targetCount, generation))
+        }
+      }
+      await Promise.all(reloads)
+    }
+
+    await nextTick()
+    if (activeTab.value === 'browse') void checkBrowseGroupSentinels()
+    return true
+  } catch {
+    if (generation === tabRequestGeneration.browse && !browseOverviewLoaded.value) {
+      browseOverviewError.value = true
+    }
+    return false
+  } finally {
+    if (generation === tabRequestGeneration.browse) browseOverviewLoading.value = false
+  }
+}
+
+function retryBrowseOverview() {
+  browseOverviewError.value = false
+  invalidateTab('browse')
+  void ensureTabLoaded('browse')
+}
+
+function retryBrowseGroup(key: BrowseGroupKey) {
+  void loadBrowseGroup(key)
+}
+
+interface EnsureTabOptions {
+  browseGroupCounts?: ReadonlyMap<BrowseGroupKey, number>
+}
+
+function ensureTabLoaded(tab: HistoryTab, options: EnsureTabOptions = {}): Promise<void> {
   if (tabLoaded[tab]) return Promise.resolve()
   if (tabLoadPromises[tab]) return tabLoadPromises[tab]!
 
   const generation = tabRequestGeneration[tab]
   const promise = (async () => {
     try {
-      const loaded = tab === 'browse' ? await loadBrowse(generation) : await loadParse(generation)
-      if (loaded && generation === tabRequestGeneration[tab]) tabLoaded[tab] = true
+      const loaded =
+        tab === 'browse'
+          ? await loadBrowseOverview(generation, options.browseGroupCounts)
+          : await loadParse(generation)
+      if (loaded && generation === tabRequestGeneration[tab]) {
+        tabLoaded[tab] = true
+        if (tab === 'browse') {
+          await nextTick()
+          void checkBrowseGroupSentinels()
+        }
+      }
     } finally {
       if (generation === tabRequestGeneration[tab]) tabLoadPromises[tab] = null
     }
@@ -447,6 +736,24 @@ function ensureTabLoaded(tab: HistoryTab): Promise<void> {
 }
 
 async function refreshTabOnActivation(tab: HistoryTab) {
+  if (tab === 'browse') {
+    if (!tabLoaded.browse) {
+      if (activeTab.value === 'browse') await ensureTabLoaded('browse')
+      return
+    }
+
+    const loadedGroupCounts = new Map<BrowseGroupKey, number>()
+    for (const definition of BROWSE_GROUP_DEFINITIONS) {
+      const group = browseGroupStates[definition.key]
+      if (group.loaded && group.items.length > 0) {
+        loadedGroupCounts.set(group.key, group.items.length)
+      }
+    }
+    invalidateTab('browse')
+    await ensureTabLoaded('browse', { browseGroupCounts: loadedGroupCounts })
+    return
+  }
+
   if (!tabLoaded[tab]) {
     if (activeTab.value === tab) await ensureTabLoaded(tab)
     return
@@ -461,24 +768,61 @@ function invalidateTab(tab: HistoryTab) {
   tabLoaded[tab] = false
   tabLoadPromises[tab] = null
   loadingMoreByTab[tab] = false
+  if (tab === 'browse') {
+    browseGroupPromises.clear()
+    for (const definition of BROWSE_GROUP_DEFINITIONS) {
+      const group = browseGroupStates[definition.key]
+      group.generation += 1
+      group.loading = false
+    }
+  }
 }
 
-async function reloadTabFromFirstPage(tab: HistoryTab, removedId: number) {
+function browseGroupKeyForItem(
+  itemId: number,
+  preferredKey?: BrowseGroupKey,
+): BrowseGroupKey | null {
+  if (preferredKey && browseGroupStates[preferredKey].items.some((item) => item.id === itemId)) {
+    return preferredKey
+  }
+  return (
+    BROWSE_GROUP_DEFINITIONS.find((definition) =>
+      browseGroupStates[definition.key].items.some((item) => item.id === itemId),
+    )?.key ?? null
+  )
+}
+
+async function reloadTabFromFirstPage(
+  tab: HistoryTab,
+  removedId: number,
+  preferredBrowseGroupKey?: BrowseGroupKey,
+) {
+  if (tab === 'browse') {
+    const groupKey = browseGroupKeyForItem(removedId, preferredBrowseGroupKey)
+    const group = groupKey ? browseGroupStates[groupKey] : null
+    const previousLength = group?.items.length ?? 0
+    const removed = group ? group.items.some((item) => item.id === removedId) : false
+    if (group && removed) {
+      group.items = group.items.filter((item) => item.id !== removedId)
+      group.offset = Math.max(0, group.offset - 1)
+      group.totalCount = Math.max(0, group.totalCount - 1)
+      group.hasMore = group.offset < group.totalCount
+      browseTotalCount.value = Math.max(0, browseTotalCount.value - 1)
+    }
+    const reloadGroupCounts = new Map<BrowseGroupKey, number>()
+    if (group?.loaded && previousLength > 0 && groupKey) {
+      reloadGroupCounts.set(groupKey, previousLength)
+    }
+    invalidateTab('browse')
+    await ensureTabLoaded('browse', { browseGroupCounts: reloadGroupCounts })
+    return
+  }
+
   if (!tabHasSnapshotMetadata[tab]) {
-    if (tab === 'browse') {
-      const previousLength = browseItems.value.length
-      browseItems.value = browseItems.value.filter((item) => item.id !== removedId)
-      if (browseItems.value.length !== previousLength) {
-        updateBrowseTotalCount(Math.max(0, browseTotalCount.value - 1))
-        refreshBrowseGrouping()
-        pruneCollapsedBrowseGroups()
-      }
-    } else {
-      const previousLength = parseItems.value.length
-      parseItems.value = parseItems.value.filter((item) => item.id !== removedId)
-      if (parseItems.value.length !== previousLength) {
-        updateParseTotalCount(Math.max(0, parseTotalCount.value - 1))
-      }
+    const previousLength = parseItems.value.length
+    parseItems.value = parseItems.value.filter((item) => item.id !== removedId)
+    if (parseItems.value.length !== previousLength) {
+      updateParseTotalCount(Math.max(0, parseTotalCount.value - 1))
     }
     return
   }
@@ -495,6 +839,7 @@ async function switchTab(tab: HistoryTab) {
   try {
     await ensureTabLoaded(tab)
     await restoreTabScrollPosition(tab)
+    if (tab === 'browse') void checkBrowseGroupSentinels()
   } finally {
     endTabTransition(transitionId)
   }
@@ -506,7 +851,6 @@ onMounted(async () => {
 })
 
 onActivated(() => {
-  refreshBrowseGrouping()
   const shouldRefreshTotals = wasDeactivated
   wasDeactivated = false
   const transitionId = beginTabTransition()
@@ -558,6 +902,7 @@ interface ContextMenuState {
   type: 'browse' | 'parse'
   item: BrowseHistoryItem | ParseHistoryItem
   anchor: HTMLElement
+  browseGroupKey?: BrowseGroupKey
 }
 
 const contextMenu = ref<ContextMenuState | null>(null)
@@ -581,7 +926,9 @@ function openContextMenu(item: BrowseHistoryItem | ParseHistoryItem, event: Mous
     closeContextMenu()
     return
   }
-  contextMenu.value = { type, item, anchor }
+  const browseGroupKey =
+    type === 'browse' ? (browseGroupKeyForItem(item.id) ?? undefined) : undefined
+  contextMenu.value = { type, item, anchor, browseGroupKey }
 }
 
 function closeContextMenu() {
@@ -630,7 +977,7 @@ async function handleMenuDelete() {
         handler: async () => {
           if (isBrowse) {
             await HistoryService.deleteBrowseItem(m.item.id)
-            await reloadTabFromFirstPage('browse', m.item.id)
+            await reloadTabFromFirstPage('browse', m.item.id, m.browseGroupKey)
           } else {
             await HistoryService.deleteParseItem(m.item.id)
             await reloadTabFromFirstPage('parse', m.item.id)
@@ -655,11 +1002,24 @@ async function confirmClearBrowse() {
           invalidateTab('browse')
           await HistoryService.clearBrowseHistory()
           closeContextMenu()
-          browseItems.value = []
-          updateBrowseTotalCount(0)
-          browseHasMore.value = true
+          browseOverviewLoaded.value = true
+          browseOverviewLoading.value = false
+          browseOverviewError.value = false
+          browseSnapshot.value = null
+          browseTotalCount.value = 0
+          for (const definition of BROWSE_GROUP_DEFINITIONS) {
+            const group = browseGroupStates[definition.key]
+            group.items.splice(0)
+            group.totalCount = 0
+            group.offset = 0
+            group.hasMore = false
+            group.loaded = false
+            group.loading = false
+            group.error = false
+          }
+          tabLoaded.browse = false
+          tabHasSnapshotMetadata.browse = true
           collapsedBrowseGroups.value = new Set()
-          refreshBrowseGrouping()
         },
       },
     ],
@@ -765,6 +1125,34 @@ function formatRelativeTime(timestamp: number): string {
   color: #c4a494;
 }
 
+.history-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: 30vh;
+  color: #b85d52;
+}
+
+.history-error p {
+  margin: 0 0 12px;
+  font-size: 14px;
+}
+
+.retry-btn,
+.browse-group-retry {
+  border: 0;
+  border-radius: 6px;
+  background: #fff0e8;
+  color: #c96d3a;
+  cursor: pointer;
+}
+
+.retry-btn {
+  padding: 7px 18px;
+  font-size: 12px;
+}
+
 /* Section header */
 .section-header {
   display: flex;
@@ -836,6 +1224,12 @@ function formatRelativeTime(timestamp: number): string {
   -webkit-tap-highlight-color: transparent;
 }
 
+.date-group-count {
+  color: #b89078;
+  font-size: 12px;
+  font-weight: 500;
+}
+
 .date-group-toggle:focus-visible {
   outline: 2px solid #e8843c;
   outline-offset: 1px;
@@ -854,14 +1248,11 @@ function formatRelativeTime(timestamp: number): string {
 }
 
 .date-group-content {
-  display: grid;
-  grid-template-rows: 1fr;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .date-group-content-inner {
   min-height: 0;
-  overflow: hidden;
 }
 
 .date-group-cards {
@@ -870,17 +1261,24 @@ function formatRelativeTime(timestamp: number): string {
   gap: 6px;
 }
 
-.history-drawer-enter-active,
-.history-drawer-leave-active {
-  transition:
-    grid-template-rows 0.24s ease,
-    opacity 0.18s ease;
+.browse-group-sentinel {
+  height: 1px;
+  pointer-events: none;
 }
 
-.history-drawer-enter-from,
-.history-drawer-leave-to {
-  grid-template-rows: 0fr;
-  opacity: 0;
+.browse-group-loader,
+.browse-group-retry {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  color: #fa9c69;
+}
+
+.browse-group-retry {
+  width: 100%;
+  padding: 10px;
+  font-size: 12px;
 }
 
 /* Browse card */
@@ -1079,35 +1477,33 @@ function formatRelativeTime(timestamp: number): string {
   color: #c96d3a;
 }
 
-/* TransitionGroup */
-.history-list-enter-active,
-.history-list-leave-active {
+/* Parse history TransitionGroup */
+.parse-history-list-enter-active,
+.parse-history-list-leave-active {
   transition:
     opacity 0.28s ease,
     transform 0.28s ease;
 }
 
-.history-list-enter-from {
+.parse-history-list-enter-from {
   opacity: 0;
   transform: translateY(12px) scale(0.97);
 }
 
-.history-list-leave-to {
+.parse-history-list-leave-to {
   opacity: 0;
   transform: translateX(-20px);
 }
 
-.history-list-move {
+.parse-history-list-move {
   transition: transform 0.28s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .date-group-toggle-icon,
-  .history-drawer-enter-active,
-  .history-drawer-leave-active,
-  .history-list-enter-active,
-  .history-list-leave-active,
-  .history-list-move {
+  .parse-history-list-enter-active,
+  .parse-history-list-leave-active,
+  .parse-history-list-move {
     transition-duration: 0.01ms;
   }
 }

--- a/tests/unit/HistoryPage.test.ts
+++ b/tests/unit/HistoryPage.test.ts
@@ -2,12 +2,19 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { KeepAlive, defineComponent, h, nextTick, onMounted, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import type { BrowseHistoryItem, ParseHistoryItem } from '@/services/JmcomicTypes'
+import type {
+  BrowseHistoryItem,
+  BrowseHistoryOverview,
+  BrowseHistoryRange,
+  ParseHistoryItem,
+} from '@/services/JmcomicTypes'
+import { BROWSE_GROUP_DEFINITIONS, groupBrowseHistory } from '@/utils/historyDateGroups'
 
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   createAppAlert: vi.fn(),
   getBrowseHistory: vi.fn(),
+  getBrowseHistoryOverview: vi.fn(),
   getParseHistory: vi.fn(),
   clearBrowseHistory: vi.fn(),
   clearParseHistory: vi.fn(),
@@ -29,7 +36,6 @@ vi.mock('@ionic/vue', () => {
     })
 
   return {
-    alertController: { create: vi.fn() },
     IonContent: defineComponent({
       name: 'IonContent',
       setup(_, { attrs, slots }) {
@@ -75,6 +81,7 @@ vi.mock('@/services/AppAlertService', () => ({
 vi.mock('@/services/HistoryService', () => ({
   HistoryService: {
     getBrowseHistory: mocks.getBrowseHistory,
+    getBrowseHistoryOverview: mocks.getBrowseHistoryOverview,
     getParseHistory: mocks.getParseHistory,
     deleteBrowseItem: mocks.deleteBrowseItem,
     deleteParseItem: mocks.deleteParseItem,
@@ -112,17 +119,18 @@ vi.mock('@/components/common/CardContextMenu.vue', () => ({
 import HistoryPage from '@/views/HistoryPage.vue'
 
 const makeBrowseItem = (
-  chapterId = '',
+  id = 1,
+  timestamp = Date.now(),
   overrides: Partial<BrowseHistoryItem> = {},
 ): BrowseHistoryItem => ({
-  id: 1,
-  albumId: '100',
-  albumTitle: '测试本子',
-  coverUrl: 'https://example.test/cover.jpg',
+  id,
+  albumId: `${id}`,
+  albumTitle: `测试本子 ${id}`,
+  coverUrl: `https://example.test/${id}.jpg`,
   authors: '作者甲 / 作者乙',
-  chapterId,
-  chapterTitle: chapterId ? '第二话' : '',
-  timestamp: Date.now(),
+  chapterId: '',
+  chapterTitle: '',
+  timestamp,
   ...overrides,
 })
 
@@ -134,14 +142,34 @@ const makeParseItem = (id = 1, overrides: Partial<ParseHistoryItem> = {}): Parse
   ...overrides,
 })
 
-const deferred = <T>() => {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  return { promise, resolve, reject }
+function matchesRange(timestamp: number, range?: BrowseHistoryRange): boolean {
+  if (!range) return true
+  if (range.startInclusive !== null && timestamp < range.startInclusive) return false
+  if (range.endExclusive !== null && timestamp >= range.endExclusive) return false
+  return true
+}
+
+function makeOverview(items: BrowseHistoryItem[]): BrowseHistoryOverview {
+  const groups = groupBrowseHistory(items, Date.now())
+  const groupCounts = Object.fromEntries(
+    BROWSE_GROUP_DEFINITIONS.map(({ key }) => [
+      key,
+      groups.find((group) => group.key === key)?.items.length ?? 0,
+    ]),
+  ) as BrowseHistoryOverview['groupCounts']
+  return { totalCount: items.length, groupCounts }
+}
+
+function mockBrowsePages(items: BrowseHistoryItem[]) {
+  mocks.getBrowseHistory.mockImplementation(
+    async (limit: number, offset: number, range?: BrowseHistoryRange) => {
+      const matchingItems = items.filter((item) => matchesRange(item.timestamp, range))
+      return {
+        items: matchingItems.slice(offset, offset + limit),
+        totalCount: matchingItems.length,
+      }
+    },
+  )
 }
 
 beforeEach(() => {
@@ -154,7 +182,8 @@ beforeEach(() => {
   mocks.clearParseHistory.mockResolvedValue(undefined)
   mocks.deleteBrowseItem.mockResolvedValue(undefined)
   mocks.deleteParseItem.mockResolvedValue(undefined)
-  mocks.getBrowseHistory.mockResolvedValue([])
+  mocks.getBrowseHistoryOverview.mockResolvedValue(makeOverview([]))
+  mocks.getBrowseHistory.mockResolvedValue({ items: [], totalCount: 0 })
   mocks.getParseHistory.mockResolvedValue([])
 })
 
@@ -162,30 +191,21 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-async function mountHistory(items: BrowseHistoryItem[]) {
-  mocks.getBrowseHistory.mockResolvedValue(items)
-  const wrapper = mount(HistoryPage)
-  await flushPromises()
-  return wrapper
-}
-
 const settle = async () => {
   await flushPromises()
   await nextTick()
   await flushPromises()
 }
 
-const makeBrowsePage = (startId = 1) =>
-  Array.from({ length: 50 }, (_, index) =>
-    makeBrowseItem('', { id: startId + index, timestamp: new Date(2025, 6, 16, 10).getTime() }),
-  )
+async function mountHistory(items: BrowseHistoryItem[]) {
+  mocks.getBrowseHistoryOverview.mockResolvedValue(makeOverview(items))
+  mockBrowsePages(items)
+  const wrapper = mount(HistoryPage)
+  await settle()
+  return wrapper
+}
 
-const makeParsePage = (startId = 1) =>
-  Array.from({ length: 50 }, (_, index) =>
-    makeParseItem(startId + index, { text: `解析${startId + index}` }),
-  )
-
-const prepareNearBottom = (wrapper: ReturnType<typeof mount>) => {
+function prepareNearBottom(wrapper: ReturnType<typeof mount>) {
   const scrollElement = wrapper.get('main').element as HTMLElement
   Object.defineProperties(scrollElement, {
     scrollHeight: { configurable: true, value: 1000 },
@@ -195,26 +215,141 @@ const prepareNearBottom = (wrapper: ReturnType<typeof mount>) => {
   return scrollElement
 }
 
-const triggerNearBottom = async (wrapper: ReturnType<typeof mount>) => {
-  const scrollElement = prepareNearBottom(wrapper)
-  scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-  await nextTick()
-  return scrollElement
-}
+describe('HistoryPage 浏览历史概览与分组', () => {
+  test('在未加载卡片前显示所有非空分组及全量计数', async () => {
+    const today = new Date(2025, 6, 16, 10).getTime()
+    const earlier = new Date(2024, 11, 31, 10).getTime()
+    const items = [makeBrowseItem(1, today), makeBrowseItem(2, today), makeBrowseItem(3, earlier)]
+    const wrapper = await mountHistory(items)
 
-describe('HistoryPage 详情跳转', () => {
-  test('历史记录有章节 ID 时定位到对应章节', async () => {
-    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('200')])
+    expect(wrapper.findAll('.date-group-toggle').map((button) => button.text())).toEqual([
+      '今天 (2)',
+      '更早 (1)',
+    ])
+    expect(wrapper.findAll('.browse-card')).toHaveLength(2)
+    expect(mocks.getBrowseHistoryOverview).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  test('概览失败时不显示为空，并可独立重试概览', async () => {
+    const item = makeBrowseItem(1, new Date(2025, 6, 16, 10).getTime())
+    mocks.getBrowseHistoryOverview
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(makeOverview([item]))
+    mockBrowsePages([item])
     const wrapper = mount(HistoryPage)
-    await flushPromises()
+    await settle()
 
+    expect(wrapper.get('.history-error').text()).toContain('加载失败')
+    expect(wrapper.find('.empty-state').exists()).toBe(false)
+    await wrapper.get('.retry-btn').trigger('click')
+    await settle()
+    expect(wrapper.findAll('.browse-card')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  test('展开尚未加载的较早分组只请求该分组范围', async () => {
+    const today = new Date(2025, 6, 16, 10).getTime()
+    const earlier = new Date(2024, 11, 31, 10).getTime()
+    const items = [makeBrowseItem(1, today), makeBrowseItem(2, earlier)]
+    const wrapper = await mountHistory(items)
+    const earlierToggle = wrapper.get('#history-group-toggle-earlier')
+
+    await earlierToggle.trigger('click')
+    expect(wrapper.get('#history-group-content-earlier').attributes('style')).toContain(
+      'display: none',
+    )
+    await earlierToggle.trigger('click')
+    await settle()
+
+    const earlierCall = mocks.getBrowseHistory.mock.calls.find(
+      ([, , range]) => range?.startInclusive === null,
+    )
+    expect(earlierCall).toBeDefined()
+    expect(earlierCall?.[0]).toBe(50)
+    expect(earlierCall?.[1]).toBe(0)
+    expect(earlierCall?.[2]).toEqual(expect.objectContaining({ startInclusive: null }))
+    expect(earlierCall?.[2].endExclusive).toBeDefined()
+    expect(wrapper.findAll('.browse-card')).toHaveLength(2)
+    wrapper.unmount()
+  })
+
+  test('折叠使用 v-show 保留卡片和图片节点，不执行浏览列表过渡', async () => {
+    const item = makeBrowseItem(1, new Date(2025, 6, 16, 10).getTime())
+    const wrapper = await mountHistory([item])
+    const content = wrapper.get('#history-group-content-today')
+    const cardElement = wrapper.get('.browse-card').element
+    const imageElement = wrapper.get('.card-cover').element
+
+    await wrapper.get('#history-group-toggle-today').trigger('click')
+    expect(content.exists()).toBe(true)
+    expect(content.attributes('style')).toContain('display: none')
+    expect(wrapper.get('.browse-card').element).toBe(cardElement)
+
+    await wrapper.get('#history-group-toggle-today').trigger('click')
+    await settle()
+    expect(wrapper.get('.browse-card').element).toBe(cardElement)
+    expect(wrapper.get('.card-cover').element).toBe(imageElement)
+    expect(wrapper.findAll('.parse-history-list-enter-active')).toHaveLength(0)
+    expect(wrapper.findAll('.history-list-enter-active')).toHaveLength(0)
+    wrapper.unmount()
+  })
+})
+
+describe('HistoryPage 分组分页', () => {
+  test('各分组独立按范围分页并保持稳定 offset', async () => {
+    const today = new Date(2025, 6, 16, 10).getTime()
+    const items = Array.from({ length: 51 }, (_, index) => makeBrowseItem(index + 1, today))
+    mocks.getBrowseHistoryOverview.mockResolvedValue(makeOverview(items))
+    mockBrowsePages(items)
+    const wrapper = mount(HistoryPage)
+    await settle()
+
+    expect(wrapper.findAll('.browse-card')).toHaveLength(50)
+    const scrollElement = prepareNearBottom(wrapper)
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
+    await settle()
+
+    expect(mocks.getBrowseHistory).toHaveBeenCalledWith(
+      50,
+      50,
+      expect.objectContaining({ startInclusive: expect.any(Number), endExclusive: null }),
+    )
+    expect(wrapper.findAll('.browse-card')).toHaveLength(51)
+    wrapper.unmount()
+  })
+
+  test('分组分页失败后保留已加载内容并允许组尾重试', async () => {
+    const item = makeBrowseItem(1, new Date(2025, 6, 16, 10).getTime())
+    mocks.getBrowseHistoryOverview.mockResolvedValue(makeOverview([item]))
+    mocks.getBrowseHistory.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      items: [item],
+      totalCount: 1,
+    })
+    const wrapper = mount(HistoryPage)
+    await settle()
+
+    expect(wrapper.findAll('.browse-card')).toHaveLength(0)
+    const retry = wrapper.get('.browse-group-retry')
+    await retry.trigger('click')
+    await settle()
+    expect(wrapper.findAll('.browse-card')).toHaveLength(1)
+    wrapper.unmount()
+  })
+})
+
+describe('HistoryPage 详情和生命周期', () => {
+  test('历史记录有章节 ID 时定位到对应章节', async () => {
+    const wrapper = await mountHistory([
+      makeBrowseItem(1, Date.now(), { albumId: '100', chapterId: '200', chapterTitle: '第二话' }),
+    ])
     await wrapper.get('.browse-card').trigger('click')
 
     expect(mocks.routerPush).toHaveBeenCalledWith({
       path: '/album/100',
       query: {
-        title: '测试本子',
-        coverUrl: 'https://example.test/cover.jpg',
+        title: '测试本子 1',
+        coverUrl: 'https://example.test/1.jpg',
         authors: '作者甲,作者乙',
         chapterId: '200',
       },
@@ -222,456 +357,55 @@ describe('HistoryPage 详情跳转', () => {
     wrapper.unmount()
   })
 
-  test('历史记录无章节 ID 时保持本子级进入', async () => {
-    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('')])
+  test('解析历史继续使用全局分页且不受浏览分组请求影响', async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => makeParseItem(index + 1))
+    const lastItem = makeParseItem(51, { text: '最后一条解析' })
+    mocks.getBrowseHistoryOverview.mockResolvedValue(makeOverview([]))
+    mocks.getParseHistory.mockResolvedValueOnce(firstPage).mockResolvedValueOnce([lastItem])
     const wrapper = mount(HistoryPage)
-    await flushPromises()
+    await settle()
 
-    await wrapper.get('.browse-card').trigger('click')
+    await wrapper.get('.tab-btn:nth-child(2)').trigger('click')
+    await settle()
+    expect(wrapper.findAll('.parse-card')).toHaveLength(50)
 
-    expect(mocks.routerPush).toHaveBeenCalledWith({
-      path: '/album/100',
-      query: {
-        title: '测试本子',
-        coverUrl: 'https://example.test/cover.jpg',
-        authors: '作者甲,作者乙',
-      },
-    })
-    wrapper.unmount()
-  })
-})
-
-describe('HistoryPage 浏览历史分组', () => {
-  test('渲染八组中的非空分组并保持稳定顺序', async () => {
-    const wrapper = await mountHistory([
-      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
-      makeBrowseItem('', { id: 2, timestamp: new Date(2025, 6, 15, 10).getTime() }),
-      makeBrowseItem('', { id: 3, timestamp: new Date(2025, 6, 14, 10).getTime() }),
-      makeBrowseItem('', { id: 4, timestamp: new Date(2025, 6, 1, 10).getTime() }),
-      makeBrowseItem('', { id: 5, timestamp: new Date(2025, 3, 16, 10).getTime() }),
-      makeBrowseItem('', { id: 6, timestamp: new Date(2025, 0, 16, 10).getTime() }),
-      makeBrowseItem('', { id: 7, timestamp: new Date(2024, 11, 31, 10).getTime() }),
-    ])
-
-    expect(wrapper.findAll('.date-group-toggle').map((button) => button.text())).toEqual([
-      '今天',
-      '昨天',
-      '本周',
-      '本月',
-      '3个月内',
-      '6个月内',
-      '更早',
-    ])
-    expect(wrapper.findAll('.browse-card')).toHaveLength(7)
+    const scrollElement = prepareNearBottom(wrapper)
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
+    await settle()
+    expect(mocks.getParseHistory).toHaveBeenNthCalledWith(2, 50, 50)
+    expect(wrapper.findAll('.parse-card')).toHaveLength(51)
     wrapper.unmount()
   })
 
-  test('文本和图标共享可访问按钮，独立切换并同步 region 状态', async () => {
-    const wrapper = await mountHistory([
-      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
-      makeBrowseItem('', { id: 2, timestamp: new Date(2025, 6, 15, 10).getTime() }),
-    ])
-    const todayToggle = wrapper.get('#history-group-toggle-today')
-    const todayContentId = 'history-group-content-today'
-
-    expect(todayToggle.element.tagName).toBe('BUTTON')
-    expect(todayToggle.text()).toBe('今天')
-    expect(todayToggle.find('.date-group-toggle-icon').attributes('aria-hidden')).toBe('true')
-    expect(todayToggle.attributes('aria-expanded')).toBe('true')
-    expect(todayToggle.attributes('aria-controls')).toBe(todayContentId)
-    expect(wrapper.get(`#${todayContentId}`).attributes('role')).toBe('region')
-    expect(wrapper.get(`#${todayContentId}`).attributes('aria-labelledby')).toBe(
-      'history-group-toggle-today',
-    )
-
-    await todayToggle.trigger('click')
-
-    expect(todayToggle.attributes('aria-expanded')).toBe('false')
-    expect(todayToggle.find('.date-group-toggle-icon').classes()).toContain('collapsed')
-    expect(wrapper.find(`#${todayContentId}`).exists()).toBe(false)
-    expect(wrapper.get('#history-group-toggle-yesterday').attributes('aria-expanded')).toBe('true')
-
-    await todayToggle.trigger('click')
-    await todayToggle.trigger('click')
-    await todayToggle.trigger('click')
-
-    expect(todayToggle.attributes('aria-expanded')).toBe('true')
-    expect(wrapper.find(`#${todayContentId}`).exists()).toBe(true)
-    wrapper.unmount()
-  })
-
-  test('折叠包含上下文菜单的分组时先关闭菜单', async () => {
-    const wrapper = await mountHistory([
-      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
-    ])
-
-    await wrapper.get('.card-more-btn').trigger('click')
-    expect(wrapper.get('.card-context-menu').attributes('data-visible')).toBe('true')
-
-    await wrapper.get('#history-group-toggle-today').trigger('click')
-
-    expect(wrapper.get('.card-context-menu').attributes('data-visible')).toBe('false')
-    wrapper.unmount()
-  })
-
-  test('切换解析历史再返回时保留分组折叠状态', async () => {
-    const wrapper = await mountHistory([
-      makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() }),
-    ])
-
-    await wrapper.get('#history-group-toggle-today').trigger('click')
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await tabButtons[0].trigger('click')
-    await flushPromises()
-
-    expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('false')
-    wrapper.unmount()
-  })
-
-  test('清空浏览历史后重新出现的分组默认展开', async () => {
-    const items = [makeBrowseItem('', { id: 1, timestamp: new Date(2025, 6, 16, 10).getTime() })]
-    const present = vi.fn().mockResolvedValue(undefined)
+  test('删除浏览记录后刷新概览并重建当前已加载分组', async () => {
+    const item = makeBrowseItem(7, new Date(2025, 6, 16, 10).getTime())
+    mocks.getBrowseHistoryOverview
+      .mockResolvedValueOnce(makeOverview([item]))
+      .mockResolvedValueOnce(makeOverview([]))
+    mocks.getBrowseHistory.mockResolvedValue({ items: [item], totalCount: 1 })
     mocks.createAppAlert.mockImplementation(
       async (options: { buttons: Array<{ handler?: () => void | Promise<void> }> }) => {
         await options.buttons[1]?.handler?.()
-        return { present }
+        return { present: vi.fn().mockResolvedValue(undefined) }
       },
     )
-    const wrapper = await mountHistory(items)
-
-    await wrapper.get('#history-group-toggle-today').trigger('click')
-    await wrapper.get('.clear-btn').trigger('click')
-    await flushPromises()
-    expect(mocks.clearBrowseHistory).toHaveBeenCalledOnce()
-
-    mocks.getBrowseHistory.mockResolvedValue(items)
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await tabButtons[0].trigger('click')
-    await flushPromises()
-
-    expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('true')
-    expect(present).toHaveBeenCalledOnce()
-    wrapper.unmount()
-  })
-})
-
-describe('HistoryPage 分页加载提示', () => {
-  test('浏览历史分页成功时显示尾部提示、阻止重复触底并在无更多数据后隐藏', async () => {
-    const firstPage = makeBrowsePage()
-    const nextRequest = deferred<BrowseHistoryItem[]>()
-    mocks.getBrowseHistory.mockResolvedValueOnce(firstPage).mockReturnValueOnce(nextRequest.promise)
-
     const wrapper = mount(HistoryPage)
     await settle()
 
-    const scrollElement = await triggerNearBottom(wrapper)
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-    expect(wrapper.find('.history-list-loader .ion-spinner').attributes('data-name')).toBe('dots')
-    expect(wrapper.findAll('.browse-card')).toHaveLength(50)
-
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await nextTick()
-    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(2)
-    expect(mocks.getBrowseHistory).toHaveBeenNthCalledWith(2, 50, 50)
-
-    nextRequest.resolve([makeBrowseItem('', { id: 51 })])
+    await wrapper.get('.card-more-btn').trigger('click')
+    await wrapper.get('.card-context-menu').trigger('click')
     await settle()
 
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.browse-card')).toHaveLength(51)
-
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await settle()
-    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(2)
+    expect(mocks.deleteBrowseItem).toHaveBeenCalledWith(item.id)
+    expect(mocks.getBrowseHistoryOverview).toHaveBeenCalledTimes(2)
+    expect(wrapper.findAll('.browse-card')).toHaveLength(0)
     wrapper.unmount()
   })
 
-  test('解析历史分页成功时显示尾部提示并在无更多数据后隐藏', async () => {
-    const nextRequest = deferred<ParseHistoryItem[]>()
-    mocks.getBrowseHistory.mockResolvedValueOnce([makeBrowseItem()])
-    mocks.getParseHistory
-      .mockResolvedValueOnce(makeParsePage())
-      .mockReturnValueOnce(nextRequest.promise)
-
-    const wrapper = mount(HistoryPage)
-    await settle()
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await settle()
-
-    const scrollElement = await triggerNearBottom(wrapper)
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-    expect(wrapper.find('.history-list-loader .ion-spinner').attributes('data-name')).toBe('dots')
-    expect(wrapper.findAll('.parse-card')).toHaveLength(50)
-
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await nextTick()
-    expect(mocks.getParseHistory).toHaveBeenCalledTimes(2)
-    expect(mocks.getParseHistory).toHaveBeenNthCalledWith(2, 50, 50)
-
-    nextRequest.resolve([makeParseItem(51, { text: '最后一条解析' })])
-    await settle()
-
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.parse-card')).toHaveLength(51)
-
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await settle()
-    expect(mocks.getParseHistory).toHaveBeenCalledTimes(2)
-    wrapper.unmount()
-  })
-
-  test('浏览历史分页失败后隐藏提示并允许重试', async () => {
-    const failedRequest = deferred<BrowseHistoryItem[]>()
-    const retryRequest = deferred<BrowseHistoryItem[]>()
-    mocks.getBrowseHistory
-      .mockResolvedValueOnce(makeBrowsePage())
-      .mockReturnValueOnce(failedRequest.promise)
-      .mockReturnValueOnce(retryRequest.promise)
-
-    const wrapper = mount(HistoryPage)
-    await settle()
-    const scrollElement = await triggerNearBottom(wrapper)
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-
-    failedRequest.reject(new Error('browse page failed'))
-    await settle()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.browse-card')).toHaveLength(50)
-
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await nextTick()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(3)
-    expect(mocks.getBrowseHistory).toHaveBeenNthCalledWith(3, 50, 50)
-
-    retryRequest.resolve([makeBrowseItem('', { id: 51 })])
-    await settle()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.browse-card')).toHaveLength(51)
-    wrapper.unmount()
-  })
-
-  test('解析历史分页失败后隐藏提示并允许重试', async () => {
-    const failedRequest = deferred<ParseHistoryItem[]>()
-    const retryRequest = deferred<ParseHistoryItem[]>()
-    mocks.getBrowseHistory.mockResolvedValueOnce([makeBrowseItem()])
-    mocks.getParseHistory
-      .mockResolvedValueOnce(makeParsePage())
-      .mockReturnValueOnce(failedRequest.promise)
-      .mockReturnValueOnce(retryRequest.promise)
-
-    const wrapper = mount(HistoryPage)
-    await settle()
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await settle()
-    const scrollElement = await triggerNearBottom(wrapper)
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-
-    failedRequest.reject(new Error('parse page failed'))
-    await settle()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.parse-card')).toHaveLength(50)
-
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await nextTick()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-    expect(mocks.getParseHistory).toHaveBeenCalledTimes(3)
-    expect(mocks.getParseHistory).toHaveBeenNthCalledWith(3, 50, 50)
-
-    retryRequest.resolve([makeParseItem(51, { text: '重试成功' })])
-    await settle()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.parse-card')).toHaveLength(51)
-    wrapper.unmount()
-  })
-
-  test('分页 pending 时快速切换只显示当前 Tab 的提示且不影响分组折叠', async () => {
-    const browseRequest = deferred<BrowseHistoryItem[]>()
-    mocks.getBrowseHistory
-      .mockResolvedValueOnce(makeBrowsePage())
-      .mockReturnValueOnce(browseRequest.promise)
-    mocks.getParseHistory.mockResolvedValueOnce([makeParseItem()])
-
-    const wrapper = mount(HistoryPage)
-    await settle()
-    await wrapper.get('#history-group-toggle-today').trigger('click')
-
-    const scrollElement = await triggerNearBottom(wrapper)
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-    expect(wrapper.find('#history-group-content-today').exists()).toBe(false)
-
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await settle()
-    expect(tabButtons[1].classes()).toContain('active')
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.findAll('.parse-card')).toHaveLength(1)
-
-    await tabButtons[0].trigger('click')
-    await settle()
-    expect(tabButtons[0].classes()).toContain('active')
-    expect(wrapper.find('.history-list-loader').exists()).toBe(true)
-    expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('false')
-    expect(wrapper.find('#history-group-content-today').exists()).toBe(false)
-
-    browseRequest.resolve([])
-    await settle()
-    expect(wrapper.find('.history-list-loader').exists()).toBe(false)
-    expect(wrapper.get('#history-group-toggle-today').attributes('aria-expanded')).toBe('false')
-    expect(scrollElement.scrollTop).toBe(250)
-    wrapper.unmount()
-  })
-})
-
-describe('HistoryPage Tab 生命周期', () => {
-  test('浏览首屏请求 pending 时近底部滚动不会启动第二个 offset 0 请求', async () => {
-    const browseRequest = deferred<BrowseHistoryItem[]>()
-    mocks.getBrowseHistory.mockReturnValue(browseRequest.promise)
-
-    const wrapper = mount(HistoryPage)
-    await flushPromises()
-
-    const scrollElement = wrapper.get('main').element as HTMLElement
-    Object.defineProperties(scrollElement, {
-      scrollHeight: { configurable: true, value: 1000 },
-      clientHeight: { configurable: true, value: 600 },
-    })
-    scrollElement.scrollTop = 250
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await flushPromises()
-
-    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(1)
-    expect(mocks.getBrowseHistory).toHaveBeenCalledWith(50, 0)
-
-    browseRequest.resolve([makeBrowseItem('', { id: 101 }), makeBrowseItem('', { id: 102 })])
-    await settle()
-
-    expect(wrapper.findAll('.browse-card')).toHaveLength(2)
-    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(1)
-    wrapper.unmount()
-  })
-
-  test('解析首屏 pending 时切换期间滚动不会重复请求，并恢复目标位置', async () => {
-    const parseRequest = deferred<ParseHistoryItem[]>()
-    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('', { id: 10 })])
-    mocks.getParseHistory.mockReturnValue(parseRequest.promise)
-
-    const wrapper = mount(HistoryPage)
-    await settle()
-
-    const scrollElement = wrapper.get('main').element as HTMLElement
-    Object.defineProperties(scrollElement, {
-      scrollHeight: { configurable: true, value: 1000 },
-      clientHeight: { configurable: true, value: 600 },
-    })
-    scrollElement.scrollTop = 420
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await nextTick()
-    scrollElement.scrollTop = 420
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 420 } }))
-    await flushPromises()
-
-    expect(mocks.getParseHistory).toHaveBeenCalledTimes(1)
-    expect(mocks.getParseHistory).toHaveBeenCalledWith(50, 0)
-
-    parseRequest.resolve([
-      makeParseItem(201, { text: '首次解析' }),
-      makeParseItem(202, { text: '第二次解析' }),
-    ])
-    await settle()
-
-    expect(wrapper.findAll('.parse-card')).toHaveLength(2)
-    expect(wrapper.findAll('.parse-card').map((card) => card.text())).toEqual([
-      '首次解析单个解析刚刚',
-      '第二次解析单个解析刚刚',
-    ])
-    expect(scrollElement.scrollTop).toBe(0)
-    expect(mocks.getParseHistory).toHaveBeenCalledTimes(1)
-
-    await tabButtons[0].trigger('click')
-    await settle()
-    expect(scrollElement.scrollTop).toBe(420)
-    wrapper.unmount()
-  })
-
-  test('快速来回切换时旧的首屏任务不会恢复错误 Tab 的滚动位置', async () => {
-    const parseRequest = deferred<ParseHistoryItem[]>()
-    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('', { id: 1 })])
-    mocks.getParseHistory.mockReturnValue(parseRequest.promise)
-
-    const wrapper = mount(HistoryPage)
-    await settle()
-    const scrollElement = wrapper.get('main').element as HTMLElement
-    scrollElement.scrollTop = 420
-    const tabButtons = wrapper.findAll('.tab-btn')
-
-    await tabButtons[1].trigger('click')
-    await nextTick()
-    await tabButtons[0].trigger('click')
-    await settle()
-
-    expect(wrapper.get('.tab-btn.active').text()).toBe('浏览历史')
-    expect(scrollElement.scrollTop).toBe(420)
-
-    parseRequest.resolve([makeParseItem(301, { text: '延迟解析' })])
-    await settle()
-    expect(wrapper.get('.tab-btn.active').text()).toBe('浏览历史')
-    expect(scrollElement.scrollTop).toBe(420)
-
-    await tabButtons[1].trigger('click')
-    await settle()
-    expect(scrollElement.scrollTop).toBe(0)
-    wrapper.unmount()
-  })
-
-  test('每个 Tab 只在首次进入时加载并保留分页数据', async () => {
-    const firstPage = Array.from({ length: 50 }, (_, index) =>
-      makeBrowseItem('', { id: index + 1 }),
-    )
-    const secondPage = Array.from({ length: 50 }, (_, index) =>
-      makeBrowseItem('', { id: index + 51 }),
-    )
-    mocks.getBrowseHistory.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage)
-    mocks.getParseHistory.mockResolvedValueOnce([makeParseItem()])
-
-    const wrapper = mount(HistoryPage)
-    await flushPromises()
-
-    const scrollElement = wrapper.get('main').element as HTMLElement
-    Object.defineProperties(scrollElement, {
-      scrollHeight: { configurable: true, value: 1000 },
-      clientHeight: { configurable: true, value: 600 },
-    })
-    scrollElement.scrollTop = 250
-    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 250 } }))
-    await flushPromises()
-
-    expect(mocks.getBrowseHistory).toHaveBeenNthCalledWith(2, 50, 50)
-    expect(wrapper.findAll('.browse-card')).toHaveLength(100)
-
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await flushPromises()
-    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
-
-    await tabButtons[0].trigger('click')
-    await flushPromises()
-    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(2)
-    expect(wrapper.findAll('.browse-card')).toHaveLength(100)
-
-    await tabButtons[1].trigger('click')
-    await flushPromises()
-    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
-    wrapper.unmount()
-  })
-
-  test('两个 Tab 分别恢复滚动位置，并在 KeepAlive 返回时保留状态', async () => {
-    mocks.getBrowseHistory.mockResolvedValue([makeBrowseItem('', { id: 1 })])
+  test('KeepAlive 返回时保留 Tab 和各自滚动位置', async () => {
+    const item = makeBrowseItem(1, new Date(2025, 6, 16, 10).getTime())
+    mocks.getBrowseHistoryOverview.mockResolvedValue(makeOverview([item]))
+    mockBrowsePages([item])
     mocks.getParseHistory.mockResolvedValue([makeParseItem()])
     const showHistory = ref(true)
     const Host = defineComponent({
@@ -686,64 +420,27 @@ describe('HistoryPage Tab 生命周期', () => {
     })
 
     const wrapper = mount(Host)
-    await flushPromises()
+    await settle()
     const historyWrapper = wrapper.findComponent(HistoryPage)
     const scrollElement = historyWrapper.get('main').element as HTMLElement
     const tabButtons = historyWrapper.findAll('.tab-btn')
 
     scrollElement.scrollTop = 420
     await tabButtons[1].trigger('click')
-    await flushPromises()
-    expect(scrollElement.scrollTop).toBe(0)
-
+    await settle()
     scrollElement.scrollTop = 180
     await tabButtons[0].trigger('click')
-    await flushPromises()
+    await settle()
     expect(scrollElement.scrollTop).toBe(420)
-
-    await tabButtons[1].trigger('click')
-    await flushPromises()
-    expect(scrollElement.scrollTop).toBe(180)
 
     showHistory.value = false
     await nextTick()
     scrollElement.scrollTop = 0
     showHistory.value = true
     await nextTick()
-    await flushPromises()
-
-    expect(wrapper.findComponent(HistoryPage).get('.tab-btn.active').text()).toBe('解析历史')
-    expect(scrollElement.scrollTop).toBe(180)
-    expect(mocks.getBrowseHistory).toHaveBeenCalledOnce()
-    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
-    wrapper.unmount()
-  })
-
-  test('删除记录即时更新列表且切换 Tab 不重新加载已缓存数据', async () => {
-    const item = makeBrowseItem('', { id: 7 })
-    const present = vi.fn().mockResolvedValue(undefined)
-    mocks.getBrowseHistory.mockResolvedValue([item])
-    mocks.createAppAlert.mockImplementation(
-      async (options: { buttons: Array<{ handler?: () => void | Promise<void> }> }) => {
-        await options.buttons[1]?.handler?.()
-        return { present }
-      },
-    )
-    const wrapper = await mountHistory([item])
-
-    await wrapper.get('.card-more-btn').trigger('click')
-    await wrapper.get('.card-context-menu').trigger('click')
-    await flushPromises()
-
-    expect(mocks.deleteBrowseItem).toHaveBeenCalledWith(item.id)
-    expect(wrapper.findAll('.browse-card')).toHaveLength(0)
-
-    const tabButtons = wrapper.findAll('.tab-btn')
-    await tabButtons[1].trigger('click')
-    await tabButtons[0].trigger('click')
-    await flushPromises()
-    expect(mocks.getBrowseHistory).toHaveBeenCalledOnce()
-    expect(present).toHaveBeenCalledOnce()
+    await settle()
+    expect(wrapper.findComponent(HistoryPage).get('.tab-btn.active').text()).toBe('浏览历史')
+    expect(scrollElement.scrollTop).toBe(420)
     wrapper.unmount()
   })
 })

--- a/tests/unit/HistoryService.test.ts
+++ b/tests/unit/HistoryService.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { BrowseHistoryRange } from '@/services/JmcomicTypes'
+
+const mocks = vi.hoisted(() => ({
+  getBrowseHistory: vi.fn(),
+  getBrowseHistoryOverview: vi.fn(),
+}))
+
+vi.mock('@/services/JmcomicService', () => ({
+  JmcomicService: {
+    getBrowseHistory: mocks.getBrowseHistory,
+    getBrowseHistoryOverview: mocks.getBrowseHistoryOverview,
+  },
+}))
+
+import { HistoryService } from '@/services/HistoryService'
+
+const ranges: BrowseHistoryRange[] = [{ key: 'today', startInclusive: 100, endExclusive: null }]
+
+describe('HistoryService 浏览历史', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('透传概览范围并保留完整返回值', async () => {
+    const overview = {
+      totalCount: 1,
+      groupCounts: { today: 1 },
+    }
+    mocks.getBrowseHistoryOverview.mockResolvedValue(overview)
+
+    await expect(HistoryService.getBrowseHistoryOverview(ranges)).resolves.toEqual(overview)
+    expect(mocks.getBrowseHistoryOverview).toHaveBeenCalledWith(ranges)
+  })
+
+  test('范围分页透传上下界并在 Native 失败时返回 null', async () => {
+    mocks.getBrowseHistory.mockResolvedValueOnce({ items: [], totalCount: 0 })
+    const range = { startInclusive: 100, endExclusive: 200 }
+
+    await expect(HistoryService.getBrowseHistory(50, 10, range)).resolves.toEqual({
+      items: [],
+      totalCount: 0,
+    })
+    expect(mocks.getBrowseHistory).toHaveBeenCalledWith(50, 10, range)
+
+    mocks.getBrowseHistory.mockRejectedValueOnce(new Error('native failure'))
+    await expect(HistoryService.getBrowseHistory(50, 0, range)).resolves.toBeNull()
+  })
+
+  test('概览失败时不伪装成空数据', async () => {
+    mocks.getBrowseHistoryOverview.mockRejectedValueOnce(new Error('overview failure'))
+
+    await expect(HistoryService.getBrowseHistoryOverview(ranges)).resolves.toBeNull()
+  })
+})

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -3,12 +3,16 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   addListener: vi.fn(),
   retryImage: vi.fn(),
+  getBrowseHistory: vi.fn(),
+  getBrowseHistoryOverview: vi.fn(),
 }))
 
 vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
   jmcomicNativeClient: {
     addListener: mocks.addListener,
     retryImage: mocks.retryImage,
+    getBrowseHistory: mocks.getBrowseHistory,
+    getBrowseHistoryOverview: mocks.getBrowseHistoryOverview,
   },
 }))
 
@@ -90,5 +94,39 @@ describe('JmcomicService.retryImage', () => {
 
     await expect(JmcomicService.retryImage('chapter-1', image)).resolves.toEqual({ success: true })
     expect(mocks.retryImage).toHaveBeenCalledWith({ photoId: 'chapter-1', image })
+  })
+})
+
+describe('JmcomicService 浏览历史契约', () => {
+  test('透传可选时间范围，并保留无范围分页参数', async () => {
+    const range = {
+      key: 'today' as const,
+      startInclusive: 100,
+      endExclusive: null,
+    }
+    mocks.getBrowseHistory.mockResolvedValue({ items: [], totalCount: 0 })
+
+    await JmcomicService.getBrowseHistory(50, 0, range)
+    expect(mocks.getBrowseHistory).toHaveBeenCalledWith({
+      limit: 50,
+      offset: 0,
+      startInclusive: 100,
+      endExclusive: null,
+    })
+
+    await JmcomicService.getBrowseHistory(50, 50)
+    expect(mocks.getBrowseHistory).toHaveBeenLastCalledWith({ limit: 50, offset: 50 })
+  })
+
+  test('概览调用透传八组范围数组', async () => {
+    const ranges = [{ key: 'today' as const, startInclusive: 100, endExclusive: null }]
+    mocks.getBrowseHistoryOverview.mockResolvedValue({
+      totalCount: 1,
+      groupCounts: { today: 1 },
+    })
+
+    await JmcomicService.getBrowseHistoryOverview(ranges)
+
+    expect(mocks.getBrowseHistoryOverview).toHaveBeenCalledWith({ ranges })
   })
 })

--- a/tests/unit/historyDateGroups.test.ts
+++ b/tests/unit/historyDateGroups.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import type { BrowseHistoryItem } from '@/services/JmcomicTypes'
-import { groupBrowseHistory } from '@/utils/historyDateGroups'
+import {
+  BROWSE_GROUP_DEFINITIONS,
+  createBrowseHistorySnapshot,
+  groupBrowseHistory,
+} from '@/utils/historyDateGroups'
 
 function localDate(
   year: number,
@@ -32,6 +36,36 @@ function groupKeyFor(timestamp: number, nowMs: number) {
 }
 
 describe('groupBrowseHistory', () => {
+  test('生成互斥的左闭右开范围快照，并允许跨年时今年为空', () => {
+    const snapshot = createBrowseHistorySnapshot(localDate(2025, 1, 16, 12))
+
+    expect(snapshot.ranges).toHaveLength(BROWSE_GROUP_DEFINITIONS.length)
+    expect(snapshot.ranges.find((range) => range.key === 'thisYear')).toEqual({
+      key: 'thisYear',
+      startInclusive: localDate(2025, 1, 1, 0),
+      endExclusive: localDate(2024, 7, 16, 0),
+    })
+    expect(snapshot.ranges.find((range) => range.key === 'earlier')).toEqual({
+      key: 'earlier',
+      startInclusive: null,
+      endExclusive: localDate(2024, 7, 16, 0),
+    })
+
+    const nonEmptyRanges = snapshot.ranges.filter(
+      (range) =>
+        range.startInclusive === null ||
+        range.endExclusive === null ||
+        range.startInclusive < range.endExclusive,
+    )
+    for (let index = 1; index < nonEmptyRanges.length; index += 1) {
+      const previous = nonEmptyRanges[index - 1]
+      const current = nonEmptyRanges[index]
+      if (previous.endExclusive !== null && current.startInclusive !== null) {
+        expect(current.startInclusive).toBeLessThanOrEqual(previous.endExclusive)
+      }
+    }
+  })
+
   test('按固定顺序返回非空分组并保留组内输入顺序', () => {
     const now = localDate(2025, 7, 16)
     const items = [


### PR DESCRIPTION
## 变更内容

- 新增由 TypeScript 生成的八组本地日历时间范围快照，概览计数和分组分页共用同一批边界，跨年时允许“今年”成为空区间。
- 新增浏览历史概览 Bridge，SQLite 通过一次条件聚合返回全量总数和各组计数；范围分页支持可选上下界，并按 `timestamp DESC, id DESC` 稳定排序。
- 历史数据库从 v2 升至 v3，仅新增 `browse_history(timestamp DESC, id DESC)` 索引，保留现有字段和数据。
- 浏览历史页面改为按组独立保存 `items/offset/total/loading/error/generation`，按可见哨兵分页；标题不依赖已加载卡片并显示全量计数，失败时保留列表并支持组尾重试。
- 分组折叠改用 `v-show`，保留已加载卡片和图片节点；浏览卡片移除批量 `TransitionGroup`，分组高度/透明度过渡移除，仅保留 chevron 状态动画；解析历史沿用独立的列表动画。
- 补充日期边界、Service/Facade、概览失败、分组分页/重试、节点复用、删除重建、Bridge 范围查询和数据库迁移测试。

## 验证

- `NODE_OPTIONS=--localstorage-file=./node-localstorage-release-XXXXXX npm run test:unit`：44 个测试文件、264 个测试通过。
- `npm run lint`：通过。
- `npx vite build`：通过。
- `git diff --check`：通过。
- `npm run typecheck` / `npm run build`：受仓库既有 `src/services/PdfReaderService.ts:67` 的 `isEvalSupported` 类型错误阻断，本次改动未引入新的 TypeScript 错误。
- `bash gradlew :app:testDebugUnitTest`：未进入编译，当前环境没有 Android SDK、`ANDROID_HOME` 或 `sdk.dir`；新增 Android JVM/instrumentation 测试已提交，待具备 SDK 的 CI 验证。

## 兼容性

- 不传时间范围的 `getBrowseHistory` 继续使用全局 `offset/limit` 语义；解析历史接口和页面行为保持不变。
- SQLite v2 到 v3 只创建复合索引，不修改表字段、历史数据或清空/删除行为。
- 未新增虚拟列表依赖，也未改变历史记录内容、卡片样式或详情跳转契约。

Fixes #76

Closes ASTRA-14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 浏览历史改为按日期分组展示，支持折叠、分组计数和分组懒加载。
  * 支持按时间范围分页浏览，并在滚动时自动加载更多。
  * 新增浏览历史概览统计，展示总记录数及各时间分组数量。
  * 浏览历史和解析历史支持独立的加载失败重试。
* **改进**
  * 删除或清空历史后，相关分组与统计信息会自动刷新。
  * 相同时间的浏览记录保持稳定排序，提升浏览一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->