### PR TITLE
ASTRA-33: 设置页宽屏适配

### DIFF
--- a/src/views/SettingPage.vue
+++ b/src/views/SettingPage.vue
@@ -996,6 +996,10 @@ function onAutoShowToolbarAtEndChange(e: CustomEvent) {
 
 <style scoped>
 .toolbar-start {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 720px;
+  margin-inline: auto;
   padding: 0 0 8px 14px;
 }
 
@@ -1018,6 +1022,10 @@ function onAutoShowToolbarAtEndChange(e: CustomEvent) {
 }
 
 .settings-list {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 720px;
+  margin-inline: auto;
   padding: 8px 16px 32px;
 }
 


### PR DESCRIPTION
## 变更

- 为设置页顶部菜单入口与设置列表增加包含现有 gutter 的 `720px` 居中宽度上限。
- 窄屏布局、DOM/键盘顺序、设置交互、搬迁遮罩及 API/数据行为保持不变。
- 仅修改 `src/views/SettingPage.vue` 的 scoped CSS；未改应用壳、共享侧边栏或 ASTRA-40 相关代码。

## 验证

- `npx prettier --check src/views/SettingPage.vue`
- `npm run test:unit -- tests/unit/SettingPage.test.ts`（1 个测试通过）
- `NODE_OPTIONS=--localstorage-file=.vitest-localstorage npm run test:unit`（47 个文件、278 个测试通过）
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`：未通过，报告基线已有的 `src/services/JmcomicTypes.ts`、`src/services/PdfReaderService.ts`、`src/views/BatchParsePage.vue` 3 个文件；本次文件格式检查通过。

人工核验：检查 CSS 构建产物和 390/800/991/992/1280/1440 宽度下的盒模型计算；容器宽度为 `min(可用宽度, 720px)`，gutter 纳入盒模型（窄屏分别保留 14px/16px），长路径、预览和变量标签沿用现有省略、断行、换行规则，无新增横向溢出。当前环境未提供 Chromium，未执行真实浏览器视口截图检查。

Closes #98
Refs ASTRA-33
