### PR TITLE
ASTRA-34: 图片缓存页宽屏适配

### DIFF
--- a/src/views/CachePage.vue
+++ b/src/views/CachePage.vue
@@ -1,7 +1,7 @@
 <template>
   <IonPage>
     <IonHeader class="ion-no-border">
-      <IonToolbar>
+      <IonToolbar class="cache-toolbar">
         <IonButtons slot="start">
           <IonBackButton default-href="/setting" />
         </IonButtons>
@@ -642,6 +642,14 @@ function formatBytes(bytes: number): string {
   font-size: 16px;
   font-weight: 600;
   color: #4c2a18;
+}
+
+.cache-content,
+:deep(ion-toolbar.cache-toolbar) {
+  width: 100%;
+  max-width: 1000px;
+  margin-inline: auto;
+  box-sizing: border-box;
 }
 
 .cache-content {


### PR DESCRIPTION
## 变更

- 仅修改 `src/views/CachePage.vue`：为图片缓存页工具栏增加专属类，并让工具栏宿主与 `.cache-content` 共用 `width: 100%`、`max-width: 1000px`、水平居中和 `border-box`。
- 保留 `.cache-content` 的现有页面内边距、缓存摘要/章节折叠/详情跳转/刷新/滚动恢复/图片预览交互，以及 3/4/5 列断点。
- 保留全屏预览的 `100% × 100%` modal；未修改 `App.vue`、`MainMenu`、`useSideMenuState.ts` 或其他共享应用壳代码，也不依赖 ASTRA-40。

## 验证

- `npx vitest run tests/unit/CachePage.test.ts tests/unit/CachePageRoute.test.ts tests/unit/imageCacheView.test.ts`：3 个文件、13 个测试通过。
- `NODE_OPTIONS="--localstorage-file=<临时文件>" npm run test:unit`：47 个文件、278 个测试通过。
- `npx prettier --check src/views/CachePage.vue`：通过。
- `npm run lint`：通过。
- `npm run typecheck`：通过。
- `npm run build`：通过；保留仓库既有的大 chunk 警告。
- Chrome headless 实际核验 `390/599/600/899/900/1000/1280/1440px`：工具栏与内容区宽度和左边界一致，列数保持 3/4/5，宽于 1000px 时封顶居中且无横向溢出；预览 modal 仍为 `100% × 100%`。

Closes #99
Closes ASTRA-34
