### PR TITLE
ASTRA-39: 完成 PDF 文件名模板帮助页宽屏适配

### DIFF
--- a/src/views/PdfTemplateHelpPage.vue
+++ b/src/views/PdfTemplateHelpPage.vue
@@ -1,7 +1,7 @@
 <template>
   <IonPage>
     <IonHeader class="ion-no-border">
-      <IonToolbar>
+      <IonToolbar class="pdf-template-help-toolbar">
         <IonButtons slot="start">
           <IonBackButton default-href="/setting" />
         </IonButtons>
@@ -142,7 +142,18 @@ const templateExamples = [
   color: #4c2a18;
 }
 
+.pdf-template-help-toolbar {
+  width: 100%;
+  max-width: 920px;
+  margin-inline: auto;
+  box-sizing: border-box;
+}
+
 .help-container {
+  width: 100%;
+  max-width: 920px;
+  margin-inline: auto;
+  box-sizing: border-box;
   padding: 8px 16px 32px;
 }
 


### PR DESCRIPTION
## 变更

- 仅修改 `src/views/PdfTemplateHelpPage.vue`。
- 为本页 `IonToolbar` 增加 `pdf-template-help-toolbar` 专属类，并让工具栏宿主与 `.help-container` 共用 `width: 100%`、`max-width: 920px`、`margin-inline: auto`、`box-sizing: border-box` 内容边界。
- 保留现有内边距、卡片与表格语义、章节顺序、自动换行行为及所有渲染逻辑；未修改应用壳、共享侧边栏、路由、依赖或配置。

Closes #104

## 验证

- `npx --no-install prettier --check src/views/PdfTemplateHelpPage.vue`：通过。
- `npm run lint`：通过。
- `NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-astra-39-vitest-localstorage npm run test:unit`：通过，47 个测试文件、278 个测试通过。
- `npx --no-install vite build`：通过；保留仓库已有的大 chunk 警告。
- Chrome 实际布局检查：390px、688px、920px 下工具栏与正文占满 `#main-content`；1200px 下两者均为 920px 居中；四种宽度均无横向溢出，章节顺序保持不变。

## 限制

- `npm run typecheck` 与 `npm run build` 均在既有的 `src/services/PdfReaderService.ts:67` 类型错误处停止（`isEvalSupported` 不符合当前 `pdfjs-dist` 的 `DocumentInitParameters`）；该文件不在本 Issue 范围内，因此未修改。
- ASTRA-40 侧栏展开/rail 两态的合并后集成检查仍待 ASTRA-40 可用后执行；本 PR 未修改其代码。
