### PR TITLE
ASTRA-29: 限制 PDF 导入审核区宽度

### DIFF
--- a/src/views/PdfImportPage.vue
+++ b/src/views/PdfImportPage.vue
@@ -981,6 +981,10 @@ IonHeader {
 
 /* ---- 页面容器 ---- */
 .page-container {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1000px;
+  margin-inline: auto;
   padding: 12px 14px 132px;
 }
 


### PR DESCRIPTION
## 变更

- 为 `src/views/PdfImportPage.vue` 的 `.page-container` 增加 `1000px` 最大宽度、水平居中和边框盒尺寸约束；统计栏与文件卡片继续保持单列审阅路径。
- 保留现有页面内边距，窗口不足 `1000px` 时仍使用可用宽度；窄屏、文件编辑、候选 ID、章节选择、确认导入和收藏夹流程不变。
- 保留现有 `.search-drawer` 的 `680px` 断点与 `720px` 居中抽屉；未修改应用壳、共享侧边栏、共享组件、路由或业务逻辑。

## 验证

- `npx --no-install prettier --check src/views/PdfImportPage.vue`
- `npm run lint`
- `NODE_OPTIONS=--no-experimental-webstorage npm run test:unit`：42 个测试文件、243 个测试全部通过。
- `npm run typecheck`
- `npm run build`
- `git diff --check`

本地 `npm ci` 受仓库现有 lockfile 与 `package.json` 的 optional packages 不同步影响而无法执行；为保持 lockfile 不变，验证依赖使用 `npm install --no-package-lock --offline`，并将本地 `pdfjs-dist` 调整为 lockfile 指定的 `5.6.205`。仓库没有现成的 PdfImportPage 浏览器/E2E 用例，未新增测试框架或设备截图检查。

Refs ASTRA-29
Refs #94
