### PR TITLE
ASTRA-23: 作品详情页宽屏适配

### DIFF
--- a/src/components/album/AlbumChaptersTab.vue
+++ b/src/components/album/AlbumChaptersTab.vue
@@ -692,4 +692,24 @@ const toggleDisplayMode = () => {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+@container (min-width: 960px) {
+  .chapter-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+  }
+
+  .chapter-item {
+    align-items: stretch;
+    min-width: 0;
+  }
+
+  .card-wrapper {
+    width: 100%;
+  }
+
+  .chapter-card {
+    height: 100%;
+  }
+}
 </style>

--- a/src/components/album/AlbumCommentsTab.vue
+++ b/src/components/album/AlbumCommentsTab.vue
@@ -222,4 +222,12 @@ import type { CommentItem } from '@/services/JmcomicTypes'
   color: #8a6048;
   font-size: 11px;
 }
+
+@container (min-width: 960px) {
+  .comments-section {
+    width: 100%;
+    max-width: 720px;
+    margin-inline: auto;
+  }
+}
 </style>

--- a/src/components/album/AlbumHeader.vue
+++ b/src/components/album/AlbumHeader.vue
@@ -396,6 +396,61 @@ const showPreview = ref(false)
   }
 }
 
+@container (min-width: 960px) {
+  .header-area {
+    position: sticky;
+    top: 0;
+    z-index: 11;
+    overflow: visible;
+  }
+
+  .header-content {
+    max-width: none;
+    margin: 0;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .header-body {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .cover-col {
+    align-self: center;
+    width: min(100%, 220px);
+  }
+
+  .info-col {
+    width: 100%;
+    justify-content: flex-start;
+    padding-bottom: 0;
+    gap: 8px;
+  }
+
+  .album-title {
+    font-size: 20px;
+  }
+
+  .read-actions {
+    align-self: stretch;
+    width: 100%;
+  }
+
+  .read-main-row {
+    width: 100%;
+  }
+
+  .read-btn {
+    flex: 1;
+  }
+
+  .source-menu {
+    z-index: 30;
+  }
+}
+
 /* 封面预览遮罩 */
 .cover-preview-overlay {
   position: fixed;

--- a/src/components/album/AlbumInfoTab.vue
+++ b/src/components/album/AlbumInfoTab.vue
@@ -618,4 +618,18 @@ const downloadIcon = computed(() => {
     background-position: -200% 0;
   }
 }
+
+@container (min-width: 960px) {
+  .related-scroll {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    align-items: start;
+    overflow: visible;
+  }
+
+  .related-card {
+    width: auto;
+    min-width: 0;
+  }
+}
 </style>

--- a/src/components/album/AlbumPreviewTab.vue
+++ b/src/components/album/AlbumPreviewTab.vue
@@ -216,4 +216,11 @@ const onLoadMore = () => {
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+@container (min-width: 960px) {
+  .preview-grid {
+    grid-template-columns: repeat(auto-fill, minmax(116px, 1fr));
+    gap: 8px;
+  }
+}
 </style>

--- a/src/utils/previewGrid.ts
+++ b/src/utils/previewGrid.ts
@@ -1,0 +1,18 @@
+/** 返回预览网格中单个卡片的 CSS 宽度，用于按实际布局生成 PDF 缩略图。 */
+export function getPreviewGridItemWidth(grid: HTMLElement | null): number {
+  if (!grid) return 0
+
+  const item = grid.querySelector<HTMLElement>('.preview-item')
+  const itemWidth = item?.getBoundingClientRect().width ?? 0
+  if (itemWidth > 0) return itemWidth
+
+  const gridWidth = Math.max(grid.getBoundingClientRect().width, grid.clientWidth)
+  if (!gridWidth || typeof window === 'undefined') return 0
+
+  const style = window.getComputedStyle(grid)
+  const columns = style.gridTemplateColumns.trim().split(/\s+/).filter(Boolean).length
+  const gap = parseFloat(style.columnGap || style.gap || '0') || 0
+  if (columns <= 0) return gridWidth
+
+  return Math.max(1, (gridWidth - gap * (columns - 1)) / columns)
+}

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -1,113 +1,118 @@
 <template>
   <IonPage>
     <IonContent ref="contentRef" :scroll-events="true" @ion-scroll="handleScroll">
-      <!-- 区域 A：封面头部 -->
-      <AlbumHeader
-        ref="headerRef"
-        :cover-url="coverUrl"
-        :title="albumTitle"
-        :authors="albumAuthors"
-        :page-count="selectedChapterPageCount"
-        :loading="loading"
-        :chapter-loading="chapterLoading"
-        :source-menu-open="sourceMenuOpen"
-        :network-available="networkAvailable"
-        :image-available="selectedChapterHasDownload"
-        :pdf-available="Boolean(selectedChapterPdf)"
-        @back="goBack"
-        @start-reading="startReading"
-        @toggle-source-menu="toggleSourceMenu"
-        @select-source="openReaderBySource"
-      />
+      <div class="detail-page-container">
+        <div class="detail-layout">
+          <!-- 区域 A：封面头部 -->
+          <AlbumHeader
+            ref="headerRef"
+            :cover-url="coverUrl"
+            :title="albumTitle"
+            :authors="albumAuthors"
+            :page-count="selectedChapterPageCount"
+            :loading="loading"
+            :chapter-loading="chapterLoading"
+            :source-menu-open="sourceMenuOpen"
+            :network-available="networkAvailable"
+            :image-available="selectedChapterHasDownload"
+            :pdf-available="Boolean(selectedChapterPdf)"
+            @back="goBack"
+            @start-reading="startReading"
+            @toggle-source-menu="toggleSourceMenu"
+            @select-source="openReaderBySource"
+          />
 
-      <div ref="tabGestureRef" class="tab-gesture-area">
-        <!-- 区域 B：Tab 栏 -->
-        <div
-          ref="tabBarRef"
-          class="tab-bar"
-          :class="{ sticky: tabBarSticky, swiping: tabSwipeActive, settling: tabSwipeSettling }"
-          :style="tabBarStyle"
-        >
-          <div class="tab-active-indicator" />
-          <button
-            v-for="(tab, index) in tabs"
-            :key="tab.key"
-            type="button"
-            class="tab-btn"
-            :class="{ active: activeTab === tab.key }"
-            :style="getTabButtonStyle(index)"
-            @click="switchTab(tab.key)"
-          >
-            {{ tab.label }}
-          </button>
-        </div>
+          <div ref="tabGestureRef" class="tab-gesture-area">
+            <!-- 区域 B：Tab 栏 -->
+            <div
+              ref="tabBarRef"
+              class="tab-bar"
+              :class="{ sticky: tabBarSticky, swiping: tabSwipeActive, settling: tabSwipeSettling }"
+              :style="tabBarStyle"
+            >
+              <div class="tab-active-indicator" />
+              <button
+                v-for="(tab, index) in tabs"
+                :key="tab.key"
+                type="button"
+                class="tab-btn"
+                :class="{ active: activeTab === tab.key }"
+                :style="getTabButtonStyle(index)"
+                @click="switchTab(tab.key)"
+              >
+                {{ tab.label }}
+              </button>
+            </div>
 
-        <!-- 区域 C：Tab 内容 -->
-        <div
-          ref="tabContentRef"
-          class="tab-content"
-          :class="{ swiping: tabSwipeActive, settling: tabSwipeSettling }"
-          :style="tabContentStyle"
-        >
-          <div
-            v-for="(tab, index) in tabs"
-            :key="tab.key"
-            :ref="(el) => setTabPanelRef(tab.key, el)"
-            class="tab-panel"
-            :class="{ current: activeTab === tab.key }"
-            :style="getTabPanelStyle(index)"
-          >
-            <AlbumInfoTab
-              v-if="tab.key === 'info'"
-              :album="albumDetail"
-              :action-busy="actionBusy"
-              :download-status="selectedChapterDownloadStatus"
-              :image-available="selectedChapterHasDownload"
-              :pdf-available="Boolean(selectedChapterPdf)"
-              @toggle-like="handleToggleLike"
-              @toggle-favorite="handleToggleFavorite"
-              @download="handleDownload"
-              @navigate-album="onNavigateAlbum"
-            />
-            <AlbumChaptersTab
-              v-else-if="tab.key === 'chapters'"
-              :photo-metas="albumDetail?.photoMetas ?? []"
-              :selected-chapter-id="selectedChapterId"
-              :loading="loading"
-              :show-actions="showChapterActions"
-              :chapter-download-statuses="chapterDownloadStatuses"
-              :chapter-pdf-statuses="chapterPdfStatuses"
-              @select-chapter="selectChapter"
-              @download-chapter="onDownloadChapter"
-              @dismiss-actions="showChapterActions = false"
-              @batch-download="onBatchDownload"
-            />
-            <AlbumPreviewTab
-              v-else-if="tab.key === 'preview'"
-              :slots="previewSlots"
-              :total-count="previewImageTotal"
-              :visible-count="previewDisplayCount"
-              :all-visible="previewAllVisible"
-              :auto-load="previewAutoLoad"
-              :loading="previewLoading"
-              :loading-more="previewLoadingMore"
-              :loaded-count="previewLoadedCount"
-              empty-text="请先选择章节"
-              @load-more="loadMorePreview"
-              @open-reader="onOpenReader"
-            />
-            <AlbumCommentsTab
-              v-else-if="tab.key === 'comments'"
-              :comments="comments"
-              :loading="commentsLoading"
-              :has-more="hasMoreComments"
-              :total="totalComments"
-            />
+            <!-- 区域 C：Tab 内容 -->
+            <div
+              ref="tabContentRef"
+              class="tab-content"
+              :class="{ swiping: tabSwipeActive, settling: tabSwipeSettling }"
+              :style="tabContentStyle"
+            >
+              <div
+                v-for="(tab, index) in tabs"
+                :key="tab.key"
+                :ref="(el) => setTabPanelRef(tab.key, el)"
+                class="tab-panel"
+                :class="{ current: activeTab === tab.key }"
+                :style="getTabPanelStyle(index)"
+              >
+                <AlbumInfoTab
+                  v-if="tab.key === 'info'"
+                  :album="albumDetail"
+                  :action-busy="actionBusy"
+                  :download-status="selectedChapterDownloadStatus"
+                  :image-available="selectedChapterHasDownload"
+                  :pdf-available="Boolean(selectedChapterPdf)"
+                  @toggle-like="handleToggleLike"
+                  @toggle-favorite="handleToggleFavorite"
+                  @download="handleDownload"
+                  @navigate-album="onNavigateAlbum"
+                />
+                <AlbumChaptersTab
+                  v-else-if="tab.key === 'chapters'"
+                  :photo-metas="albumDetail?.photoMetas ?? []"
+                  :selected-chapter-id="selectedChapterId"
+                  :loading="loading"
+                  :show-actions="showChapterActions"
+                  :chapter-download-statuses="chapterDownloadStatuses"
+                  :chapter-pdf-statuses="chapterPdfStatuses"
+                  @select-chapter="selectChapter"
+                  @download-chapter="onDownloadChapter"
+                  @dismiss-actions="showChapterActions = false"
+                  @batch-download="onBatchDownload"
+                />
+                <AlbumPreviewTab
+                  v-else-if="tab.key === 'preview'"
+                  :ref="setPreviewTabRef"
+                  :slots="previewSlots"
+                  :total-count="previewImageTotal"
+                  :visible-count="previewDisplayCount"
+                  :all-visible="previewAllVisible"
+                  :auto-load="previewAutoLoad"
+                  :loading="previewLoading"
+                  :loading-more="previewLoadingMore"
+                  :loaded-count="previewLoadedCount"
+                  empty-text="请先选择章节"
+                  @load-more="loadMorePreview"
+                  @open-reader="onOpenReader"
+                />
+                <AlbumCommentsTab
+                  v-else-if="tab.key === 'comments'"
+                  :comments="comments"
+                  :loading="commentsLoading"
+                  :has-more="hasMoreComments"
+                  :total="totalComments"
+                />
+              </div>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="bottom-spacer" />
+        <div class="bottom-spacer" />
+      </div>
     </IonContent>
 
     <FavoriteFolderPicker
@@ -160,6 +165,7 @@ import { HistoryService } from '@/services/HistoryService'
 import { useAuth } from '@/composables/useAuth'
 import { openLeftMenu, setLeftMenuGestureEnabled } from '@/composables/useSideMenuState'
 import { type PreviewImageSlotSetter, usePreviewBatches } from '@/composables/usePreviewBatches'
+import { getPreviewGridItemWidth } from '@/utils/previewGrid'
 import AlbumHeader from '@/components/album/AlbumHeader.vue'
 import AlbumInfoTab from '@/components/album/AlbumInfoTab.vue'
 import AlbumChaptersTab from '@/components/album/AlbumChaptersTab.vue'
@@ -498,6 +504,7 @@ const headerRef = ref<InstanceType<typeof AlbumHeader> | null>(null)
 const tabBarRef = ref<HTMLElement | null>(null)
 const tabGestureRef = ref<HTMLElement | null>(null)
 const tabContentRef = ref<HTMLElement | null>(null)
+const previewTabRef = ref<InstanceType<typeof AlbumPreviewTab> | null>(null)
 const contentRef = ref<InstanceType<typeof IonContent> | null>(null)
 const PREVIEW_NEAR_BOTTOM_THRESHOLD = 200
 const tabPanelRefs = new Map<TabKey, HTMLElement>()
@@ -706,6 +713,11 @@ const setTabPanelRef = (key: TabKey, el: Element | ComponentPublicInstance | nul
   }
 }
 
+const setPreviewTabRef = (el: Element | ComponentPublicInstance | null) => {
+  previewTabRef.value =
+    el && !(el instanceof Element) ? (el as InstanceType<typeof AlbumPreviewTab>) : null
+}
+
 const measureActiveTabPanel = () => {
   const panel = tabPanelRefs.get(activeTab.value)
   if (!panel) return
@@ -732,7 +744,7 @@ const getTabPanelWidth = () => {
   if (panel?.offsetWidth) return panel.offsetWidth
 
   const contentEl = tabContentRef.value
-  const contentWidth = contentEl?.clientWidth || window.innerWidth || 1
+  const contentWidth = contentEl?.clientWidth || tabGestureRef.value?.clientWidth || 1
   if (!contentEl) return Math.max(1, contentWidth - 28)
 
   const style = getComputedStyle(contentEl)
@@ -1002,10 +1014,7 @@ const renderPdfPreviewPage = async (
     page = await pdfDoc.getPage(pageNum)
     if (!isCurrentPreviewRequest(requestGeneration)) return null
     const rawViewport = page.getViewport({ scale: 1 })
-    const columns = window.innerWidth >= 680 ? 4 : 3
-    const gap = 6
-    const sidePadding = 24
-    const targetWidth = (window.innerWidth - sidePadding - gap * (columns - 1)) / columns
+    const targetWidth = getPreviewGridItemWidth(getAlbumPreviewGrid())
     const scale = Math.max(
       0.4,
       (targetWidth * Math.min(window.devicePixelRatio || 1, 2)) / rawViewport.width,
@@ -1087,6 +1096,11 @@ const loadNetworkPreview = async (
     setImageSlot,
   )
   return listenerReady ? photo : null
+}
+
+const getAlbumPreviewGrid = (): HTMLElement | null => {
+  const root = previewTabRef.value?.$el as HTMLElement | undefined
+  return root?.querySelector<HTMLElement>('.preview-grid') ?? null
 }
 
 const loadPreviewBatch = async (
@@ -1234,6 +1248,8 @@ const loadPreview = async () => {
     if (!context || !isCurrentPreviewRequest(requestGeneration)) return
     previewLoadContext = context
     previewSourceOverride.value = context.source
+    await nextTick()
+    if (!isCurrentPreviewRequest(requestGeneration)) return
     await previewBatches.initialize()
     if (!isCurrentPreviewRequest(requestGeneration)) return
     previewLoadedKey.value = cacheKey
@@ -1606,6 +1622,20 @@ const handleScroll = async (event: CustomEvent<{ scrollTop?: number }>) => {
 </script>
 
 <style scoped>
+.detail-page-container {
+  width: 100%;
+  container-type: inline-size;
+}
+
+.detail-layout {
+  width: 100%;
+  min-width: 0;
+}
+
+.tab-gesture-area {
+  min-width: 0;
+}
+
 /* Tab 栏 */
 .tab-bar {
   display: flex;
@@ -1716,6 +1746,36 @@ const handleScroll = async (event: CustomEvent<{ scrollTop?: number }>) => {
 
   .tab-content.swiping .tab-panel {
     width: calc(100% - 28px);
+  }
+}
+
+@container (min-width: 960px) {
+  .detail-layout {
+    display: grid;
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    align-items: start;
+    gap: 24px;
+    box-sizing: border-box;
+    max-width: 1280px;
+    margin-inline: auto;
+    padding-inline: 16px;
+  }
+
+  .tab-bar {
+    position: sticky;
+    top: 0;
+    padding-top: calc(var(--ion-safe-area-top) + 8px);
+    margin-bottom: calc(-1 * var(--ion-safe-area-top));
+    box-shadow: 0 2px 10px rgb(76 42 24 / 0.08);
+  }
+
+  .tab-active-indicator {
+    top: calc(var(--ion-safe-area-top) + 8px);
+  }
+
+  .tab-content {
+    max-width: none;
+    margin-inline: 0;
   }
 }
 </style>

--- a/src/views/ChapterSelectPage.vue
+++ b/src/views/ChapterSelectPage.vue
@@ -16,65 +16,69 @@
       </IonToolbar>
     </IonHeader>
     <IonContent>
-      <!-- 已下载模式 -->
-      <div v-if="showMode === 'downloaded'" class="chapter-grid">
-        <button
-          v-for="ch in downloadedChapters"
-          :key="ch.chapterId"
-          type="button"
-          class="chapter-card downloaded"
-          @click="openLocalChapter(ch)"
-        >
-          <span class="chapter-num">{{ chapterNum(ch) }}</span>
-          <span class="chapter-title">{{ ch.chapterId }}</span>
-          <span v-if="ch.totalPages > 0" class="chapter-pages">{{ ch.totalPages }} 页</span>
-          <span class="source-row">
-            <span v-if="ch.downloadTask" class="source-chip image">图片</span>
-            <span v-if="ch.pdfData" class="source-chip pdf">PDF</span>
-          </span>
-          <img v-if="chapterCover(ch)" :src="chapterCover(ch)!" class="chapter-thumb" alt="" />
-        </button>
-      </div>
+      <div class="chapter-page-container">
+        <div class="chapter-content">
+          <!-- 已下载模式 -->
+          <div v-if="showMode === 'downloaded'" class="chapter-grid">
+            <button
+              v-for="ch in downloadedChapters"
+              :key="ch.chapterId"
+              type="button"
+              class="chapter-card downloaded"
+              @click="openLocalChapter(ch)"
+            >
+              <span class="chapter-num">{{ chapterNum(ch) }}</span>
+              <span class="chapter-title">{{ ch.chapterId }}</span>
+              <span v-if="ch.totalPages > 0" class="chapter-pages">{{ ch.totalPages }} 页</span>
+              <span class="source-row">
+                <span v-if="ch.downloadTask" class="source-chip image">图片</span>
+                <span v-if="ch.pdfData" class="source-chip pdf">PDF</span>
+              </span>
+              <img v-if="chapterCover(ch)" :src="chapterCover(ch)!" class="chapter-thumb" alt="" />
+            </button>
+          </div>
 
-      <!-- 全部章节模式：加载中骨架屏 -->
-      <div v-else-if="loadingAll" class="chapter-grid">
-        <div v-for="n in skeletonCount" :key="n" class="skeleton-card">
-          <div class="sk-line sk-line--short" />
-          <div class="sk-line" />
+          <!-- 全部章节模式：加载中骨架屏 -->
+          <div v-else-if="loadingAll" class="chapter-grid">
+            <div v-for="n in skeletonCount" :key="n" class="skeleton-card">
+              <div class="sk-line sk-line--short" />
+              <div class="sk-line" />
+            </div>
+          </div>
+
+          <!-- 全部章节模式：章节列表 -->
+          <div v-else class="chapter-grid">
+            <button
+              v-for="meta in allChapters"
+              :key="meta.id"
+              type="button"
+              class="chapter-card"
+              :class="{ downloaded: downloadedIds.has(meta.id) }"
+              @click="onOpenChapter(meta, downloadedIds.has(meta.id))"
+            >
+              <span class="chapter-num">第{{ meta.sortOrder }}话</span>
+              <span class="chapter-title">{{ meta.title }}</span>
+              <span v-if="downloadedIds.has(meta.id)" class="chapter-pages"
+                >{{ getDownloadedPages(meta.id) }} 页</span
+              >
+              <span v-if="downloadedIds.has(meta.id)" class="source-row">
+                <span v-if="downloadedMap.get(meta.id)?.downloadTask" class="source-chip image"
+                  >图片</span
+                >
+                <span v-if="downloadedMap.get(meta.id)?.pdfData" class="source-chip pdf">PDF</span>
+              </span>
+              <img
+                v-if="downloadedIds.has(meta.id) && getDownloadedCover(meta.id)"
+                :src="getDownloadedCover(meta.id)!"
+                class="chapter-thumb"
+                alt=""
+              />
+            </button>
+          </div>
+
+          <div class="bottom-spacer" />
         </div>
       </div>
-
-      <!-- 全部章节模式：章节列表 -->
-      <div v-else class="chapter-grid">
-        <button
-          v-for="meta in allChapters"
-          :key="meta.id"
-          type="button"
-          class="chapter-card"
-          :class="{ downloaded: downloadedIds.has(meta.id) }"
-          @click="onOpenChapter(meta, downloadedIds.has(meta.id))"
-        >
-          <span class="chapter-num">第{{ meta.sortOrder }}话</span>
-          <span class="chapter-title">{{ meta.title }}</span>
-          <span v-if="downloadedIds.has(meta.id)" class="chapter-pages"
-            >{{ getDownloadedPages(meta.id) }} 页</span
-          >
-          <span v-if="downloadedIds.has(meta.id)" class="source-row">
-            <span v-if="downloadedMap.get(meta.id)?.downloadTask" class="source-chip image"
-              >图片</span
-            >
-            <span v-if="downloadedMap.get(meta.id)?.pdfData" class="source-chip pdf">PDF</span>
-          </span>
-          <img
-            v-if="downloadedIds.has(meta.id) && getDownloadedCover(meta.id)"
-            :src="getDownloadedCover(meta.id)!"
-            class="chapter-thumb"
-            alt=""
-          />
-        </button>
-      </div>
-
-      <div class="bottom-spacer" />
     </IonContent>
   </IonPage>
 </template>
@@ -343,6 +347,17 @@ onMounted(async () => {
 </script>
 
 <style scoped>
+.chapter-page-container {
+  width: 100%;
+  container-type: inline-size;
+}
+
+.chapter-content {
+  width: 100%;
+  max-width: 1280px;
+  margin-inline: auto;
+}
+
 .toolbar-title {
   font-size: 16px;
   font-weight: 600;
@@ -496,6 +511,20 @@ onMounted(async () => {
 @media (min-width: 680px) {
   .chapter-grid {
     grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@container (min-width: 960px) {
+  .chapter-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 12px;
+    align-items: stretch;
+  }
+
+  .chapter-card {
+    width: 100%;
+    min-width: 0;
+    height: 100%;
   }
 }
 </style>

--- a/src/views/PreviewAllPage.vue
+++ b/src/views/PreviewAllPage.vue
@@ -12,48 +12,50 @@
       </ion-toolbar>
     </IonHeader>
     <IonContent ref="contentRef" :scroll-events="true" @ion-scroll="onIonScroll">
-      <div class="preview-container">
-        <!-- 初始加载中：骨架占位 -->
-        <div v-if="loading" class="preview-grid">
-          <div v-for="i in skeletonCount" :key="'init-skel-' + i" class="preview-item">
-            <div class="skeleton-thumb" />
-            <span class="preview-page-num">{{ i }}</span>
-          </div>
-        </div>
-
-        <!-- 逐批显示槽位 -->
-        <template v-else-if="totalCount > 0">
-          <div class="preview-grid">
-            <div v-for="i in displayCount" :key="'slot-' + i" class="preview-item">
-              <template v-if="slots[i - 1]">
-                <img
-                  :src="slots[i - 1]!.dataUrl"
-                  :alt="'第 ' + i + ' 页'"
-                  class="preview-thumb"
-                  @click="openReader(i)"
-                />
-              </template>
-              <template v-else>
-                <div class="skeleton-thumb" />
-              </template>
+      <div class="preview-page-container">
+        <div class="preview-container">
+          <!-- 初始加载中：骨架占位 -->
+          <div v-if="loading" ref="previewGridRef" class="preview-grid">
+            <div v-for="i in skeletonCount" :key="'init-skel-' + i" class="preview-item">
+              <div class="skeleton-thumb" />
               <span class="preview-page-num">{{ i }}</span>
             </div>
           </div>
 
-          <div class="preview-footer" role="status" aria-live="polite" aria-atomic="true">
-            <p v-if="loadingMore" class="footer-loading">
-              <ion-spinner name="dots" aria-hidden="true" />
-              <span>加载中...（{{ loadedCount }} / {{ totalCount }}）</span>
-            </p>
-            <p v-else-if="allVisible" class="footer-text">已显示所有图片</p>
-            <p v-else-if="loadedCount < displayCount" class="footer-text">
-              上滑重新加载缺失图片...（{{ loadedCount }} / {{ displayCount }}）
-            </p>
-            <p v-else class="footer-text">上滑加载更多...</p>
-          </div>
-        </template>
+          <!-- 逐批显示槽位 -->
+          <template v-else-if="totalCount > 0">
+            <div ref="previewGridRef" class="preview-grid">
+              <div v-for="i in displayCount" :key="'slot-' + i" class="preview-item">
+                <template v-if="slots[i - 1]">
+                  <img
+                    :src="slots[i - 1]!.dataUrl"
+                    :alt="'第 ' + i + ' 页'"
+                    class="preview-thumb"
+                    @click="openReader(i)"
+                  />
+                </template>
+                <template v-else>
+                  <div class="skeleton-thumb" />
+                </template>
+                <span class="preview-page-num">{{ i }}</span>
+              </div>
+            </div>
 
-        <p v-else class="preview-empty">暂无图片</p>
+            <div class="preview-footer" role="status" aria-live="polite" aria-atomic="true">
+              <p v-if="loadingMore" class="footer-loading">
+                <ion-spinner name="dots" aria-hidden="true" />
+                <span>加载中...（{{ loadedCount }} / {{ totalCount }}）</span>
+              </p>
+              <p v-else-if="allVisible" class="footer-text">已显示所有图片</p>
+              <p v-else-if="loadedCount < displayCount" class="footer-text">
+                上滑重新加载缺失图片...（{{ loadedCount }} / {{ displayCount }}）
+              </p>
+              <p v-else class="footer-text">上滑加载更多...</p>
+            </div>
+          </template>
+
+          <p v-else class="preview-empty">暂无图片</p>
+        </div>
       </div>
     </IonContent>
   </IonPage>
@@ -85,6 +87,7 @@ import {
   type PreviewImageSlotSetter,
   usePreviewBatches,
 } from '@/composables/usePreviewBatches'
+import { getPreviewGridItemWidth } from '@/utils/previewGrid'
 import { buildPdfDocumentParams, fetchPdfArrayBuffer } from '@/services/PdfReaderService'
 import * as pdfjsLib from 'pdfjs-dist'
 
@@ -122,6 +125,7 @@ const pdfObjectUrls = new Set<string>()
 // ---- 滚动容器 ----
 const contentRef = ref<InstanceType<typeof IonContent> | null>(null)
 const scrollEl = ref<HTMLElement | null>(null)
+const previewGridRef = ref<HTMLElement | null>(null)
 
 const resolveScrollElement = async (): Promise<HTMLElement | null> => {
   if (scrollEl.value) return scrollEl.value
@@ -140,10 +144,7 @@ const renderPdfPage = async (pageNum: number): Promise<string | null> => {
     page = await pdfDoc.getPage(pageNum)
     if (disposed) return null
     const rawViewport = page.getViewport({ scale: 1 })
-    const columns = window.innerWidth >= 680 ? 4 : 3
-    const gap = 6
-    const sidePadding = 24
-    const targetWidth = (window.innerWidth - sidePadding - gap * (columns - 1)) / columns
+    const targetWidth = getPreviewGridItemWidth(previewGridRef.value)
     const scale = Math.max(
       0.4,
       (targetWidth * Math.min(window.devicePixelRatio || 1, 2)) / rawViewport.width,
@@ -265,9 +266,9 @@ onMounted(async () => {
   await resolveScrollElement()
   if (disposed) return
 
-  loading.value = false
   await previewBatches.initialize()
   if (disposed) return
+  loading.value = false
   await maybeLoadMoreAfterRender()
 })
 
@@ -347,8 +348,17 @@ const goBack = () => router.back()
 </script>
 
 <style scoped>
+.preview-page-container {
+  width: 100%;
+  container-type: inline-size;
+}
+
 .preview-container {
   padding: 10px 12px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1280px;
+  margin-inline: auto;
 }
 
 .preview-grid {
@@ -432,6 +442,13 @@ const goBack = () => router.back()
 @media (min-width: 680px) {
   .preview-grid {
     grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@container (min-width: 960px) {
+  .preview-grid {
+    grid-template-columns: repeat(auto-fill, minmax(116px, 1fr));
+    gap: 8px;
   }
 }
 </style>

--- a/tests/unit/previewGrid.test.ts
+++ b/tests/unit/previewGrid.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test, vi } from 'vitest'
+import { getPreviewGridItemWidth } from '@/utils/previewGrid'
+
+describe('getPreviewGridItemWidth', () => {
+  test('优先读取实际预览卡片宽度', () => {
+    const grid = document.createElement('div')
+    const item = document.createElement('div')
+    item.className = 'preview-item'
+    grid.append(item)
+    vi.spyOn(item, 'getBoundingClientRect').mockReturnValue({ width: 224 } as DOMRect)
+
+    expect(getPreviewGridItemWidth(grid)).toBe(224)
+  })
+
+  test('没有网格时返回零', () => {
+    expect(getPreviewGridItemWidth(null)).toBe(0)
+  })
+
+  test('没有卡片时按网格轨道和间距回算宽度', () => {
+    const grid = document.createElement('div')
+    grid.style.gridTemplateColumns = '100px 100px 100px 100px'
+    grid.style.columnGap = '8px'
+    Object.defineProperty(grid, 'clientWidth', { configurable: true, value: 440 })
+    vi.spyOn(grid, 'getBoundingClientRect').mockReturnValue({ width: 440 } as DOMRect)
+
+    expect(getPreviewGridItemWidth(grid)).toBe(104)
+  })
+})


### PR DESCRIPTION
## 变更

- 以实际内容区 960px 为容器查询断点，宽屏详情页使用最大 1280px、约 320px 摘要栏和可伸缩的 Tab 内容栏；窄屏布局与单滚动容器保持不变。
- 宽屏摘要栏改为纵向卡片并吸顶，Tab 栏从内容区顶部吸顶；信息、章节、预览和评论分别增加适合宽屏的网格或可读宽度限制，保留既有交互、加载和滚动记忆。
- `PreviewAllPage.vue` 与 `ChapterSelectPage.vue` 增加居中内容上限和自适应网格；PDF 预览缩略图改按实际预览格宽度生成，避免侧栏或超宽窗口导致尺寸估算错误。
- 未修改 `App.vue`、`MainMenu.vue`、`useSideMenuState.ts`、阅读器页面或共享收藏夹组件。

## 验证

- `npm run lint`
- `NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-ast23-localstorage.json npm run test:unit`（48 个测试文件、281 个测试通过）
- `npm run typecheck`
- `npm run build`

Closes #88
Closes ASTRA-23
