### PR TITLE
ASTRA-27: 收藏页宽屏适配

### DIFF
--- a/src/components/favorite/FavoriteSideMenu.vue
+++ b/src/components/favorite/FavoriteSideMenu.vue
@@ -1,15 +1,24 @@
 <template>
-  <div
+  <nav
     v-show="isVisible"
+    id="favorite-side-menu"
     class="fav-menu-backdrop"
+    :class="{ 'fav-menu-pane': isPaneMode }"
     :style="backdropStyle"
+    role="navigation"
+    aria-label="收藏夹"
     @click.self="closeMenu"
     @touchstart.stop
   >
-    <div ref="panelRef" class="fav-menu-panel" :style="panelStyle">
+    <div
+      ref="panelRef"
+      class="fav-menu-panel"
+      :class="{ 'fav-menu-panel--pane': isPaneMode }"
+      :style="panelStyle"
+    >
       <div class="menu-header">
         <div class="menu-title">收藏夹</div>
-        <button type="button" class="menu-close-btn" @click="closeMenu">
+        <button type="button" class="menu-close-btn" aria-label="关闭收藏夹" @click="closeMenu">
           <IonIcon :icon="closeOutline" />
         </button>
       </div>
@@ -117,7 +126,7 @@
       @close="closeContextMenu"
       @select="handleContextMenuAction"
     />
-  </div>
+  </nav>
 </template>
 
 <script setup lang="ts">
@@ -139,18 +148,30 @@ import CardContextMenu from '@/components/common/CardContextMenu.vue'
 import type { FolderEntry } from '@/services/JmcomicTypes'
 import { OFFLINE_ALL_FOLDER_ID } from '@/services/JmcomicTypes'
 
+type DisplayMode = 'overlay' | 'pane'
+
 defineOptions({ name: 'FavoriteSideMenu' })
 
-const props = defineProps<{
-  modelValue: boolean
-  onlineFolders: FolderEntry[]
-  offlineFolders: FolderEntry[]
-  selectedOnlineId: string
-  selectedOfflineId: string
-  onlineFolderCounts: Record<string, number>
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    displayMode?: DisplayMode
+    paneOpen?: boolean
+    onlineFolders: FolderEntry[]
+    offlineFolders: FolderEntry[]
+    selectedOnlineId: string
+    selectedOfflineId: string
+    onlineFolderCounts: Record<string, number>
+  }>(),
+  {
+    displayMode: 'overlay',
+    paneOpen: false,
+  },
+)
+
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
+  'update:paneOpen': [value: boolean]
   'select-online-folder': [folderId: string]
   'select-offline-folder': [folderId: string]
   'add-folder': [source: 'online' | 'offline']
@@ -162,6 +183,8 @@ const emit = defineEmits<{
 }>()
 
 const { isDraggingRight, isSnappingClosed, rightDragProgress } = useSideMenuState()
