### PR TITLE
fix: 修复收起侧边栏时左划显示遮罩

### DIFF
--- a/src/components/menu/MainMenu.vue
+++ b/src/components/menu/MainMenu.vue
@@ -630,7 +630,9 @@ const setupTaskProgress = async () => {
   ])
 }
 
-const isInteractive = computed(() => leftMenuOpen.value || isDragging.value)
+const isInteractive = computed(
+  () => leftMenuOpen.value || (isDragging.value && dragProgress.value > 0),
+)
 const currentProgress = computed(() =>
   isDragging.value ? dragProgress.value : leftMenuOpen.value ? 1 : 0,
 )

--- a/tests/unit/MainMenu.test.ts
+++ b/tests/unit/MainMenu.test.ts
@@ -180,7 +180,7 @@ describe('MainMenu 自定义左侧手势', () => {
 
     gesture.onStart()
     await nextTick()
-    expect(backdrop.style.opacity).toBe('0.32')
+    expect(backdrop.style.opacity).toBe('0')
     gesture.onMove({ deltaX: 60 })
     await nextTick()
     expect(backdrop.style.opacity).toBe('0.32')
@@ -188,6 +188,29 @@ describe('MainMenu 自定义左侧手势', () => {
     gesture.onEnd({ velocityX: 0 })
     await nextTick()
     expect(backdrop.style.opacity).toBe('0.32')
+    wrapper.unmount()
+  })
+
+  test('收起状态下向左滑动不显示遮罩且保持关闭', async () => {
+    const wrapper = mountMenu()
+    const backdrop = wrapper.find('.main-menu-backdrop').element as HTMLElement
+    const gesture = getGesture()
+
+    gesture.onStart()
+    await nextTick()
+    expect(backdrop.style.opacity).toBe('0')
+    expect(wrapper.find('.main-menu').classes()).not.toContain('interactive')
+
+    gesture.onMove({ deltaX: -60 })
+    await nextTick()
+    expect(backdrop.style.opacity).toBe('0')
+    expect(wrapper.find('.main-menu').classes()).not.toContain('interactive')
+
+    gesture.onEnd({ velocityX: 0 })
+    await nextTick()
+    expect(leftMenuOpen.value).toBe(false)
+    expect(backdrop.style.opacity).toBe('0')
+    expect(wrapper.find('.main-menu').classes()).not.toContain('interactive')
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## 变更内容

- 收起状态下仅在拖拽进度大于 0 时启用菜单交互，反向左划不显示遮罩、不露出面板且保持关闭。
- 补充收起状态左划回归测试，并保留右划开启与打开后左划关闭的行为覆盖。
- Multica 子任务：ASTRA-18

## 验证

- `npm run test:unit -- tests/unit/MainMenu.test.ts`：20 项全部通过。
- `npm run lint`：通过。
- `npx prettier --check src/components/menu/MainMenu.vue tests/unit/MainMenu.test.ts`：通过。
- `npm run format:check`：仓库现有 `src/services/JmcomicTypes.ts`、`src/services/PdfReaderService.ts`、`src/views/BatchParsePage.vue` 未通过，本次未修改这些文件。
- `npm run build`：被仓库现有 `src/services/PdfReaderService.ts:67` 的 `DocumentInitParameters` 类型错误阻塞，本次未修改该文件。

Fixes #80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化菜单拖拽交互：仅在拖拽进度有效时启用交互状态。
  * 修复收起状态下向左滑动时遮罩显示和菜单状态异常的问题。

* **Tests**
  * 补充并更新菜单手势测试，覆盖拖拽遮罩及收起状态下的滑动行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->