### PR TITLE
ASTRA-31: 历史页宽屏适配

### DIFF
--- a/src/views/HistoryPage.vue
+++ b/src/views/HistoryPage.vue
@@ -1062,18 +1062,28 @@ function formatRelativeTime(timestamp: number): string {
 
 <style scoped>
 .toolbar-start {
+  width: 100%;
+  max-width: 720px;
+  box-sizing: border-box;
+  margin-inline: auto;
   padding: 0 0 8px 14px;
 }
 
 /* 页面容器 */
 .page-shell {
-  margin: 0 14px 86px;
+  width: calc(100% - 28px);
+  max-width: 720px;
+  margin: 0 auto 86px;
 }
 
 /* Tab 栏 */
 .tab-bar {
   display: flex;
+  width: 100%;
+  max-width: 720px;
+  box-sizing: border-box;
   gap: 2px;
+  margin-inline: auto;
   margin-bottom: 10px;
   padding: 4px 14px;
   border-radius: 18px;


### PR DESCRIPTION
## 变更

- 为历史页工具栏入口、Tab 栏和正文统一增加 `720px` 最大宽度并水平居中。
- 正文保留窄屏两侧各 `14px` 留白，继续使用单列布局；Tab 切换、分组折叠、分页加载、清空确认、卡片点击和更多菜单交互保持不变。
- 仅修改 `src/views/HistoryPage.vue` 的 scoped CSS，未修改应用壳、共享侧栏或共享组件。

## 验证

- `npx prettier --check src/views/HistoryPage.vue`
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit -- tests/unit/HistoryPage.test.ts`（11/11 通过）
- `npm run build`（通过；保留仓库现有的大 chunk 警告）

未执行真实浏览器视口人工核验；本次改动仅涉及 CSS，未引入新的业务或交互逻辑。

Closes #96
Closes ASTRA-31


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化历史页面布局，内容区域最大宽度调整为 720px 并居中显示。
  * 工具栏和标签栏扩展至整行宽度，提升页面对齐和响应式表现。
  * 调整页面边距计算方式，使不同屏幕尺寸下的间距更加一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->