### PR TITLE
ASTRA-32: 批量解析页宽屏适配

### DIFF
--- a/src/views/BatchParsePage.vue
+++ b/src/views/BatchParsePage.vue
@@ -2,108 +2,115 @@
   <IonPage>
     <IonHeader class="ion-no-border">
       <IonToolbar>
-        <div class="header-row">
-          <div class="toolbar-start">
-            <MenuToggleButton />
-          </div>
-          <button type="button" class="header-btn" @click="sourceExpanded = !sourceExpanded">
-            <span class="header-btn-label">{{ sourceExpanded ? '收起原文' : '展开原文' }}</span>
-            <IonIcon :icon="sourceExpanded ? chevronUpOutline : chevronDownOutline" />
-          </button>
-          <button type="button" class="header-btn" :class="{ active: editing }" @click="toggleEdit">
-            <IonIcon :icon="createOutline" />
-          </button>
-        </div>
-
-        <div v-show="sourceExpanded" class="source-area">
-          <template v-if="editing">
-            <div class="edit-toolbar">
-              <div class="edit-fields">
-                <input
-                  v-model="findText"
-                  class="edit-input"
-                  placeholder="查找"
-                  aria-label="查找文本"
-                  enterkeyhint="done"
-                />
-                <input
-                  v-model="replaceText"
-                  class="edit-input"
-                  placeholder="替换为"
-                  aria-label="替换文本"
-                  enterkeyhint="done"
-                />
-              </div>
-              <div class="edit-actions">
-                <button type="button" class="edit-btn" @click="replaceAll">全部替换</button>
-                <button type="button" class="edit-btn" @click="removeSpaces">去除空格</button>
-                <button
-                  type="button"
-                  class="edit-btn"
-                  :disabled="!canNormalizeEditText"
-                  @click="normalizeEditText"
-                >
-                  按 ID 分行
-                </button>
-                <button type="button" class="edit-btn apply" @click="applyEdit">应用修改</button>
-              </div>
+        <div class="toolbar-content">
+          <div class="header-row">
+            <div class="toolbar-start">
+              <MenuToggleButton />
             </div>
-            <textarea v-model="editText" class="source-textarea" rows="5" spellcheck="false" />
-          </template>
-
-          <div v-else ref="sourceScrollRef" class="source-scroll">
-            <div
-              v-for="(line, li) in sourceLines"
-              :key="li"
-              class="source-line"
-              :class="{
-                'current-line': li === currentHighlightLine,
-                'no-results': line.hasOnlyFailed,
-              }"
-              @click="onSourceLineClick(li)"
-            >
-              <template v-for="(seg, si) in line.segments" :key="si">
-                <button
-                  v-if="seg.itemIndex !== undefined"
-                  type="button"
-                  class="source-id"
-                  :class="segClass(seg.type)"
-                  :aria-label="`定位到 ${seg.text}`"
-                  @click.stop="onSourceItemClick(seg.itemIndex)"
-                >
-                  {{ seg.text }}
-                </button>
-                <span v-else :class="segClass(seg.type)">{{ seg.text }}</span>
-              </template>
-            </div>
-          </div>
-        </div>
-
-        <div v-show="sourceExpanded && !editing" class="source-actions-row">
-          <label class="fav-toggle-label">
-            <span class="fav-toggle-text">显示已收藏</span>
+            <button type="button" class="header-btn" @click="sourceExpanded = !sourceExpanded">
+              <span class="header-btn-label">{{ sourceExpanded ? '收起原文' : '展开原文' }}</span>
+              <IonIcon :icon="sourceExpanded ? chevronUpOutline : chevronDownOutline" />
+            </button>
             <button
               type="button"
-              class="fav-toggle"
-              :class="{ on: showFavStatus }"
-              :disabled="loadingFavStatus"
-              role="switch"
-              :aria-checked="showFavStatus"
-              @click="toggleFavStatus"
+              class="header-btn"
+              :class="{ active: editing }"
+              @click="toggleEdit"
             >
-              <IonSpinner v-if="loadingFavStatus" name="dots" class="fav-toggle-spinner" />
-              <span v-else class="fav-toggle-knob" />
+              <IonIcon :icon="createOutline" />
             </button>
