### PR TITLE
ASTRA-37: 登录页宽屏居中适配

### DIFF
--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -105,6 +105,15 @@ async function doLogin() {
   padding: 32px 20px 0;
 }
 
+@media (min-width: 680px) {
+  .login-container {
+    align-items: center;
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: 32px 20px;
+  }
+}
+
 .login-card {
   width: 100%;
   max-width: 400px;


### PR DESCRIPTION
## 变更

- 仅修改 `src/views/LoginPage.vue` 的 scoped style。
- `680px` 以下保留现有布局和交互；从 `680px` 起让登录卡片在 `IonContent` 可用内容区水平、垂直居中，并继续保持 `400px` 宽度上限。
- 使用带 `box-sizing: border-box` 的 `min-height: 100%` 和四周安全内边距，内容在短视口、软键盘压缩或错误提示出现时可增长并由 `IonContent` 滚动；未修改模板、认证逻辑、router、API、数据格式、配置、应用壳或共享侧边栏。

## 验证

- `npx prettier --check src/views/LoginPage.vue`
- `npm run lint -- --no-fix`
- `npm run typecheck`
- `npm run build`（通过；保留仓库既有的大 chunk 警告）
- 使用 Chrome 151 本地服务人工核验 `390×844`、`679px`、`680px`、`1024×768`、`1440×900` 和 `1024×480`：窄屏保持顶部布局，`680px` 起卡片在内容区居中且宽度为 `400px`；另在 `1024×240` 压缩视口插入错误提示后确认 `IonContent` 可滚动、滚到底部登录按钮可见。

Closes #102
Closes ASTRA-37
