### PR TITLE
ASTRA-26: 完成漫画阅读页宽屏适配

### DIFF
--- a/src/components/reader/HorizontalPageView.vue
+++ b/src/components/reader/HorizontalPageView.vue
@@ -144,6 +144,8 @@ let lastTapT = 0,
   lastTapX = 0,
   lastTapY = 0
 let tapTimer: ReturnType<typeof setTimeout> | null = null
+let animationTimer: ReturnType<typeof setTimeout> | null = null
+let resizeObserver: ResizeObserver | null = null
 
 // ---- 可见槽位 ----
 const visibleIndices = computed(() => {
@@ -177,11 +179,18 @@ watch(
 
 onMounted(() => {
   displayIndex.value = props.currentIndex
-  updateSlotWidth()
-  containerRef.value?.addEventListener('touchstart', onTouchStart, { passive: false })
-  containerRef.value?.addEventListener('touchmove', onTouchMove, { passive: false })
-  containerRef.value?.addEventListener('touchend', onTouchEnd)
-  containerRef.value?.addEventListener('touchcancel', onTouchEnd)
+  const el = containerRef.value
+  if (!el) return
+  refreshAfterResize()
+  el.addEventListener('touchstart', onTouchStart, { passive: false })
+  el.addEventListener('touchmove', onTouchMove, { passive: false })
+  el.addEventListener('touchend', onTouchEnd)
+  el.addEventListener('touchcancel', onTouchEnd)
+
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(refreshAfterResize)
+    resizeObserver.observe(el)
+  }
 })
 
 onUnmounted(() => {
@@ -189,20 +198,42 @@ onUnmounted(() => {
     clearTimeout(tapTimer)
     tapTimer = null
   }
-  containerRef.value?.removeEventListener('touchstart', onTouchStart)
-  containerRef.value?.removeEventListener('touchmove', onTouchMove)
-  containerRef.value?.removeEventListener('touchend', onTouchEnd)
-  containerRef.value?.removeEventListener('touchcancel', onTouchEnd)
+  clearAnimationTimer()
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  const el = containerRef.value
+  if (!el) return
+  el.removeEventListener('touchstart', onTouchStart)
+  el.removeEventListener('touchmove', onTouchMove)
+  el.removeEventListener('touchend', onTouchEnd)
+  el.removeEventListener('touchcancel', onTouchEnd)
 })
 
 function updateSlotWidth() {
-  slotWidth.value = containerRef.value?.clientWidth ?? 0
+  const nextWidth = containerRef.value?.clientWidth ?? 0
+  const changed = nextWidth !== slotWidth.value
+  slotWidth.value = nextWidth
+  return changed
+}
+
+function clearAnimationTimer() {
+  if (!animationTimer) return
+  clearTimeout(animationTimer)
+  animationTimer = null
+}
+
+function refreshAfterResize() {
+  if (!updateSlotWidth()) return
+  clearAnimationTimer()
+  isAnimating.value = false
+  offsetX.value = 0
 }
 
 function slotStyle(idx: number) {
   const zoomed = idx === displayIndex.value && zoomScale.value > 1
   return {
-    left: idx * 100 + 'vw',
+    left: idx * slotWidth.value + 'px',
+    width: slotWidth.value + 'px',
     zIndex: zoomed ? 1 : 0,
     overflow: zoomed ? 'visible' : 'hidden',
   }
@@ -225,7 +256,7 @@ function mid(t: TouchList) {
 // ==================== 手势 ====================
 
 function onTouchStart(ev: TouchEvent) {
-  updateSlotWidth()
+  refreshAfterResize()
   isAnimating.value = false
   fingers = ev.touches.length
 
@@ -420,9 +451,11 @@ function snapTo(target: number) {
     return
   }
   resetZoom()
+  clearAnimationTimer()
   isAnimating.value = true
   offsetX.value = -(target - displayIndex.value) * slotWidth.value
-  setTimeout(() => {
+  animationTimer = setTimeout(() => {
+    animationTimer = null
     isAnimating.value = false
     displayIndex.value = target
     offsetX.value = 0
@@ -431,9 +464,11 @@ function snapTo(target: number) {
 }
 
 function snapBack() {
+  clearAnimationTimer()
   isAnimating.value = true
   offsetX.value = 0
-  setTimeout(() => {
+  animationTimer = setTimeout(() => {
+    animationTimer = null
     isAnimating.value = false
   }, 320)
 }
@@ -468,7 +503,8 @@ defineExpose({ scrollToIndex })
 .page-slot {
   position: absolute;
   top: 0;
-  width: 100vw;
+  left: 0;
+  width: 100%;
   height: 100%;
   overflow: hidden;
 }

--- a/src/components/reader/ReaderSettingsPanel.vue
+++ b/src/components/reader/ReaderSettingsPanel.vue
@@ -299,6 +299,7 @@ function onPreloadConcurrencyChange(e: Event) {
 
 .panel-card {
   width: 100%;
+  max-width: 720px;
   max-height: 80vh;
   background: #fff;
   border-radius: 16px 16px 0 0;

--- a/src/components/reader/ReaderTopToolbar.vue
+++ b/src/components/reader/ReaderTopToolbar.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="top-toolbar">
-    <button type="button" class="back-btn" @click="$emit('back')">
-      <ion-icon :icon="arrowBack" />
-    </button>
-    <span class="chapter-title">{{ title }}</span>
+    <div class="top-toolbar-content">
+      <button type="button" class="back-btn" @click="$emit('back')">
+        <ion-icon :icon="arrowBack" />
+      </button>
+      <span class="chapter-title">{{ title }}</span>
+    </div>
   </div>
 </template>
 
@@ -29,12 +31,20 @@ import { arrowBack } from 'ionicons/icons'
   z-index: 20;
   display: flex;
   align-items: center;
-  gap: 12px;
   min-height: calc(50px + var(--jq-reader-safe-area-top, var(--ion-safe-area-top, 0px)));
   padding: 8px 14px;
   padding-top: calc(8px + var(--jq-reader-safe-area-top, var(--ion-safe-area-top, 0px)));
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(8px);
+}
+
+.top-toolbar-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
 }
 
 .back-btn {
@@ -52,6 +62,8 @@ import { arrowBack } from 'ionicons/icons'
 }
 
 .chapter-title {
+  min-width: 0;
+  flex: 1;
   color: #fff;
   font-size: 14px;
   font-weight: 600;

--- a/src/components/reader/VerticalScrollView.vue
+++ b/src/components/reader/VerticalScrollView.vue
@@ -108,6 +108,7 @@ const ZOOM_MIN = 1
 const DOUBLE_TAP_MS = 280
 const DOUBLE_TAP_DIST = 30
 const MAX_DOM_ITEMS = 100
+const READER_CONTENT_MAX_WIDTH = 720
 // 与 .edge-indicator 高度保持一致，首尾提示区不参与图片高度缩放。
 const EDGE_INDICATOR_HEIGHT = 120
 const SCROLL_SYNC_RETRY_MAX = 30
@@ -129,12 +130,26 @@ const zoomScale = ref(1)
 const zoomTx = ref(0)
 const zoomTy = ref(0)
 
+function getFallbackContentWidth() {
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 0
+  return Math.min(viewportWidth || 360, READER_CONTENT_MAX_WIDTH)
+}
+
+const contentWidth = computed(() => containerWidth.value || getFallbackContentWidth())
+
 const wrapperStyle = computed(() => {
-  if (zoomScale.value <= 1 && zoomTx.value === 0 && zoomTy.value === 0) return undefined
-  return {
-    transform: `translate(${zoomTx.value}px, ${zoomTy.value}px) scale(${zoomScale.value})`,
-    transformOrigin: '0 0',
+  const style: Record<string, string> = {
+    width: `${contentWidth.value}px`,
+    left: '50%',
+    marginLeft: `${-contentWidth.value / 2}px`,
   }
+
+  if (zoomScale.value > 1 || zoomTx.value !== 0 || zoomTy.value !== 0) {
+    style.transform = `translate(${zoomTx.value}px, ${zoomTy.value}px) scale(${zoomScale.value})`
+    style.transformOrigin = '0 0'
+  }
+
+  return style
 })
 
 const contentOffset = computed(() => (props.totalCount > 0 ? EDGE_INDICATOR_HEIGHT : 0))
@@ -169,8 +184,7 @@ const visibleItems = computed<VisibleItem[]>(() => {
 })
 
 function getEstimatedHeight() {
-  const width = containerWidth.value || window.innerWidth || 360
-  return Math.max(320, (width * 4) / 3)
+  return Math.max(320, (contentWidth.value * 4) / 3)
 }
 
 function clampIndex(index: number) {
@@ -274,6 +288,11 @@ function getZoomViewportContentTop() {
   return Math.max(0, (scrollTop - zoomTy.value) / (zoomScale.value || 1))
 }
 
+function getContentOffsetX() {
+  const viewportWidth = containerRef.value?.clientWidth || window.innerWidth || 360
+  return Math.max(0, (viewportWidth - contentWidth.value) / 2)
+}
+
 function updateZoomCurrentIndex() {
   if (zoomScale.value <= 1) return
   updateVisibleRange(getZoomViewportContentTop())
@@ -303,7 +322,10 @@ function updateContainerSize() {
   const el = containerRef.value
   if (!el) return false
   const nextHeight = el.clientHeight
-  const nextWidth = el.clientWidth
+  const nextWidth =
+    el.clientWidth > 0
+      ? Math.min(el.clientWidth, READER_CONTENT_MAX_WIDTH)
+      : getFallbackContentWidth()
   const changed = nextHeight !== containerHeight.value || nextWidth !== containerWidth.value
   containerHeight.value = nextHeight
   containerWidth.value = nextWidth
@@ -338,7 +360,7 @@ function updateMeasuredHeight(index: number, nextHeight: number) {
 function onImageLoad(index: number, ev: Event) {
   const img = ev.target as HTMLImageElement | null
   if (!img || img.naturalWidth <= 0 || img.naturalHeight <= 0) return
-  const width = containerWidth.value || containerRef.value?.clientWidth || img.clientWidth
+  const width = contentWidth.value || img.clientWidth
   if (width <= 0) return
   updateMeasuredHeight(index, (width * img.naturalHeight) / img.naturalWidth)
 }
@@ -479,7 +501,7 @@ function getViewportContentPoint(relX: number, relY: number, scale = zoomScale.v
   const scrollTop = containerRef.value?.scrollTop ?? 0
   const safeScale = scale || 1
   return {
-    x: (relX - zoomTx.value) / safeScale,
+    x: (relX - getContentOffsetX() - zoomTx.value) / safeScale,
     y: (scrollTop + relY - zoomTy.value) / safeScale,
   }
 }
@@ -493,7 +515,7 @@ function applyZoomAtContentPoint(
 ) {
   const scrollTop = containerRef.value?.scrollTop ?? 0
   zoomScale.value = scale
-  zoomTx.value = relX - contentX * scale
+  zoomTx.value = relX - getContentOffsetX() - contentX * scale
   zoomTy.value = scrollTop + relY - contentY * scale
 }
 
@@ -574,7 +596,7 @@ function onTM(ev: TouchEvent) {
     const dx = ev.touches[0].clientX - startX
     const dy = ev.touches[0].clientY - startY
     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true
-    const cw = containerRef.value?.clientWidth ?? 0
+    const cw = contentWidth.value
     const ch = containerRef.value?.clientHeight ?? 0
     const st = containerRef.value?.scrollTop ?? 0
     const contentHeight = Math.max(innerHeight.value, ch)
@@ -708,9 +730,13 @@ defineExpose({ scrollToIndex, containerRef, isAtBottom })
 
 .zoom-wrapper {
   position: absolute;
-  inset: 0;
-  width: 100%;
+  top: 0;
+  right: auto;
+  bottom: 0;
+  left: max(0px, calc((100% - 720px) / 2));
+  width: min(100%, 720px);
   height: 100%;
+  box-sizing: border-box;
   will-change: transform;
 }
 

--- a/tests/unit/HorizontalPageView.test.ts
+++ b/tests/unit/HorizontalPageView.test.ts
@@ -1,12 +1,37 @@
 import { mount } from '@vue/test-utils'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import HorizontalPageView from '@/components/reader/HorizontalPageView.vue'
+
+let resizeObserverTrigger: (() => void) | null = null
+let lastResizeObserver: { disconnected: boolean } | null = null
+
+class ResizeObserverMock {
+  constructor(callback: () => void) {
+    lastResizeObserver = { disconnected: false }
+    resizeObserverTrigger = callback
+  }
+
+  observe() {}
+
+  disconnect() {
+    if (lastResizeObserver) lastResizeObserver.disconnected = true
+  }
+}
+
+beforeEach(() => {
+  resizeObserverTrigger = null
+  lastResizeObserver = null
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  resizeObserverTrigger = null
+  lastResizeObserver = null
 })
 
-function mountView(currentIndex = 1) {
+function mountView(currentIndex = 1, width = 300) {
   const wrapper = mount(HorizontalPageView, {
     props: {
       imageMap: new Map([
@@ -21,12 +46,48 @@ function mountView(currentIndex = 1) {
   const container = wrapper.get('.horizontal-container')
   Object.defineProperties(container.element, {
     clientHeight: { configurable: true, value: 400 },
-    clientWidth: { configurable: true, value: 300 },
+    clientWidth: { configurable: true, value: width },
   })
   return { wrapper, container }
 }
 
 describe('HorizontalPageView', () => {
+  test('页面槽位统一使用容器实际宽度', async () => {
+    const { wrapper } = mountView(1, 1280)
+    resizeObserverTrigger?.()
+    await wrapper.vm.$nextTick()
+
+    const slots = wrapper.findAll('.page-slot')
+    expect(slots[0].attributes('style')).toContain('left: 0px')
+    expect(slots[0].attributes('style')).toContain('width: 1280px')
+    expect(slots[1].attributes('style')).toContain('left: 1280px')
+    expect(slots[2].attributes('style')).toContain('left: 2560px')
+    expect(wrapper.get('.strip').attributes('style')).toContain('width: 3840px')
+    wrapper.unmount()
+  })
+
+  test('容器尺寸变化后重新对齐当前页并断开观察器', async () => {
+    const { wrapper, container } = mountView(1, 300)
+    resizeObserverTrigger?.()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.get('.strip').attributes('style')).toContain('translate3d(-300px, 0, 0)')
+
+    Object.defineProperty(container.element, 'clientWidth', {
+      configurable: true,
+      value: 800,
+    })
+    resizeObserverTrigger?.()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.get('.strip').attributes('style')).toContain('translate3d(-800px, 0, 0)')
+    expect(wrapper.findAll('.page-slot')[1].attributes('style')).toContain('width: 800px')
+    expect(wrapper.props('currentIndex')).toBe(1)
+    expect(wrapper.emitted('update:currentIndex')).toBeUndefined()
+
+    wrapper.unmount()
+    expect(lastResizeObserver?.disconnected).toBe(true)
+  })
+
   test('双指缩放上限为 5 倍', async () => {
     const { wrapper, container } = mountView(0)
 

--- a/tests/unit/VerticalScrollView.test.ts
+++ b/tests/unit/VerticalScrollView.test.ts
@@ -2,7 +2,13 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import VerticalScrollView from '@/components/reader/VerticalScrollView.vue'
 
+let resizeObserverTrigger: (() => void) | null = null
+
 class ResizeObserverMock {
+  constructor(callback: () => void) {
+    resizeObserverTrigger = callback
+  }
+
   observe() {}
 
   disconnect() {}
@@ -12,6 +18,7 @@ let frameId = 0
 
 beforeEach(() => {
   frameId = 0
+  resizeObserverTrigger = null
   vi.stubGlobal('ResizeObserver', ResizeObserverMock)
   vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
     const id = ++frameId
@@ -24,6 +31,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  resizeObserverTrigger = null
 })
 
 async function flushAnimationFrames() {
@@ -154,6 +162,73 @@ describe('VerticalScrollView', () => {
     expect(wrapper.vm.isAtBottom()).toBe(true)
     expect(wrapper.emitted('reached-bottom')).toHaveLength(2)
 
+    wrapper.unmount()
+  })
+
+  test('宽屏纵向阅读轨道限制为 720px，窄屏仍使用可用宽度', async () => {
+    const wrapper = mount(VerticalScrollView, {
+      props: {
+        imageMap: new Map<number, string>(),
+        totalCount: 1,
+        currentIndex: 0,
+      },
+    })
+    const container = wrapper.get('.vertical-container')
+    Object.defineProperties(container.element, {
+      clientHeight: { configurable: true, value: 400 },
+      clientWidth: { configurable: true, value: 1440 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    })
+    await flushAnimationFrames()
+    resizeObserverTrigger?.()
+    await flushAnimationFrames()
+
+    expect(wrapper.get('.zoom-wrapper').attributes('style')).toContain('width: 720px')
+    expect(wrapper.get('.image-wrapper').attributes('style')).toContain('height: 960px')
+
+    Object.defineProperty(container.element, 'clientWidth', {
+      configurable: true,
+      value: 390,
+    })
+    resizeObserverTrigger?.()
+    await flushAnimationFrames()
+
+    expect(wrapper.get('.zoom-wrapper').attributes('style')).toContain('width: 390px')
+    expect(wrapper.get('.image-wrapper').attributes('style')).toContain('height: 520px')
+    wrapper.unmount()
+  })
+
+  test('纵向轨道尺寸变化后保持当前页和滚动锚点', async () => {
+    const wrapper = mount(VerticalScrollView, {
+      props: {
+        imageMap: new Map<number, string>(),
+        totalCount: 3,
+        currentIndex: 0,
+      },
+    })
+    const container = wrapper.get('.vertical-container')
+    Object.defineProperties(container.element, {
+      clientHeight: { configurable: true, value: 400 },
+      clientWidth: { configurable: true, value: 600 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    })
+    await flushAnimationFrames()
+    resizeObserverTrigger?.()
+    await flushAnimationFrames()
+
+    wrapper.vm.scrollToIndex(1)
+    await flushAnimationFrames()
+    expect(container.element.scrollTop).toBe(920)
+
+    Object.defineProperty(container.element, 'clientWidth', {
+      configurable: true,
+      value: 300,
+    })
+    resizeObserverTrigger?.()
+    await flushAnimationFrames()
+
+    expect(container.element.scrollTop).toBe(520)
+    expect(wrapper.emitted('update:currentIndex')).toEqual([[0], [1]])
     wrapper.unmount()
   })
 


### PR DESCRIPTION
Closes ASTRA-26
Closes #91

## 变更

- 纵向阅读保留全屏滚动交互，将漫画图片、占位和首尾提示收束到最大 720px 的居中阅读轨道；窄屏继续使用可用宽度。
- 纵向宽度变化按有效阅读宽度重建高度模型并保持滚动锚点；缩放的焦点和拖拽边界继续以阅读轨道为基准。
- 横向页面槽位、条带位移统一使用容器实际像素宽度，监听并清理 `ResizeObserver`，尺寸变化后保持当前页对齐。
- 顶部工具栏和阅读设置面板保留全屏背景/遮罩，仅将内容行和卡片限制到 720px；未修改应用壳或共享侧边栏。
- 增加宽屏、窄屏、尺寸变化、滚动锚点和观察器清理的单元测试。

## 验证

- `npm run lint -- --no-fix`
- `NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-vitest-localstorage npm run test:unit`（47 个测试文件、282 个测试通过）
- `npm run typecheck`
- `npm run format:check`
- `npm run build`

本机 Node 26 运行全量单测时需要显式提供 `--localstorage-file`；构建保留仓库现有的大 chunk 警告。
