### PR TITLE
首页宽屏适配

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -93,6 +93,9 @@ const reDisplay = async () => {
 }
 
 .home-content {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
   padding-top: 16vh;
 }
 


### PR DESCRIPTION
## 变更

- 为首页主内容设置 `width: 100%`、`max-width: 720px` 和水平自动居中。
- 保留现有顶部间距、标题、搜索交互及共享侧边栏边界。

## 验证

- `npx prettier --check src/views/HomePage.vue`
- `npm run lint`
- `npm run build`（通过；保留仓库现有的大 chunk 警告）

当前环境未安装系统浏览器或 Cypress 二进制，未执行 390×844、800×1280、1280×800、1440×900 的人工视口核验。

Fixes #85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化首页内容区域布局，新增最大宽度限制并支持全宽显示。
  * 内容区域现已水平居中，提升页面视觉一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->