### PR TITLE
修复：限制搜索结果页工具栏宽度

### DIFF
--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -789,6 +789,8 @@ onMounted(() => {
 }
 
 .search-page-toolbar {
+  max-width: 1000px;
+  margin-inline: auto;
   display: grid;
   grid-template-columns: 44px minmax(0, 1fr);
   align-items: start;


### PR DESCRIPTION
## 变更

- 为 `src/views/SearchPage.vue` 的 `.search-page-toolbar` 增加 `max-width: 1000px` 和 `margin-inline: auto`。
- 宽屏下菜单按钮与搜索面板整体与既有结果区保持同宽居中；窄屏布局、搜索交互和共享侧边栏不变。
- 未修改 `SearchResultContainer`、`SearchHeaderBar`、`src/App.vue`、`MainMenu`、`MenuToggleButton` 或其他共享实现。

## 验证

- `npx prettier --check src/views/SearchPage.vue`
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`：47 个测试文件、278 个测试通过（Node 26 使用临时 `--localstorage-file` 复核）。
- `npm run build`
- Chrome headless 人工检查 390×844、800×1280、1280×800、1440×900，以及空/加载/错误、筛选、搜索历史、列表/网格 2/7 列、卡片菜单和搜索浮层状态；各视口无横向溢出，桌面视口工具栏与结果区均为 1000px 居中，搜索浮层保持现有 920px 上限。

Closes #86