+
+const isPaneMode = computed(() => props.displayMode === 'pane')
 
 const panelRef = ref<HTMLElement | null>(null)
 interface ContextMenuState {
@@ -239,11 +262,14 @@ const onContextMenuExport = (folderId: string, folderName: string, isOnline: boo
   emit('export-folder', { folderId, folderName, isOnline })
 }
 
-const isVisible = computed(
-  () => props.modelValue || isDraggingRight.value || isSnappingClosed.value,
+const isVisible = computed(() =>
+  isPaneMode.value
+    ? props.paneOpen
+    : props.modelValue || isDraggingRight.value || isSnappingClosed.value,
 )
 
 const currentProgress = computed(() => {
+  if (isPaneMode.value) return props.paneOpen ? 1 : 0
   if (isDraggingRight.value) return rightDragProgress.value
   if (isSnappingClosed.value) return 0
   return props.modelValue ? 1 : 0
@@ -252,14 +278,22 @@ const currentProgress = computed(() => {
 const useTransition = computed(() => !isDraggingRight.value)
 
 const panelStyle = computed(() => ({
-  transform: `translateX(${(1 - currentProgress.value) * 100}%)`,
-  transition: useTransition.value ? 'transform 0.24s cubic-bezier(0.22, 0.61, 0.36, 1)' : 'none',
+  transform: isPaneMode.value ? 'none' : `translateX(${(1 - currentProgress.value) * 100}%)`,
+  transition: isPaneMode.value
+    ? 'none'
+    : useTransition.value
+      ? 'transform 0.24s cubic-bezier(0.22, 0.61, 0.36, 1)'
+      : 'none',
 }))
 
-const backdropStyle = computed(() => ({
-  opacity: currentProgress.value > 0 ? currentProgress.value : 0,
-  transition: useTransition.value ? 'opacity 0.24s ease' : 'none',
-}))
+const backdropStyle = computed(() =>
+  isPaneMode.value
+    ? {}
+    : {
+        opacity: currentProgress.value > 0 ? currentProgress.value : 0,
+        transition: useTransition.value ? 'opacity 0.24s ease' : 'none',
+      },
+)
 
 const animateClose = () => {
   if (isDraggingRight.value) return
@@ -273,17 +307,22 @@ const animateClose = () => {
 }
 
 const closeMenu = () => {
+  closeContextMenu()
+  if (isPaneMode.value) {
+    emit('update:paneOpen', false)
+    return
+  }
   animateClose()
 }
 
 const selectOnlineFolder = (folderId: string) => {
   emit('select-online-folder', folderId)
-  animateClose()
+  if (!isPaneMode.value) animateClose()
 }
 
 const selectOfflineFolder = (folderId: string) => {
   emit('select-offline-folder', folderId)
-  animateClose()
+  if (!isPaneMode.value) animateClose()
 }
 
 defineExpose({ panelRef })
@@ -298,6 +337,19 @@ defineExpose({ panelRef })
   backdrop-filter: blur(2px);
 }
 
+.fav-menu-pane {
+  position: relative;
+  inset: auto;
+  flex: 0 0 280px;
+  width: 280px;
+  min-width: 280px;
+  height: 100%;
+  overflow: hidden;
+  background: linear-gradient(180deg, #fffaf6 0%, #fff3eb 100%);
+  box-shadow: -12px 0 36px rgb(76 42 24 / 0.14);
+  backdrop-filter: none;
+}
+
 .fav-menu-panel {
   position: absolute;
   top: 0;
@@ -308,6 +360,14 @@ defineExpose({ panelRef })
   flex-direction: column;
   background: linear-gradient(180deg, #fffaf6 0%, #fff3eb 100%);
   box-shadow: -12px 0 36px rgb(76 42 24 / 0.14);
+}
+
+.fav-menu-panel--pane {
+  position: relative;
+  inset: auto;
+  width: 100%;
+  height: 100%;
+  box-shadow: none;
 }
 
 .menu-header {
@@ -336,6 +396,7 @@ defineExpose({ panelRef })
   color: #8a6048;
   font-size: 18px;
   box-shadow: 0 4px 12px rgb(115 67 38 / 0.1);
+  cursor: pointer;
 }
 
 .menu-body {
@@ -478,6 +539,14 @@ defineExpose({ panelRef })
 .folder-more-btn.active {
   background: rgb(250 156 105 / 0.15);
   color: #c96d3a;
+}
+
+.menu-close-btn:focus-visible,
+.section-add-btn:focus-visible,
+.folder-item:focus-visible,
+.folder-more-btn:focus-visible {
+  outline: 3px solid rgb(201 109 58 / 0.45);
+  outline-offset: 2px;
 }
 
 .empty-state {

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -1,80 +1,104 @@
 <template>
   <IonPage>
-    <IonContent ref="contentRef" :scroll-events="true" @ion-scroll="handleContentScroll">
-      <IonRefresher
-        slot="fixed"
-        :disabled="canLoadPrevious && pageAtTop"
-        @ion-refresh="handleRefresh"
-      >
-        <IonRefresherContent />
-      </IonRefresher>
+    <div ref="pageShellRef" class="favorite-page-layout">
+      <IonContent ref="contentRef" :scroll-events="true" @ion-scroll="handleContentScroll">
+        <IonRefresher
+          slot="fixed"
+          :disabled="canLoadPrevious && pageAtTop"
+          @ion-refresh="handleRefresh"
+        >
+          <IonRefresherContent />
+        </IonRefresher>
 
-      <div class="favorite-page-top">
-        <div class="favorite-page-toolbar" :class="{ pinned: pullHeaderPinned }">
-          <MenuToggleButton />
-          <div class="toolbar-favorite">
-            <div class="toolbar-row">
-              <FavoriteSearchBar
-                ref="searchBarRef"
-                :query="currentFavoriteQuery"
-                :loading="busy"
-                @search="submitSearch"
-              />
-              <button
-                type="button"
-                class="folders-toggle-btn"
-                aria-label="收藏夹列表"
-                @click="openRightMenu"
-              >
-                <IonIcon :icon="folderOpenOutline" />
-              </button>
+        <div class="favorite-page-top">
+          <div class="favorite-page-toolbar" :class="{ pinned: pullHeaderPinned }">
+            <MenuToggleButton />
+            <div class="toolbar-favorite">
+              <div class="toolbar-row">
+                <FavoriteSearchBar
+                  ref="searchBarRef"
+                  :query="currentFavoriteQuery"
+                  :loading="busy"
+                  @search="submitSearch"
+                />
+                <button
+                  type="button"
+                  class="folders-toggle-btn"
+                  aria-label="收藏夹列表"
+                  aria-controls="favorite-side-menu"
+                  :aria-expanded="isWideLayout ? widePaneOpen : rightMenuOpen"
+                  @click="openRightMenu"
+                >
+                  <IonIcon :icon="folderOpenOutline" />
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <SearchResultContainer
-        ref="resultContainerRef"
-        :result="resultMeta"
-        :items="displayItems"
-        :loading="initialLoading"
-        :loading-previous="loadingPrevious"
-        :loading-next="loadingNext"
-        :can-load-previous="canLoadPrevious"
-        :page-at-top="pageAtTop"
-        :error-message="errorMessage"
-        :mode="displayMode"
-        :loaded-page-start="loadedPageStart"
-        :loaded-page-end="loadedPageEnd"
-        :downloaded-album-ids="downloadedAlbumIds"
-        idle-text="请在右侧收藏夹菜单中选择文件夹"
-        @mode-change="displayMode = $event"
-        @item-click="handleItemClick"
-        @load-previous="handleLoadPrevious"
-        @pull-state-change="pullGestureActive = $event"
-        @retry="retrySearch"
-      >
-        <template #item-actions="{ item }">
-          <button
-            type="button"
-            class="card-more-btn"
-            :class="{ active: cardMenu?.item.id === item.id }"
-            aria-label="更多操作"
-            @click.stop="openCardMenu(item, $event)"
-          >
-            <IonIcon :icon="ellipsisVertical" />
-          </button>
-        </template>
-      </SearchResultContainer>
+        <SearchResultContainer
+          ref="resultContainerRef"
+          :result="resultMeta"
+          :items="displayItems"
+          :loading="initialLoading"
+          :loading-previous="loadingPrevious"
+          :loading-next="loadingNext"
+          :can-load-previous="canLoadPrevious"
+          :page-at-top="pageAtTop"
+          :error-message="errorMessage"
+          :mode="displayMode"
+          :loaded-page-start="loadedPageStart"
+          :loaded-page-end="loadedPageEnd"
+          :downloaded-album-ids="downloadedAlbumIds"
+          idle-text="请在右侧收藏夹菜单中选择文件夹"
+          @mode-change="displayMode = $event"
+          @item-click="handleItemClick"
+          @load-previous="handleLoadPrevious"
+          @pull-state-change="pullGestureActive = $event"
+          @retry="retrySearch"
+        >
+          <template #item-actions="{ item }">
+            <button
+              type="button"
+              class="card-more-btn"
+              :class="{ active: cardMenu?.item.id === item.id }"
+              aria-label="更多操作"
+              @click.stop="openCardMenu(item, $event)"
+            >
+              <IonIcon :icon="ellipsisVertical" />
+            </button>
+          </template>
+        </SearchResultContainer>
 
-      <QuickActionFab
-        slot="fixed"
-        @search="openRightMenu"
-        @jump="scrollToTop"
-        @top="scrollToTop"
-        @back="goBack"
+        <QuickActionFab
+          slot="fixed"
+          @search="openRightMenu"
+          @jump="scrollToTop"
+          @top="scrollToTop"
+          @back="goBack"
+        />
+      </IonContent>
+
+      <FavoriteSideMenu
+        ref="sideMenuRef"
+        v-model="rightMenuOpen"
+        v-model:pane-open="widePaneOpen"
+        :display-mode="isWideLayout ? 'pane' : 'overlay'"
+        :online-folders="onlineFolderEntries"
+        :offline-folders="offlineFolderEntries"
+        :selected-online-id="folderSource === 'online' ? currentFolderId : ''"
+        :selected-offline-id="folderSource === 'offline' ? currentFolderId : ''"
+        :online-folder-counts="onlineFolderCounts"
+        @select-online-folder="onSelectOnlineFolder"
+        @select-offline-folder="onSelectOfflineFolder"
+        @add-folder="onAddFolder"
+        @rename-folder="onRenameFolder"
+        @delete-folder="onDeleteFolder"
+        @move-folder="onMoveFolder"
+        @copy-folder="onCopyFolder"
+        @export-folder="onExportFolder"
       />
-    </IonContent>
+    </div>
 
     <!-- 操作进度遮罩（阻塞式，不可关闭） -->
     <div v-if="showProgressModal" class="progress-overlay">
@@ -95,24 +119,6 @@
         <div class="progress-warning">请勿关闭应用</div>
       </div>
     </div>
-
-    <FavoriteSideMenu
-      ref="sideMenuRef"
-      v-model="rightMenuOpen"
-      :online-folders="onlineFolderEntries"
-      :offline-folders="offlineFolderEntries"
-      :selected-online-id="folderSource === 'online' ? currentFolderId : ''"
-      :selected-offline-id="folderSource === 'offline' ? currentFolderId : ''"
-      :online-folder-counts="onlineFolderCounts"
-      @select-online-folder="onSelectOnlineFolder"
-      @select-offline-folder="onSelectOfflineFolder"
-      @add-folder="onAddFolder"
-      @rename-folder="onRenameFolder"
-      @delete-folder="onDeleteFolder"
-      @move-folder="onMoveFolder"
-      @copy-folder="onCopyFolder"
-      @export-folder="onExportFolder"
-    />
 
     <CardContextMenu
       :visible="Boolean(cardMenu)"
@@ -191,6 +197,7 @@ defineOptions({ name: 'FavoritePage' })
 const { isDraggingRight, isSnappingClosed, leftMenuOpen, rightDragProgress, rightMenuOpen } =
   useSideMenuState()
 
+const WIDE_LAYOUT_MIN_WIDTH = 1280
 const NEXT_PAGE_THRESHOLD = 220
 
 const router = useRouter()
@@ -248,10 +255,16 @@ const pageAtTop = ref(true)
 const pullGestureActive = ref(false)
 
 const contentRef = ref<InstanceType<typeof IonContent> | null>(null)
+const pageShellRef = ref<HTMLElement | null>(null)
 const scrollElementRef = ref<HTMLElement | null>(null)
 const resultContainerRef = ref<SearchResultContainerExposed | null>(null)
 const searchBarRef = ref<{ focusInput: () => Promise<void> } | null>(null)
 const sideMenuRef = ref<InstanceType<typeof FavoriteSideMenu> | null>(null)
+const pageWidth = ref(0)
+const widePaneOpen = ref(false)
+const isWideLayout = computed(() => pageWidth.value >= WIDE_LAYOUT_MIN_WIDTH)
+
+let pageResizeObserver: ResizeObserver | undefined
 
 const pageCache = ref<Record<number, SearchResultItem[]>>({})
 
@@ -396,6 +409,40 @@ const resolveScrollElement = async () => {
   if (!contentEl?.getScrollElement) return null
   scrollElementRef.value = await contentEl.getScrollElement()
   return scrollElementRef.value
+}
+
+const updatePageWidth = (width: number) => {
+  pageWidth.value = width
+}
+
+const measurePageWidth = () => {
+  const shell = pageShellRef.value
+  if (!shell) return
+  const measuredWidth =
+    shell.getBoundingClientRect().width || shell.clientWidth || window.innerWidth
+  updatePageWidth(measuredWidth)
+}
+
+const startPageResizeObserver = () => {
+  pageResizeObserver?.disconnect()
+  pageResizeObserver = undefined
+  measurePageWidth()
+
+  const shell = pageShellRef.value
+  if (!shell || typeof ResizeObserver === 'undefined') return
+
+  pageResizeObserver = new ResizeObserver((entries) => {
+    const width = entries[0]?.contentRect.width
+    if (typeof width === 'number') {
+      updatePageWidth(width)
+    }
+  })
+  pageResizeObserver.observe(shell)
+}
+
+const stopPageResizeObserver = () => {
+  pageResizeObserver?.disconnect()
+  pageResizeObserver = undefined
 }
 
 // --- 数据获取 ---
@@ -671,6 +718,12 @@ const openRightMenu = async () => {
   if (leftMenuOpen.value) {
     closeLeftMenu()
   }
+
+  if (isWideLayout.value) {
+    widePaneOpen.value = true
+    return
+  }
+
   // 两阶段入场动画：先渲染在关闭位置，再 transition 到打开位置
   rightDragProgress.value = 0
   isDraggingRight.value = true
@@ -750,6 +803,7 @@ function handleCardMenuAction(action: string) {
 // 组件卸载时清理
 onBeforeUnmount(() => {
   downloadProgressHandle?.remove()
+  stopPageResizeObserver()
 })
 
 // --- 卡片操作：阅读 ---
@@ -1570,6 +1624,21 @@ const setupCloseGesture = () => {
   menuCloseGesture.enable(true)
 }
 
+const resetOverlayMenuState = () => {
+  menuCloseGesture?.destroy()
+  menuCloseGesture = undefined
+  rightMenuOpen.value = false
+  isDraggingRight.value = false
+  isSnappingClosed.value = false
+  rightDragProgress.value = 0
+}
+
+// 宽屏 pane 与窄屏 overlay 不共享打开状态，跨越断点时始终从当前模式的默认状态开始。
+watch(isWideLayout, (wide) => {
+  widePaneOpen.value = wide
+  resetOverlayMenuState()
+})
+
 // 右侧菜单打开时建立关闭手势，关闭时销毁；同时刷新在线文件夹数量
 watch(rightMenuOpen, (open) => {
   if (open) {
@@ -1594,6 +1663,7 @@ watch(isLoggedIn, (loggedIn, wasLoggedIn) => {
 })
 
 onMounted(async () => {
+  startPageResizeObserver()
   void initOnlineFolders()
   nextTick(() => {
     void resolveScrollElement()
@@ -1615,8 +1685,10 @@ const savedScrollTop = ref(0)
 
 onDeactivated(() => {
   savedScrollTop.value = scrollElementRef.value?.scrollTop ?? 0
+  stopPageResizeObserver()
   menuCloseGesture?.destroy()
   menuCloseGesture = undefined
+  widePaneOpen.value = false
   rightMenuOpen.value = false
   isDraggingRight.value = false
   isSnappingClosed.value = false
@@ -1625,6 +1697,10 @@ onDeactivated(() => {
 
 onActivated(async () => {
   await nextTick()
+  startPageResizeObserver()
+  if (isWideLayout.value) {
+    widePaneOpen.value = true
+  }
   const scrollEl = scrollElementRef.value ?? (await resolveScrollElement())
   if (scrollEl && savedScrollTop.value > 0) {
     scrollEl.scrollTop = savedScrollTop.value
@@ -1633,8 +1709,27 @@ onActivated(async () => {
 </script>
 
 <style scoped>
+.favorite-page-layout {
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.favorite-page-layout > ion-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+}
+
 .favorite-page-top {
   padding: calc(var(--ion-safe-area-top) + 2px) 14px 0;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .favorite-page-toolbar {
@@ -1685,6 +1780,11 @@ onActivated(async () => {
 
 .folders-toggle-btn:active {
   transform: scale(0.94);
+}
+
+.folders-toggle-btn:focus-visible {
+  outline: 3px solid rgb(201 109 58 / 0.45);
+  outline-offset: 2px;
 }
 
 .current-folder-label {

--- a/tests/unit/FavoriteSideMenu.test.ts
+++ b/tests/unit/FavoriteSideMenu.test.ts
@@ -1,0 +1,107 @@
+/* eslint-disable vue/one-component-per-file -- test-only Ionic and child-component fixtures */
+import { defineComponent, h, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('@ionic/vue', () => ({
+  IonIcon: defineComponent({
+    name: 'IonIcon',
+    setup: () => () => h('span'),
+  }),
+}))
+
+vi.mock('@/components/common/CardContextMenu.vue', () => ({
+  default: defineComponent({
+    name: 'CardContextMenu',
+    props: {
+      visible: Boolean,
+    },
+    setup(props) {
+      return () => (props.visible ? h('div', { class: 'card-context-menu-stub' }) : null)
+    },
+  }),
+}))
+
+import FavoriteSideMenu from '@/components/favorite/FavoriteSideMenu.vue'
+import {
+  isDraggingRight,
+  isSnappingClosed,
+  rightDragProgress,
+  rightMenuOpen,
+} from '@/composables/useSideMenuState'
+
+const baseProps = {
+  modelValue: false,
+  onlineFolders: [{ id: 'online-1', name: '在线收藏', count: 0 }],
+  offlineFolders: [{ id: 'offline-1', name: '离线收藏', count: 3 }],
+  selectedOnlineId: '',
+  selectedOfflineId: 'offline-1',
+  onlineFolderCounts: { 'online-1': 5 },
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  isDraggingRight.value = false
+  isSnappingClosed.value = false
+  rightDragProgress.value = 0
+  rightMenuOpen.value = false
+})
+
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  isDraggingRight.value = false
+  isSnappingClosed.value = false
+  rightDragProgress.value = 0
+  rightMenuOpen.value = false
+})
+
+describe('FavoriteSideMenu 展示模式', () => {
+  test('overlay 模式选择收藏夹后沿用关闭动画', async () => {
+    const wrapper = mount(FavoriteSideMenu, {
+      props: { ...baseProps, modelValue: true },
+    })
+
+    expect(wrapper.get('nav').classes()).not.toContain('fav-menu-pane')
+    await wrapper.get('.folder-item').trigger('click')
+
+    expect(wrapper.emitted('select-online-folder')).toEqual([['online-1']])
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+
+    vi.advanceTimersByTime(260)
+    await nextTick()
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+    wrapper.unmount()
+  })
+
+  test('pane 模式保持静态显示，选择收藏夹后不自动收起', async () => {
+    const wrapper = mount(FavoriteSideMenu, {
+      props: { ...baseProps, displayMode: 'pane', paneOpen: true },
+    })
+
+    const navigation = wrapper.get('nav')
+    expect(navigation.attributes('role')).toBe('navigation')
+    expect(navigation.attributes('aria-label')).toBe('收藏夹')
+    expect(navigation.classes()).toContain('fav-menu-pane')
+    expect(wrapper.get('.fav-menu-panel').element.style.transform).toBe('none')
+
+    await wrapper.get('.folder-item').trigger('click')
+
+    expect(wrapper.emitted('select-online-folder')).toEqual([['online-1']])
+    expect(wrapper.emitted('update:paneOpen')).toBeUndefined()
+    expect(wrapper.get('nav').element.style.display).not.toBe('none')
+    wrapper.unmount()
+  })
+
+  test('pane 模式的关闭按钮只收起 pane', async () => {
+    const wrapper = mount(FavoriteSideMenu, {
+      props: { ...baseProps, displayMode: 'pane', paneOpen: true },
+    })
+
+    await wrapper.get('.menu-close-btn').trigger('click')
+
+    expect(wrapper.emitted('update:paneOpen')).toEqual([[false]])
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 变更

- 收藏页以实际页面容器宽度 1280px 为断点；宽屏保持 1000px 主内容，并提供 280px 右侧收藏夹常驻 pane，pane 可收起和重新展开。
- 窄屏继续使用原有收藏夹 overlay、遮罩、滑动关闭和选择后关闭行为；窗口缩放及应用壳宽度变化会在两种展示模式间重新计算，不共享打开状态。
- 收藏夹 pane 使用导航语义并补齐收藏夹按钮、关闭、添加、选择和更多操作的键盘焦点样式；未修改应用壳、共享侧栏或共享结果组件。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-astra27-localstorage.json npm run test:unit`（48 个测试文件、281 个测试通过）
- `npm run build`

尚未执行真实浏览器下 390/800/1279/1280px 断点与 ASTRA-40 侧栏切换的人工检查；build 保留仓库现有的大 chunk 提示。

Closes #92
Refs ASTRA-27
