### PR TITLE
ASTRA-25: 章节选择页宽屏自适应布局

### DIFF
--- a/src/views/ChapterSelectPage.vue
+++ b/src/views/ChapterSelectPage.vue
@@ -365,6 +365,12 @@ onMounted(async () => {
   background: #f5d2bc;
 }
 
+.mode-btn:focus-visible,
+.chapter-card:focus-visible {
+  outline: 2px solid #e8843c;
+  outline-offset: 2px;
+}
+
 /* 章节网格 */
 .chapter-grid {
   display: grid;
@@ -379,6 +385,7 @@ onMounted(async () => {
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  min-width: 0;
   padding: 14px 10px;
   border: 1px solid rgb(245 210 188 / 0.7);
   border-radius: 12px;
@@ -411,8 +418,10 @@ onMounted(async () => {
 }
 
 .chapter-title {
+  max-width: 100%;
   font-size: 11px;
   line-height: 1.3;
+  overflow-wrap: anywhere;
 }
 
 .chapter-pages {
@@ -495,7 +504,40 @@ onMounted(async () => {
 
 @media (min-width: 680px) {
   .chapter-grid {
-    grid-template-columns: repeat(3, 1fr);
+    width: 100%;
+    max-width: 1140px;
+    box-sizing: border-box;
+    grid-template-columns: repeat(auto-fill, minmax(196px, 1fr));
+    gap: 12px;
+    padding: 16px 24px;
+    margin-inline: auto;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .mode-btn:hover:not(:disabled) {
+    background: #fff0e7;
+    border-color: #fa9c69;
+  }
+
+  .chapter-card:hover {
+    background: #fff4ed;
+    border-color: #f2b58f;
+  }
+
+  .chapter-card.downloaded:hover {
+    background: #ffe5d6;
+    border-color: #e8843c;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chapter-card {
+    transition: none;
+  }
+
+  .skeleton-card .sk-line {
+    animation: none;
   }
 }
 </style>


### PR DESCRIPTION
## 变更

- 保留手机端两列章节网格和现有业务行为。
- 680px 以上使用 `auto-fill/minmax(196px, 1fr)`，增加桌面间距与内边距，内容区最大宽度为 1140px 并居中。
- 为章节卡片与模式切换补充键盘焦点、精确指针设备 hover 反馈，以及 reduced-motion 支持；长标题不会撑破卡片。
- 仅修改 `src/views/ChapterSelectPage.vue`，未触及应用壳、共享侧栏或 `PreviewAllPage.vue`。

## 验证

- `npm run lint` 通过。
- `NODE_OPTIONS=--localstorage-file=<临时文件> npm run test:unit` 通过：47 个文件、278 个测试。
- `npx prettier --check src/views/ChapterSelectPage.vue` 通过。
- `npx vite build` 通过；仅保留既有 chunk size warning。
- `npm run typecheck` 仍受基线 `src/services/PdfReaderService.ts:67` 的 `isEvalSupported` 类型错误影响，未修改该范围外代码。

Closes ASTRA-25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **无障碍优化**
  * 为模式按钮和章节卡片新增键盘焦点提示。
  * 支持减少动态效果偏好，降低动画和过渡效果。

* **界面优化**
  * 优化章节卡片布局，使其在不同屏幕尺寸下更灵活适配。
  * 改善较长章节标题的换行显示，避免内容溢出。
  * 增强悬停状态的交互表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->