### PR TITLE
fix: 优化历史 Tab 切换性能（ASTRA-17）

### DIFF
--- a/src/views/HistoryPage.vue
+++ b/src/views/HistoryPage.vue
@@ -27,7 +27,7 @@
     </IonHeader>
     <IonContent ref="contentRef" :scroll-events="true" @ion-scroll="onScroll">
       <div class="page-shell">
-        <div v-if="activeTab === 'browse'" class="tab-content">
+        <div v-show="activeTab === 'browse'" class="tab-content">
           <div v-if="!browseOverviewLoaded && browseOverviewError" class="history-error">
             <IonIcon :icon="timeOutline" class="empty-icon" />
             <p>浏览历史加载失败</p>
@@ -132,7 +132,7 @@
           </template>
         </div>
 
-        <div v-else class="tab-content">
+        <div v-show="activeTab === 'parse'" class="tab-content">
           <div v-if="parseItems.length === 0" class="empty-state">
             <IonIcon :icon="documentTextOutline" class="empty-icon" />
             <p>暂无解析记录</p>

--- a/tests/unit/HistoryPage.test.ts
+++ b/tests/unit/HistoryPage.test.ts
@@ -241,7 +241,7 @@ describe('HistoryPage 浏览历史概览与分组', () => {
     await settle()
 
     expect(wrapper.get('.history-error').text()).toContain('加载失败')
-    expect(wrapper.find('.empty-state').exists()).toBe(false)
+    expect(wrapper.find('.tab-content').find('.empty-state').exists()).toBe(false)
     await wrapper.get('.retry-btn').trigger('click')
     await settle()
     expect(wrapper.findAll('.browse-card')).toHaveLength(1)
@@ -374,6 +374,51 @@ describe('HistoryPage 详情和生命周期', () => {
     await settle()
     expect(mocks.getParseHistory).toHaveBeenNthCalledWith(2, 50, 50)
     expect(wrapper.findAll('.parse-card')).toHaveLength(51)
+    wrapper.unmount()
+  })
+
+  test('切换 Tab 保留浏览卡片节点、折叠状态、分页数据和各自滚动位置', async () => {
+    const today = new Date(2025, 6, 16, 10).getTime()
+    const browseItems = Array.from({ length: 51 }, (_, index) => makeBrowseItem(index + 1, today))
+    mocks.getParseHistory.mockResolvedValue([makeParseItem()])
+    const wrapper = await mountHistory(browseItems)
+    const firstCardElement = wrapper.get('.browse-card').element
+    const firstCoverElement = wrapper.get('.card-cover').element
+    const todayContent = wrapper.get('#history-group-content-today')
+    const scrollElement = prepareNearBottom(wrapper)
+
+    scrollElement.scrollTop = 420
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 420 } }))
+    await settle()
+    expect(wrapper.findAll('.browse-card')).toHaveLength(51)
+
+    await wrapper.get('#history-group-toggle-today').trigger('click')
+    expect(todayContent.attributes('style')).toContain('display: none')
+
+    await wrapper.get('.tab-btn:nth-child(2)').trigger('click')
+    await settle()
+    expect(wrapper.findAll('.tab-content')[0].attributes('style')).toContain('display: none')
+    expect(wrapper.findAll('.parse-card')).toHaveLength(1)
+    const parseCardElement = wrapper.get('.parse-card').element
+    scrollElement.scrollTop = 180
+    scrollElement.dispatchEvent(new CustomEvent('ion-scroll', { detail: { scrollTop: 180 } }))
+    await settle()
+
+    await wrapper.get('.tab-btn:nth-child(1)').trigger('click')
+    await settle()
+    expect(wrapper.findAll('.browse-card')).toHaveLength(51)
+    expect(wrapper.get('.browse-card').element).toBe(firstCardElement)
+    expect(wrapper.get('.card-cover').element).toBe(firstCoverElement)
+    expect(todayContent.attributes('style')).toContain('display: none')
+    expect(scrollElement.scrollTop).toBe(420)
+    expect(mocks.getBrowseHistoryOverview).toHaveBeenCalledOnce()
+    expect(mocks.getBrowseHistory).toHaveBeenCalledTimes(2)
+
+    await wrapper.get('.tab-btn:nth-child(2)').trigger('click')
+    await settle()
+    expect(wrapper.get('.parse-card').element).toBe(parseCardElement)
+    expect(mocks.getParseHistory).toHaveBeenCalledOnce()
+    expect(scrollElement.scrollTop).toBe(180)
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## 变更内容

- 将浏览历史和解析历史的顶层容器改为 `v-show`，切换 Tab 时保留已加载的卡片、图片和解析节点。
- 保持现有按需加载、分页、滚动位置和分组折叠状态，并补充跨 Tab 切换回归测试。

Fixes #81

子任务：ASTRA-17

## 验证

- `npm run test:unit -- tests/unit/HistoryPage.test.ts`：11/11 通过。
- `npm run lint`：通过。
- `npx prettier --check src/views/HistoryPage.vue tests/unit/HistoryPage.test.ts`：通过。
- `npx vite build`：通过。
- `npm run test:unit`：其他既有测试有 23 项因 jsdom 未提供 `localStorage` 失败，与本次改动无关。
- `npm run typecheck` / `npm run build`：被未改动的 `src/services/PdfReaderService.ts:67` 中 `isEvalSupported` 类型错误阻断。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 切换“浏览历史”和“解析历史”标签页时，页面状态得以保留。
  * 各标签页可独立维持卡片展开状态、分页数据和滚动位置。
* **测试**
  * 增加标签页状态保留的验证。
  * 优化空状态显示的测试范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->