### PR TITLE
ASTRA-35: 网络状态页宽屏适配

### DIFF
--- a/src/views/NetworkStatusPage.vue
+++ b/src/views/NetworkStatusPage.vue
@@ -10,51 +10,57 @@
     </IonHeader>
     <IonContent>
       <div class="page-content">
-        <!-- 域名连通性 -->
-        <div class="section-header">
-          <span class="section-label">域名连通性</span>
-          <div class="header-actions">
-            <IonIcon
-              :icon="speedometerOutline"
-              class="speed-btn"
-              :class="{ spinning: measuring }"
-              @click="handleMeasureLatency"
-            />
-            <IonIcon
-              :icon="refreshOutline"
-              class="refresh-btn"
-              :class="{ spinning: refreshing }"
-              @click="handleRefresh"
-            />
-          </div>
-        </div>
-        <div class="card">
-          <div v-if="store.domains.value.length" class="domain-list">
-            <div v-for="d in store.domains.value" :key="d.domain" class="domain-row">
-              <span
-                class="domain-dot"
-                :class="store.allDeadFallback.value ? 'dead' : d.reachable ? 'alive' : 'dead'"
-              />
-              <span class="domain-name">{{ d.domain }}</span>
-              <span class="latency" :class="latencyClass(d.domain, d.reachable)">
-                {{ latencyText(d.domain, d.reachable) }}
-              </span>
+        <div class="status-grid">
+          <section class="status-section">
+            <!-- 域名连通性 -->
+            <div class="section-header">
+              <span class="section-label">域名连通性</span>
+              <div class="header-actions">
+                <IonIcon
+                  :icon="speedometerOutline"
+                  class="speed-btn"
+                  :class="{ spinning: measuring }"
+                  @click="handleMeasureLatency"
+                />
+                <IonIcon
+                  :icon="refreshOutline"
+                  class="refresh-btn"
+                  :class="{ spinning: refreshing }"
+                  @click="handleRefresh"
+                />
+              </div>
             </div>
-          </div>
-          <div v-else class="empty-state">等待首次探活...</div>
-        </div>
+            <div class="card">
+              <div v-if="store.domains.value.length" class="domain-list">
+                <div v-for="d in store.domains.value" :key="d.domain" class="domain-row">
+                  <span
+                    class="domain-dot"
+                    :class="store.allDeadFallback.value ? 'dead' : d.reachable ? 'alive' : 'dead'"
+                  />
+                  <span class="domain-name">{{ d.domain }}</span>
+                  <span class="latency" :class="latencyClass(d.domain, d.reachable)">
+                    {{ latencyText(d.domain, d.reachable) }}
+                  </span>
+                </div>
+              </div>
+              <div v-else class="empty-state">等待首次探活...</div>
+            </div>
+          </section>
 
-        <!-- 事件日志 -->
-        <div class="section-label" style="margin: 8px 0 8px 6px">事件日志</div>
-        <div class="card">
-          <div v-if="store.events.value.length" class="log-list">
-            <div v-for="(evt, i) in store.events.value" :key="i" class="log-row">
-              <span class="log-time">{{ formatTime(evt.timestamp) }}</span>
-              <span class="log-dot" :class="phaseClass(evt.phase)" />
-              <span class="log-msg">{{ evt.message }}</span>
+          <section class="status-section">
+            <!-- 事件日志 -->
+            <div class="section-label section-title">事件日志</div>
+            <div class="card">
+              <div v-if="store.events.value.length" class="log-list">
+                <div v-for="(evt, i) in store.events.value" :key="i" class="log-row">
+                  <span class="log-time">{{ formatTime(evt.timestamp) }}</span>
+                  <span class="log-dot" :class="phaseClass(evt.phase)" />
+                  <span class="log-msg">{{ evt.message }}</span>
+                </div>
+              </div>
+              <div v-else class="empty-state">暂无事件</div>
             </div>
-          </div>
-          <div v-else class="empty-state">暂无事件</div>
+          </section>
         </div>
       </div>
     </IonContent>
@@ -186,7 +192,25 @@ function formatTime(ts: number): string {
 }
 
 .page-content {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
   padding: 8px 16px 32px;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+
+.status-section {
+  min-width: 0;
+}
+
+.section-title {
+  margin: 8px 0 8px 6px;
 }
 
 .section-label {
@@ -243,6 +267,7 @@ function formatTime(ts: number): string {
   background: #fffbf8;
   border-radius: 14px;
   box-shadow: 0 2px 12px rgba(115, 67, 38, 0.06);
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -251,6 +276,7 @@ function formatTime(ts: number): string {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   padding: 10px 16px;
 }
 
@@ -277,6 +303,7 @@ function formatTime(ts: number): string {
   font-size: 13px;
   color: #4c2a18;
   word-break: break-all;
+  min-width: 0;
   flex: 1;
 }
 
@@ -304,6 +331,7 @@ function formatTime(ts: number): string {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
   padding: 6px 16px;
 }
 
@@ -344,6 +372,9 @@ function formatTime(ts: number): string {
 .log-msg {
   font-size: 12px;
   color: #4c2a18;
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
 }
 
 .empty-state {
@@ -351,5 +382,12 @@ function formatTime(ts: number): string {
   text-align: center;
   font-size: 13px;
   color: #b89a84;
+}
+
+@media (min-width: 992px) {
+  .status-grid {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    column-gap: 16px;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更

- 仅修改 `src/views/NetworkStatusPage.vue`：窄屏继续单列，`992px` 起切换为域名连通性与事件日志 `2:3` 双栏。
- 内容区限制为 `1000px` 并居中；为域名、日志行及消息补充可收缩和换行约束，50 条事件保持纵向延伸且不造成页面横向溢出。
- 保留原有刷新、测速、状态文案和事件处理逻辑，不依赖 ASTRA-40，也未修改共享应用壳。

## 验证

- `npx prettier --check src/views/NetworkStatusPage.vue`
- `npm run lint`
- `npm run typecheck`
- `NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-astra-35-vitest-localstorage npm run test:unit`：47 个测试文件、278 个测试通过。
- `npm run build`：构建通过；保留仓库既有的大 chunk 警告。
- Chrome 手工核验 `390×844`、`800×1280`、`991×800`、`992×800`、`1280×800`、`1440×900`：断点前后即时重排，宽屏 `1000px` 居中；注入长域名、长日志和 50 条事件后各视口无页面级横向溢出，刷新/测速控件可触发。

## 限制

- 手工核验使用浏览器空状态及注入的长文本/事件数据，未连接 Android 原生网络探活实现；本 PR 未改变该原生交互路径。

Closes #100
