### PR TITLE
修复分类页宽屏工具栏布局

### DIFF
--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -681,6 +681,8 @@ onMounted(() => {
   grid-template-columns: 44px minmax(0, 1fr);
   align-items: start;
   gap: 5px;
+  max-width: 1000px;
+  margin-inline: auto;
 }
 
 .category-page-toolbar.pinned {


### PR DESCRIPTION
## 变更

- 为分类页顶部工具栏增加 `1000px` 最大宽度并水平居中。
- 保持窄屏可用宽度、分类筛选交互和共享结果组件不变。

## 验证

- `npx prettier --check src/views/CategoryPage.vue`
- `npm run lint`
- `NODE_OPTIONS="--localstorage-file=<临时文件>" npm run test:unit`（47 个测试文件、278 个测试通过）
- `npm run typecheck`
- `npm run build`
- 本地浏览器检查 390×844 与 1280×800：工具栏和结果区分别同宽，宽屏均为 1000px 居中，页面无横向滚动。

Closes #87