-          </label>
-          <button
-            type="button"
-            class="save-list-btn"
-            :disabled="loading || albumResults.every((a) => a === null)"
-            @click="openBatchSave"
-          >
-            <IonIcon :icon="bookmarkOutline" class="save-list-icon" />
-            <span>保存当前列表到收藏夹</span>
-          </button>
+          </div>
+
+          <div v-show="sourceExpanded" class="source-area">
+            <template v-if="editing">
+              <div class="edit-toolbar">
+                <div class="edit-fields">
+                  <input
+                    v-model="findText"
+                    class="edit-input"
+                    placeholder="查找"
+                    aria-label="查找文本"
+                    enterkeyhint="done"
+                  />
+                  <input
+                    v-model="replaceText"
+                    class="edit-input"
+                    placeholder="替换为"
+                    aria-label="替换文本"
+                    enterkeyhint="done"
+                  />
+                </div>
+                <div class="edit-actions">
+                  <button type="button" class="edit-btn" @click="replaceAll">全部替换</button>
+                  <button type="button" class="edit-btn" @click="removeSpaces">去除空格</button>
+                  <button
+                    type="button"
+                    class="edit-btn"
+                    :disabled="!canNormalizeEditText"
+                    @click="normalizeEditText"
+                  >
+                    按 ID 分行
+                  </button>
+                  <button type="button" class="edit-btn apply" @click="applyEdit">应用修改</button>
+                </div>
+              </div>
+              <textarea v-model="editText" class="source-textarea" rows="5" spellcheck="false" />
+            </template>
+
+            <div v-else ref="sourceScrollRef" class="source-scroll">
+              <div
+                v-for="(line, li) in sourceLines"
+                :key="li"
+                class="source-line"
+                :class="{
+                  'current-line': li === currentHighlightLine,
+                  'no-results': line.hasOnlyFailed,
+                }"
+                @click="onSourceLineClick(li)"
+              >
+                <template v-for="(seg, si) in line.segments" :key="si">
+                  <button
+                    v-if="seg.itemIndex !== undefined"
+                    type="button"
+                    class="source-id"
+                    :class="segClass(seg.type)"
+                    :aria-label="`定位到 ${seg.text}`"
+                    @click.stop="onSourceItemClick(seg.itemIndex)"
+                  >
+                    {{ seg.text }}
+                  </button>
+                  <span v-else :class="segClass(seg.type)">{{ seg.text }}</span>
+                </template>
+              </div>
+            </div>
+          </div>
+
+          <div v-show="sourceExpanded && !editing" class="source-actions-row">
+            <label class="fav-toggle-label">
+              <span class="fav-toggle-text">显示已收藏</span>
+              <button
+                type="button"
+                class="fav-toggle"
+                :class="{ on: showFavStatus }"
+                :disabled="loadingFavStatus"
+                role="switch"
+                :aria-checked="showFavStatus"
+                @click="toggleFavStatus"
+              >
+                <IonSpinner v-if="loadingFavStatus" name="dots" class="fav-toggle-spinner" />
+                <span v-else class="fav-toggle-knob" />
+              </button>
+            </label>
+            <button
+              type="button"
+              class="save-list-btn"
+              :disabled="loading || albumResults.every((a) => a === null)"
+              @click="openBatchSave"
+            >
+              <IonIcon :icon="bookmarkOutline" class="save-list-icon" />
+              <span>保存当前列表到收藏夹</span>
+            </button>
+          </div>
         </div>
       </IonToolbar>
     </IonHeader>
@@ -1161,6 +1168,12 @@ const progressPercent = computed(() => {
   --min-height: auto;
   --padding-top: 0;
   --padding-bottom: 0;
+}
+
+.toolbar-content {
+  width: 100%;
+  max-width: 1000px;
+  margin-inline: auto;
 }
 
 .header-row {


### PR DESCRIPTION
## 变更

- 在 `IonToolbar` 内增加页面局部容器，将批量解析页顶部工作区限制为 `1000px` 并水平居中。
- 保留原有内部边距、编辑布局、原文滚动上限，以及结果列表/网格、定位高亮、菜单、收藏和进度遮罩行为。
- 仅修改 `src/views/BatchParsePage.vue`，不涉及共享组件、应用壳、路由或共享侧边栏。

## 验证

- `npx vitest run tests/unit/BatchParsePage.test.ts`：8/8 通过。
- `npm run lint`：通过。
- `env NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-localstorage.json npm run test:unit`：47 个测试文件、278 个测试通过。
- `npm run typecheck`：通过。
- `npx prettier --check src/views/BatchParsePage.vue`：通过。
- 使用本分支本地服务检查 390×844、800×1280、1280×800、1440×900：顶部工作区在宽屏居中并与结果区对齐，窄屏与平板无横向溢出。

Refs ASTRA-32
Refs #97
