### PR TITLE
ASTRA-41: add fake debug-only Picacomic reader flow

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,6 +84,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 repositories {

--- a/android/app/src/androidTest/java/io/github/jukomu/picacomic/PicacomicDebugFixtureContractTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/picacomic/PicacomicDebugFixtureContractTest.java
@@ -1,0 +1,58 @@
+package io.github.jukomu.picacomic;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import io.github.jukomu.feature.cache.ImageCache;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Verifies that a debug Android flow uses the CP2 native fake boundary. */
+@RunWith(AndroidJUnit4.class)
+public class PicacomicDebugFixtureContractTest {
+
+    private PicacomicRuntime runtime;
+
+    @After
+    public void tearDown() {
+        if (runtime != null) runtime.close();
+        PicacomicRuntime.resetProcessForTests();
+        PicacomicCacheNamespace.clear(ImageCache.getInstance());
+    }
+
+    @Test
+    public void debugRuntimeProvidesFakeCatalogChapterAndNativeImageBoundary() throws Exception {
+        runtime = PicacomicRuntime.getOrCreate(
+            InstrumentationRegistry.getInstrumentation().getTargetContext());
+        runtime.login("fixture-user", "fixture-password", new PicacomicCancellationToken());
+
+        PicacomicCatalogPage page = runtime.search(
+            "fixture", "latest", 1, new PicacomicCancellationToken());
+        assertEquals(1, page.items.size());
+        assertTrue(page.items.get(0).ref.albumId.startsWith("fixture-album-"));
+
+        PicacomicAlbumDetail album = runtime.getAlbum(
+            page.items.get(0).ref.albumId, new PicacomicCancellationToken());
+        PicacomicChapterDetail chapter = runtime.getPhoto(
+            album.chapters.get(0).ref, new PicacomicCancellationToken());
+        PicacomicImageRef image = chapter.images.get(0);
+        assertTrue(image.imageKey.startsWith("pica-"));
+        assertTrue(image.cacheUrl.contains("/picacomic/"));
+
+        CountDownLatch ready = new CountDownLatch(1);
+        PicacomicImageRequestResult request = runtime.requestImages(
+            java.util.Collections.singletonList(image.imageKey), false, event -> ready.countDown(),
+            new PicacomicCancellationToken());
+        assertEquals(1, request.pending.size());
+        assertTrue(ready.await(2, TimeUnit.SECONDS));
+        assertTrue(ImageCache.getInstance().has(image.cacheKey()));
+        assertFalse(image.cacheUrl.contains("debug-fixture"));
+    }
+}

--- a/android/app/src/main/java/io/github/jukomu/picacomic/PicacomicDebugRemoteClient.java
+++ b/android/app/src/main/java/io/github/jukomu/picacomic/PicacomicDebugRemoteClient.java
@@ -1,0 +1,144 @@
+package io.github.jukomu.picacomic;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Deterministic debug-only fixture for the internal UI route.
+ *
+ * <p>This client has no network implementation and is selected only when the
+ * Android application is built with {@code BuildConfig.DEBUG}. Release builds
+ * keep the unavailable CP2 default client.</p>
+ */
+final class PicacomicDebugRemoteClient implements PicacomicRemoteClient {
+
+    private static final byte[] PNG_HEADER = new byte[]{
+        (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        0x00, 0x00, 0x00, 0x00
+    };
+
+    private final List<PicacomicRemoteModels.Album> albums = Arrays.asList(
+        album("fixture-album-1", "Debug Fixture: Moonlit Archive", "Fixture Author A"),
+        album("fixture-album-2", "Debug Fixture: Paper Garden", "Fixture Author B"));
+
+    @Override
+    public PicacomicRemoteModels.User login(String usernameOrEmail, String password,
+                                            PicacomicCancellationToken cancellation)
+        throws Exception {
+        cancellation.throwIfCancelled();
+        return new PicacomicRemoteModels.User(
+            "debug-user", usernameOrEmail, "", "");
+    }
+
+    @Override
+    public PicacomicRemoteModels.Page search(String query, String order, int page,
+                                             PicacomicCancellationToken cancellation)
+        throws Exception {
+        cancellation.throwIfCancelled();
+        throwScenario(query);
+        if ("empty".equalsIgnoreCase(value(query))) {
+            return new PicacomicRemoteModels.Page(page, 1, 0, Collections.emptyList());
+        }
+        return page(page);
+    }
+
+    @Override
+    public PicacomicRemoteModels.Page categories(String category, String order, int page,
+                                                 PicacomicCancellationToken cancellation)
+        throws Exception {
+        cancellation.throwIfCancelled();
+        throwScenario(category);
+        if ("empty".equalsIgnoreCase(value(category))) {
+            return new PicacomicRemoteModels.Page(page, 1, 0, Collections.emptyList());
+        }
+        return page(page);
+    }
+
+    @Override
+    public PicacomicRemoteModels.Album getAlbum(String albumId,
+                                                PicacomicCancellationToken cancellation)
+        throws Exception {
+        cancellation.throwIfCancelled();
+        for (PicacomicRemoteModels.Album album : albums) {
+            if (album.id.equals(albumId)) return album;
+        }
+        throw new PicacomicRemoteException(PicacomicRemoteException.Kind.NOT_FOUND, 404);
+    }
+
+    @Override
+    public PicacomicRemoteModels.Photo getPhoto(String albumId, int order,
+                                                PicacomicCancellationToken cancellation)
+        throws Exception {
+        cancellation.throwIfCancelled();
+        PicacomicRemoteModels.Album album = getAlbum(albumId, cancellation);
+        for (PicacomicRemoteModels.Photo photo : album.photos) {
+            if (photo.order == order) return photo;
+        }
+        throw new PicacomicRemoteException(PicacomicRemoteException.Kind.NOT_FOUND, 404);
+    }
+
+    @Override
+    public byte[] fetchImageBytes(PicacomicImageSource source,
+                                  PicacomicCancellationToken cancellation)
+        throws Exception {
+        cancellation.throwIfCancelled();
+        return PNG_HEADER.clone();
+    }
+
+    @Override
+    public void close() {
+        // The fixture owns no external resource.
+    }
+
+    private PicacomicRemoteModels.Page page(int page) {
+        if (page <= 0 || page > albums.size()) {
+            return new PicacomicRemoteModels.Page(page, albums.size(), albums.size(),
+                Collections.emptyList());
+        }
+        return new PicacomicRemoteModels.Page(page, albums.size(), albums.size(),
+            Collections.singletonList(albums.get(page - 1)));
+    }
+
+    private static void throwScenario(String value) throws PicacomicRemoteException {
+        switch (value.toLowerCase()) {
+            case "401":
+                throw PicacomicRemoteException.unauthorized();
+            case "403":
+                throw PicacomicRemoteException.forbidden();
+            case "network":
+                throw new PicacomicRemoteException(PicacomicRemoteException.Kind.NETWORK);
+            case "parse":
+                throw new PicacomicRemoteException(PicacomicRemoteException.Kind.PARSE);
+            default:
+                return;
+        }
+    }
+
+    private static String value(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static PicacomicRemoteModels.Album album(String id, String title, String author) {
+        PicacomicRemoteModels.Image cover = new PicacomicRemoteModels.Image(
+            "cover.jpg", "debug-fixture", "/" + id + "/cover.jpg", null);
+        PicacomicRemoteModels.Photo chapterOne = new PicacomicRemoteModels.Photo(
+            id, "chapter-1", "Archive entry", "2026-08-01", 1, false,
+            Arrays.asList(
+                image(id, "chapter-1", 1), image(id, "chapter-1", 2),
+                image(id, "chapter-1", 3)));
+        PicacomicRemoteModels.Photo chapterTwo = new PicacomicRemoteModels.Photo(
+            id, "chapter-2", "Garden entry", "2026-08-02", 2, false,
+            Arrays.asList(image(id, "chapter-2", 1), image(id, "chapter-2", 2)));
+        return new PicacomicRemoteModels.Album(id, title, author, "Debug Team",
+            Collections.singletonList("debug"), Collections.singletonList("fixture"), cover,
+            "A local fake album for the CP3 debug-only read flow.", 5, 2, false,
+            "2026-08-01", "2026-08-02", Arrays.asList(chapterTwo, chapterOne));
+    }
+
+    private static PicacomicRemoteModels.Image image(String albumId, String chapterId, int page) {
+        return new PicacomicRemoteModels.Image(
+            "page-" + page + ".png", "debug-fixture",
+            "/" + albumId + "/" + chapterId + "/page-" + page + ".png", null);
+    }
+}

--- a/android/app/src/main/java/io/github/jukomu/picacomic/PicacomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/picacomic/PicacomicPlugin.java
@@ -57,6 +57,14 @@ public final class PicacomicPlugin extends Plugin {
         return new PicacomicPlugin(runtime, null);
     }
 
+    /** Build gate for the internal fake UI; it does not create a runtime. */
+    @PluginMethod
+    public void getBuildInfo(PluginCall call) {
+        JSObject result = new JSObject();
+        result.put("debugUiEnabled", io.github.jukomu.BuildConfig.DEBUG);
+        resolve(call, result);
+    }
+
     @PluginMethod
     public void getAuthState(PluginCall call) {
         PicacomicRuntime runtime = currentRuntime();

--- a/android/app/src/main/java/io/github/jukomu/picacomic/PicacomicRuntime.java
+++ b/android/app/src/main/java/io/github/jukomu/picacomic/PicacomicRuntime.java
@@ -2,6 +2,7 @@ package io.github.jukomu.picacomic;
 
 import android.content.Context;
 
+import io.github.jukomu.BuildConfig;
 import io.github.jukomu.feature.cache.ImageCache;
 
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public final class PicacomicRuntime implements AutoCloseable {
 
     /** Production process runtime.  The default client is intentionally unavailable in CP2. */
     public static PicacomicRuntime getOrCreate(Context context) {
-        return getOrCreate(context, UNAVAILABLE_CLIENT_FACTORY);
+        return getOrCreate(context, defaultClientFactory());
     }
 
     /** Injectable overload used by a future artifact adapter and contract tests. */
@@ -98,6 +99,11 @@ public final class PicacomicRuntime implements AutoCloseable {
     /** Isolated runtime constructor for JVM/Android contract tests. */
     public static PicacomicRuntime createIsolated(ClientFactory factory, ImageCache cache) {
         return new PicacomicRuntime(factory, cache);
+    }
+
+    private static ClientFactory defaultClientFactory() {
+        return BuildConfig.DEBUG ? PicacomicDebugRemoteClient::new
+            : UNAVAILABLE_CLIENT_FACTORY;
     }
 
     /** Test cleanup for a process singleton; it is not used by application code. */

--- a/src/features/picacomic/auth.ts
+++ b/src/features/picacomic/auth.ts
@@ -1,0 +1,88 @@
+import { computed, readonly, ref, type ComputedRef, type Ref } from 'vue'
+import type { PicacomicAuthState, PicacomicRedirect, PicacomicRouteName } from './types'
+import { picacomicService } from './service'
+import type { PicacomicService } from './service'
+
+export interface PicacomicAuthController {
+  state: Readonly<Ref<PicacomicAuthState>>
+  user: ComputedRef<PicacomicAuthState['user']>
+  isSignedIn: ComputedRef<boolean>
+  refresh: () => Promise<PicacomicAuthState>
+  login: (usernameOrEmail: string, password: string) => Promise<PicacomicAuthState>
+  logout: () => Promise<void>
+  captureRedirect: (redirect: PicacomicRedirect) => void
+  consumeRedirect: () => PicacomicRedirect | null
+}
+
+export function createPicacomicAuth(service: PicacomicService): PicacomicAuthController {
+  const state = ref<PicacomicAuthState>({ state: 'signed_out' })
+  const redirect = ref<PicacomicRedirect | null>(null)
+
+  const refresh = async () => {
+    const next = await service.getAuthState()
+    state.value = next
+    return next
+  }
+
+  const login = async (usernameOrEmail: string, password: string) => {
+    state.value = { state: 'authenticating' }
+    try {
+      const next = await service.login(usernameOrEmail, password)
+      state.value = next
+      return next
+    } catch (error) {
+      const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined
+      state.value =
+        code === 'PICACOMIC_AUTH_EXPIRED' ? { state: 'expired' } : { state: 'signed_out' }
+      throw error
+    }
+  }
+
+  const logout = async () => {
+    try {
+      await service.logout()
+    } finally {
+      state.value = { state: 'signed_out' }
+      redirect.value = null
+    }
+  }
+
+  const captureRedirect = (next: PicacomicRedirect) => {
+    redirect.value = {
+      name: next.name,
+      params: { ...next.params },
+    }
+  }
+
+  const consumeRedirect = () => {
+    const next = redirect.value
+    redirect.value = null
+    return next ? { name: next.name, params: { ...next.params } } : null
+  }
+
+  return {
+    state: readonly(state),
+    user: computed(() => state.value.user),
+    isSignedIn: computed(() => state.value.state === 'signed_in'),
+    refresh,
+    login,
+    logout,
+    captureRedirect,
+    consumeRedirect,
+  }
+}
+
+export const picacomicAuth = createPicacomicAuth(picacomicService)
+
+export function usePicacomicAuth() {
+  return picacomicAuth
+}
+
+export function isPicacomicRouteName(value: unknown): value is PicacomicRouteName {
+  return (
+    value === 'PicacomicLoginPage' ||
+    value === 'PicacomicBrowsePage' ||
+    value === 'PicacomicAlbumPage' ||
+    value === 'PicacomicReaderPage'
+  )
+}

--- a/src/features/picacomic/client.ts
+++ b/src/features/picacomic/client.ts
@@ -1,0 +1,4 @@
+import { registerPlugin } from '@capacitor/core'
+import type { PicacomicPluginClient } from './types'
+
+export const picacomicNativeClient = registerPlugin<PicacomicPluginClient>('Picacomic')

--- a/src/features/picacomic/errors.ts
+++ b/src/features/picacomic/errors.ts
@@ -1,0 +1,16 @@
+import type { PicacomicErrorCode } from './types'
+
+export class PicacomicServiceError extends Error {
+  readonly code: PicacomicErrorCode
+  readonly retryable: boolean
+
+  constructor(code: PicacomicErrorCode, operation: string, cause?: unknown) {
+    super(`${operation} failed (${code})`)
+    this.name = 'PicacomicServiceError'
+    this.code = code
+    this.retryable = ['PICACOMIC_NETWORK', 'PICACOMIC_RATE_LIMITED', 'PICACOMIC_UPSTREAM'].includes(
+      code,
+    )
+    if (cause !== undefined) this.cause = cause
+  }
+}

--- a/src/features/picacomic/fixture.ts
+++ b/src/features/picacomic/fixture.ts
@@ -1,0 +1,306 @@
+import { PicacomicServiceError } from './errors'
+import type {
+  PicacomicAuthState,
+  PicacomicImageFailedEvent,
+  PicacomicImageReadyEvent,
+  PicacomicImageRequestResult,
+  PicacomicPluginClient,
+  RawPicacomicAlbumDetail,
+  RawPicacomicCatalogPage,
+  RawPicacomicChapterDetail,
+} from './types'
+
+export interface PicacomicFixtureOptions {
+  initiallySignedIn?: boolean
+  failImageKeys?: string[]
+  deferImageEvents?: boolean
+}
+
+type ImageListener = (event: PicacomicImageReadyEvent | PicacomicImageFailedEvent) => void
+
+export function createPicacomicFixtureClient(
+  options: PicacomicFixtureOptions = {},
+): PicacomicPluginClient & {
+  readonly calls: string[]
+  readonly imageKeys: readonly string[]
+  readonly flushImageEvents: () => void
+} {
+  const listeners = new Map<'picacomicImageReady' | 'picacomicImageFailed', Set<ImageListener>>([
+    ['picacomicImageReady', new Set()],
+    ['picacomicImageFailed', new Set()],
+  ])
+  const calls: string[] = []
+  const loadedImages = new Set<string>()
+  const pendingImages = new Set<string>()
+  const failedOnce = new Set<string>()
+  const failImageKeys = new Set(options.failImageKeys ?? [])
+  const deferredImageEvents: Array<() => void> = []
+  let authState: PicacomicAuthState = options.initiallySignedIn
+    ? { state: 'signed_in', user: { id: 'fixture-user', username: 'fixture-user' } }
+    : { state: 'signed_out' }
+
+  const albums = [
+    createAlbum('fixture-album-1', '月光档案', '作者甲'),
+    createAlbum('fixture-album-2', '纸上花园', '作者乙'),
+  ]
+  const imageMap = new Map<string, { cacheUrl: string }>()
+  for (const album of albums) {
+    for (const chapter of album.chapters ?? []) {
+      for (const image of chapter.images ?? []) {
+        if (image.imageKey && image.cacheUrl)
+          imageMap.set(image.imageKey, { cacheUrl: image.cacheUrl })
+      }
+    }
+    if (album.cover?.imageKey && album.cover.cacheUrl) {
+      imageMap.set(album.cover.imageKey, { cacheUrl: album.cover.cacheUrl })
+    }
+  }
+
+  const emit = (
+    eventName: 'picacomicImageReady' | 'picacomicImageFailed',
+    event: PicacomicImageReadyEvent | PicacomicImageFailedEvent,
+  ) => {
+    for (const listener of listeners.get(eventName) ?? []) listener(event)
+  }
+
+  const ensureSignedIn = () => {
+    if (authState.state !== 'signed_in') {
+      throw new PicacomicServiceError('PICACOMIC_AUTH_REQUIRED', 'fixture')
+    }
+  }
+
+  const scenario = (value: string) => {
+    switch (value.trim().toLowerCase()) {
+      case '401':
+        throw new PicacomicServiceError('PICACOMIC_AUTH_EXPIRED', 'fixture')
+      case '403':
+        throw new PicacomicServiceError('PICACOMIC_AUTH_REQUIRED', 'fixture')
+      case 'network':
+        throw new PicacomicServiceError('PICACOMIC_NETWORK', 'fixture')
+      case 'parse':
+        throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'fixture')
+      default:
+        return
+    }
+  }
+
+  const fixture: PicacomicPluginClient & {
+    readonly calls: string[]
+    readonly imageKeys: readonly string[]
+    readonly flushImageEvents: () => void
+  } = {
+    calls,
+    get imageKeys() {
+      return [...imageMap.keys()]
+    },
+    flushImageEvents() {
+      const events = deferredImageEvents.splice(0)
+      for (const event of events) queueMicrotask(event)
+    },
+    async getBuildInfo() {
+      calls.push('getBuildInfo')
+      return { debugUiEnabled: true }
+    },
+    async getAuthState() {
+      calls.push('getAuthState')
+      return authState
+    },
+    async login({ usernameOrEmail }: { usernameOrEmail: string; password: string }) {
+      calls.push('login')
+      scenario(usernameOrEmail)
+      authState = {
+        state: 'signed_in',
+        user: { id: 'fixture-user', username: usernameOrEmail },
+      }
+      return authState
+    },
+    async logout() {
+      calls.push('logout')
+      authState = { state: 'signed_out' }
+      loadedImages.clear()
+      pendingImages.clear()
+      return authState
+    },
+    async search({ query, page = 1 }: { query: string; order?: string; page?: number }) {
+      calls.push(`search:${query}:${page}`)
+      ensureSignedIn()
+      scenario(query)
+      if (query.trim().toLowerCase() === 'empty') return emptyPage(page)
+      return catalogPage(page)
+    },
+    async categories({ category, page = 1 }: { category: string; order?: string; page?: number }) {
+      calls.push(`categories:${category}:${page}`)
+      ensureSignedIn()
+      scenario(category)
+      if (category.trim().toLowerCase() === 'empty') return emptyPage(page)
+      return catalogPage(page)
+    },
+    async getAlbum({ albumId }: { albumId: string }) {
+      calls.push(`getAlbum:${albumId}`)
+      ensureSignedIn()
+      const album = albums.find((candidate) => candidate.albumId === albumId)
+      if (!album) throw new PicacomicServiceError('PICACOMIC_NOT_FOUND', 'fixture')
+      return album
+    },
+    async getPhoto({
+      albumId,
+      chapterId,
+      order,
+    }: {
+      albumId: string
+      chapterId: string
+      order: number
+    }) {
+      calls.push(`getPhoto:${albumId}:${chapterId}:${order}`)
+      ensureSignedIn()
+      if (chapterId === 'stale')
+        throw new PicacomicServiceError('PICACOMIC_STALE_RESOURCE', 'fixture')
+      const album = albums.find((candidate) => candidate.albumId === albumId)
+      const chapter = album?.chapters?.find(
+        (candidate) => candidate.ref?.chapterId === chapterId && candidate.ref.order === order,
+      )
+      if (!chapter) throw new PicacomicServiceError('PICACOMIC_STALE_RESOURCE', 'fixture')
+      return chapter
+    },
+    async requestImages({
+      imageKeys,
+      replacePending = false,
+    }): Promise<PicacomicImageRequestResult> {
+      calls.push(`requestImages:${imageKeys.join(',')}:${replacePending}`)
+      ensureSignedIn()
+      const cached: string[] = []
+      const pending: string[] = []
+      for (const imageKey of [...new Set(imageKeys)]) {
+        if (!imageMap.has(imageKey))
+          throw new PicacomicServiceError('PICACOMIC_INVALID_ARGUMENT', 'fixture')
+        if (loadedImages.has(imageKey)) {
+          cached.push(imageKey)
+          continue
+        }
+        if (pendingImages.has(imageKey) && !replacePending) {
+          pending.push(imageKey)
+          continue
+        }
+        pendingImages.add(imageKey)
+        pending.push(imageKey)
+        const emitImageEvent = () => {
+          pendingImages.delete(imageKey)
+          if (failImageKeys.has(imageKey) && !failedOnce.has(imageKey)) {
+            failedOnce.add(imageKey)
+            emit('picacomicImageFailed', {
+              imageKey,
+              code: 'PICACOMIC_NETWORK',
+              retryable: true,
+            })
+            return
+          }
+          loadedImages.add(imageKey)
+          emit('picacomicImageReady', { imageKey })
+        }
+        if (options.deferImageEvents) deferredImageEvents.push(emitImageEvent)
+        else queueMicrotask(emitImageEvent)
+      }
+      return { cached, pending }
+    },
+    async retryImage({ imageKey }) {
+      calls.push(`retryImage:${imageKey}`)
+      return fixture.requestImages({ imageKeys: [imageKey], replacePending: true })
+    },
+    async addListener(event, handler) {
+      const bucket = listeners.get(event)
+      if (!bucket) throw new PicacomicServiceError('PICACOMIC_INTERNAL', 'listener')
+      bucket.add(handler)
+      return {
+        remove: async () => {
+          bucket.delete(handler)
+        },
+      }
+    },
+  }
+
+  return fixture
+
+  function catalogPage(page: number): RawPicacomicCatalogPage {
+    const safePage = page === 2 ? 2 : 1
+    const album = albums[safePage - 1]
+    return {
+      currentPage: safePage,
+      totalPages: 2,
+      totalItems: albums.length,
+      items: [
+        {
+          provider: 'picacomic',
+          albumId: album.albumId,
+          title: album.title,
+          authors: album.authors,
+          translator: album.translator,
+          cover: album.cover,
+          pagesCount: album.pagesCount,
+          finished: album.finished,
+        },
+      ],
+    }
+  }
+
+  function emptyPage(page: number): RawPicacomicCatalogPage {
+    return { currentPage: Math.max(1, page), totalPages: 1, totalItems: 0, items: [] }
+  }
+}
+
+function createAlbum(id: string, title: string, author: string): RawPicacomicAlbumDetail {
+  const cover = createImage(`${id}-cover`, 1, `${id}/cover.jpg`)
+  const chapterOne = createChapter(id, 'chapter-1', 1, '第一章', 3)
+  const chapterTwo = createChapter(id, 'chapter-2', 2, '第二章', 2)
+  return {
+    provider: 'picacomic',
+    albumId: id,
+    title,
+    authors: [author],
+    translator: 'Fixture Team',
+    categories: ['debug'],
+    tags: ['fixture', '只读'],
+    cover,
+    description: '仅用于 CP3 的本地 fake 只读闭环。',
+    pagesCount: 5,
+    epsCount: 2,
+    finished: false,
+    createdAt: '2026-08-01',
+    updatedAt: '2026-08-02',
+    chapters: [chapterTwo, chapterOne],
+  }
+}
+
+function createChapter(
+  albumId: string,
+  chapterId: string,
+  order: number,
+  title: string,
+  pageCount: number,
+): RawPicacomicChapterDetail {
+  return {
+    provider: 'picacomic',
+    albumId,
+    chapterId,
+    order,
+    title,
+    updatedAt: `2026-08-0${order}`,
+    contentRevision: `fixture-revision-${order}`,
+    isSingleChapterAlbum: false,
+    images: Array.from({ length: pageCount }, (_, index) =>
+      createImage(
+        `${albumId}-${chapterId}-${index + 1}`,
+        index + 1,
+        `${albumId}/${chapterId}/${index + 1}.png`,
+      ),
+    ),
+  }
+}
+
+function createImage(imageKeySuffix: string, pageIndex: number, path: string) {
+  return {
+    imageKey: `pica-fixture-${imageKeySuffix}`,
+    pageIndex,
+    cacheUrl: `https://jqviewer.local/picacomic/pica-fixture-${imageKeySuffix}/${pageIndex}`,
+    path,
+  }
+}

--- a/src/features/picacomic/pages/PicacomicAlbumPage.vue
+++ b/src/features/picacomic/pages/PicacomicAlbumPage.vue
@@ -1,0 +1,343 @@
+<template>
+  <IonPage>
+    <IonHeader class="ion-no-border">
+      <IonToolbar>
+        <IonButtons slot="start">
+          <IonButton fill="clear" aria-label="返回浏览" @click="goBrowse">返回</IonButton>
+        </IonButtons>
+        <IonTitle>PicaComic 详情</IonTitle>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent>
+      <main class="pica-page">
+        <div v-if="loading" class="state-card" data-testid="picacomic-album-loading">
+          正在加载详情…
+        </div>
+        <div
+          v-else-if="errorMessage"
+          class="state-card error-state"
+          data-testid="picacomic-album-error"
+        >
+          <p>{{ errorMessage }}</p>
+          <IonButton fill="outline" @click="loadAlbum">重试</IonButton>
+        </div>
+        <template v-else-if="album">
+          <section class="album-hero pica-card">
+            <div class="cover-wrap">
+              <img v-if="coverUrl" :src="coverUrl" :alt="album.title" class="cover-image" />
+              <span v-else class="cover-placeholder">封面</span>
+            </div>
+            <div class="hero-copy">
+              <p class="eyebrow">PICA ALBUM · {{ album.ref.albumId }}</p>
+              <h1>{{ album.title || '未命名作品' }}</h1>
+              <p class="authors">{{ album.authors.join(' / ') || '作者未知' }}</p>
+              <p class="description">{{ album.description || '暂无简介' }}</p>
+              <div class="chips">
+                <span v-for="tag in album.tags" :key="tag" class="chip">{{ tag }}</span>
+                <span class="chip">{{ album.finished ? '完结' : '连载' }}</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="pica-card chapter-card" aria-labelledby="chapters-title">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">READ-ONLY CHAPTERS</p>
+                <h2 id="chapters-title">章节</h2>
+              </div>
+              <span class="chapter-count">{{ album.chapters.length }} 章</span>
+            </div>
+            <div v-if="album.chapters.length" class="chapter-list" data-testid="picacomic-chapters">
+              <button
+                v-for="chapter in album.chapters"
+                :key="chapter.ref.chapterId"
+                type="button"
+                class="chapter-item"
+                :data-testid="`picacomic-chapter-${chapter.ref.chapterId}`"
+                @click="openReader(chapter.ref)"
+              >
+                <span class="chapter-order">第{{ chapter.ref.order }}话</span>
+                <span class="chapter-title">{{ chapter.title || '未命名章节' }}</span>
+                <span class="chapter-date">{{ chapter.updatedAt || '—' }}</span>
+              </button>
+            </div>
+            <div v-else class="empty-chapters" data-testid="picacomic-no-chapters">暂无章节</div>
+          </section>
+        </template>
+      </main>
+    </IonContent>
+  </IonPage>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: 'PicacomicAlbumPage' })
+
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/vue'
+import { picacomicErrorMessage, picacomicService, type PicacomicImageScope } from '../service'
+import type { PicacomicAlbumDetail, PicacomicChapterRef } from '../types'
+import { routeForPicacomicError } from '../routeGate'
+
+const route = useRoute()
+const router = useRouter()
+const album = ref<PicacomicAlbumDetail | null>(null)
+const loading = ref(true)
+const errorMessage = ref('')
+const coverUrl = ref('')
+let imageScope: PicacomicImageScope | null = null
+let loadGeneration = 0
+
+const albumId = computed(() => String(route.params.albumId ?? ''))
+
+onMounted(() => {
+  void loadAlbum()
+})
+
+onBeforeUnmount(() => {
+  loadGeneration++
+  void disposeImageScope()
+})
+
+async function loadAlbum() {
+  const generation = ++loadGeneration
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const next = await picacomicService.getAlbum(albumId.value)
+    if (generation !== loadGeneration) return
+    album.value = next
+    coverUrl.value = ''
+    await loadCover(next, generation)
+  } catch (error) {
+    if (generation !== loadGeneration) return
+    const redirect = routeForPicacomicError(error)
+    if (redirect) {
+      await router.replace(redirect)
+      return
+    }
+    errorMessage.value = picacomicErrorMessage(error)
+  } finally {
+    if (generation === loadGeneration) loading.value = false
+  }
+}
+
+async function loadCover(next: PicacomicAlbumDetail, generation: number) {
+  await disposeImageScope()
+  if (!next.cover) return
+  const scope = picacomicService.createImageScope({
+    onReady: (event) => {
+      if (generation === loadGeneration && event.imageKey === next.cover?.imageKey) {
+        coverUrl.value = next.cover.cacheUrl
+      }
+    },
+    onFailed: () => {
+      // Metadata and chapters remain available when the cover cannot load.
+    },
+  })
+  imageScope = scope
+  await scope.start()
+  const result = await scope.request([next.cover.imageKey])
+  if (generation === loadGeneration && result.cached.includes(next.cover.imageKey)) {
+    coverUrl.value = next.cover.cacheUrl
+  }
+}
+
+async function disposeImageScope() {
+  const scope = imageScope
+  imageScope = null
+  if (scope) await scope.dispose()
+}
+
+function openReader(ref: PicacomicChapterRef) {
+  void router.push({
+    name: 'PicacomicReaderPage',
+    params: { albumId: ref.albumId, chapterId: ref.chapterId },
+  })
+}
+
+function goBrowse() {
+  void router.replace({ name: 'PicacomicBrowsePage' })
+}
+</script>
+
+<style scoped>
+.pica-page {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 20px 16px 48px;
+}
+
+.pica-card,
+.state-card {
+  border: 1px solid rgb(245 210 188 / 0.7);
+  border-radius: 16px;
+  background: #fffaf6;
+  box-shadow: 0 10px 28px rgb(76 42 24 / 0.06);
+}
+
+.album-hero {
+  display: grid;
+  grid-template-columns: minmax(130px, 190px) 1fr;
+  gap: 20px;
+  padding: 20px;
+}
+
+.cover-wrap {
+  aspect-ratio: 3 / 4;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #f3e9e2;
+}
+
+.cover-image,
+.cover-placeholder {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-placeholder {
+  display: grid;
+  place-items: center;
+  color: #bd9a85;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: #bd652a;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+h1,
+h2 {
+  margin: 0;
+  color: #4c2a18;
+}
+
+h1 {
+  font-size: 24px;
+}
+
+h2 {
+  font-size: 19px;
+}
+
+.authors,
+.description,
+.chapter-count,
+.chapter-date {
+  color: #806451;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.description {
+  margin: 16px 0;
+  white-space: pre-wrap;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #f6e1d4;
+  color: #8a6048;
+  font-size: 11px;
+}
+
+.chapter-card {
+  margin-top: 16px;
+  padding: 20px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.chapter-list {
+  display: grid;
+  gap: 7px;
+}
+
+.chapter-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid rgb(245 210 188 / 0.56);
+  border-radius: 10px;
+  background: #fff;
+  color: #4c2a18;
+  text-align: start;
+  cursor: pointer;
+}
+
+.chapter-item:active {
+  background: #fff1e8;
+}
+
+.chapter-order {
+  color: #bd652a;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.chapter-title {
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty-chapters,
+.state-card {
+  padding: 28px 20px;
+  color: #806451;
+  text-align: center;
+}
+
+.error-state {
+  color: var(--ion-color-danger);
+}
+
+@media (max-width: 560px) {
+  .album-hero {
+    grid-template-columns: 112px 1fr;
+    gap: 14px;
+    padding: 14px;
+  }
+
+  .chapter-item {
+    grid-template-columns: auto 1fr;
+  }
+
+  .chapter-date {
+    grid-column: 2;
+  }
+}
+</style>

--- a/src/features/picacomic/pages/PicacomicBrowsePage.vue
+++ b/src/features/picacomic/pages/PicacomicBrowsePage.vue
@@ -1,0 +1,443 @@
+<template>
+  <IonPage>
+    <IonHeader class="ion-no-border">
+      <IonToolbar>
+        <IonButtons slot="start">
+          <IonButton fill="clear" aria-label="返回首页" @click="goHome">返回</IonButton>
+        </IonButtons>
+        <IonTitle>PicaComic 浏览</IonTitle>
+        <IonButtons slot="end">
+          <IonButton fill="clear" data-testid="picacomic-logout" @click="logout">退出</IonButton>
+        </IonButtons>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent>
+      <main class="pica-page">
+        <section class="pica-card search-card" aria-labelledby="browse-title">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">FAKE READ-ONLY CATALOG</p>
+              <h1 id="browse-title">搜索或浏览分类</h1>
+            </div>
+            <span v-if="auth.user.value" class="session-chip">{{ auth.user.value.username }}</span>
+          </div>
+          <form class="search-row" data-testid="picacomic-search-form" @submit.prevent="runSearch">
+            <IonInput
+              v-model="keyword"
+              label="关键词"
+              label-placement="stacked"
+              placeholder="输入关键词（fixture）"
+              data-testid="picacomic-search-input"
+              :disabled="loading"
+            />
+            <IonButton type="submit" :disabled="loading" data-testid="picacomic-search-submit">
+              搜索
+            </IonButton>
+            <IonButton
+              type="button"
+              fill="outline"
+              :disabled="loading"
+              data-testid="picacomic-category-submit"
+              @click="runCategory"
+            >
+              全部分类
+            </IonButton>
+          </form>
+          <p class="hint">可用 fixture：普通关键词、empty、401、403、network、parse。</p>
+        </section>
+
+        <section class="result-section" aria-live="polite">
+          <div v-if="loading && !result" class="state-card" data-testid="picacomic-loading">
+            正在加载目录…
+          </div>
+          <div
+            v-else-if="errorMessage"
+            class="state-card error-state"
+            data-testid="picacomic-error"
+          >
+            <p>{{ errorMessage }}</p>
+            <IonButton
+              fill="outline"
+              :disabled="loading"
+              data-testid="picacomic-retry"
+              @click="retry"
+            >
+              重试
+            </IonButton>
+          </div>
+          <div
+            v-else-if="result && result.items.length === 0"
+            class="state-card"
+            data-testid="picacomic-empty"
+          >
+            没有找到结果
+          </div>
+          <template v-else-if="result">
+            <div class="result-summary">
+              <span
+                >第 {{ result.currentPage }}/{{ result.totalPages }} 页 · 共
+                {{ result.totalItems }} 条</span
+              >
+              <span v-if="loading">更新中…</span>
+            </div>
+            <div class="catalog-grid" data-testid="picacomic-results">
+              <button
+                v-for="item in result.items"
+                :key="item.ref.albumId"
+                type="button"
+                class="catalog-card"
+                :data-testid="`picacomic-album-${item.ref.albumId}`"
+                @click="openAlbum(item.ref)"
+              >
+                <span class="cover-wrap">
+                  <img
+                    v-if="coverUrls.has(item.ref.albumId)"
+                    :src="coverUrls.get(item.ref.albumId)"
+                    :alt="item.title"
+                    class="cover-image"
+                  />
+                  <span v-else class="cover-placeholder">封面</span>
+                </span>
+                <span class="catalog-copy">
+                  <strong>{{ item.title || '未命名作品' }}</strong>
+                  <small>{{ item.authors.join(' / ') || '作者未知' }}</small>
+                  <small>{{ item.pagesCount }} 页 · {{ item.finished ? '完结' : '连载' }}</small>
+                </span>
+              </button>
+            </div>
+            <div class="pagination" data-testid="picacomic-pagination">
+              <IonButton
+                fill="outline"
+                :disabled="loading || result.currentPage <= 1"
+                data-testid="picacomic-page-previous"
+                @click="loadPage(result.currentPage - 1)"
+              >
+                上一页
+              </IonButton>
+              <IonButton
+                fill="outline"
+                :disabled="loading || result.currentPage >= result.totalPages"
+                data-testid="picacomic-page-next"
+                @click="loadPage(result.currentPage + 1)"
+              >
+                下一页
+              </IonButton>
+            </div>
+          </template>
+          <div v-else class="state-card">输入关键词开始浏览。</div>
+        </section>
+      </main>
+    </IonContent>
+  </IonPage>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: 'PicacomicBrowsePage' })
+
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonInput,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/vue'
+import { usePicacomicAuth } from '../auth'
+import {
+  isPicacomicAuthError,
+  picacomicErrorMessage,
+  picacomicService,
+  type PicacomicImageScope,
+} from '../service'
+import type { PicacomicAlbumRef, PicacomicCatalogPage } from '../types'
+import { routeForPicacomicError } from '../routeGate'
+
+const router = useRouter()
+const auth = usePicacomicAuth()
+const keyword = ref('')
+const category = ref('all')
+const page = ref(1)
+const result = ref<PicacomicCatalogPage | null>(null)
+const loading = ref(false)
+const errorMessage = ref('')
+const coverUrls = ref(new Map<string, string>())
+let imageScope: PicacomicImageScope | null = null
+let loadGeneration = 0
+let lastMode: 'search' | 'category' = 'search'
+
+onMounted(async () => {
+  try {
+    const state = await auth.refresh()
+    if (state.state === 'signed_in') return
+  } catch {
+    // The route guard handles the redirect; this is defensive for direct mounts.
+  }
+  await router.replace({ name: 'PicacomicLoginPage' })
+})
+
+onBeforeUnmount(() => {
+  loadGeneration++
+  void disposeImageScope()
+})
+
+async function runSearch() {
+  lastMode = 'search'
+  page.value = 1
+  await loadPage(1)
+}
+
+async function runCategory() {
+  lastMode = 'category'
+  page.value = 1
+  await loadPage(1)
+}
+
+async function retry() {
+  await loadPage(page.value)
+}
+
+async function loadPage(nextPage: number) {
+  const generation = ++loadGeneration
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const next =
+      lastMode === 'category'
+        ? await picacomicService.categories(category.value, nextPage)
+        : await picacomicService.search(keyword.value.trim(), nextPage)
+    if (generation !== loadGeneration) return
+    result.value = next
+    page.value = next.currentPage
+    await loadCovers(next, generation)
+  } catch (error) {
+    if (generation !== loadGeneration) return
+    const redirect = routeForPicacomicError(error)
+    if (redirect) {
+      await router.replace(redirect)
+      return
+    }
+    if (isPicacomicAuthError(error)) {
+      await router.replace({ name: 'PicacomicLoginPage' })
+      return
+    }
+    errorMessage.value = picacomicErrorMessage(error)
+  } finally {
+    if (generation === loadGeneration) loading.value = false
+  }
+}
+
+async function loadCovers(next: PicacomicCatalogPage, generation: number) {
+  await disposeImageScope()
+  const scope = picacomicService.createImageScope({
+    onReady: (event) => {
+      if (generation !== loadGeneration) return
+      const item = next.items.find((candidate) => candidate.cover?.imageKey === event.imageKey)
+      if (item?.cover) coverUrls.value.set(item.ref.albumId, item.cover.cacheUrl)
+    },
+    onFailed: () => {
+      // A failed cover does not block browsing the metadata.
+    },
+  })
+  imageScope = scope
+  const covers = next.items.flatMap((item) => (item.cover ? [item.cover] : []))
+  await scope.start()
+  const requested = await scope.request(covers.map((cover) => cover.imageKey))
+  if (generation !== loadGeneration) return
+  for (const imageKey of requested.cached) {
+    const item = next.items.find((candidate) => candidate.cover?.imageKey === imageKey)
+    if (item?.cover) coverUrls.value.set(item.ref.albumId, item.cover.cacheUrl)
+  }
+}
+
+async function disposeImageScope() {
+  const scope = imageScope
+  imageScope = null
+  if (scope) await scope.dispose()
+}
+
+function openAlbum(ref: PicacomicAlbumRef) {
+  void router.push({ name: 'PicacomicAlbumPage', params: { albumId: ref.albumId } })
+}
+
+function goHome() {
+  void router.replace('/home')
+}
+
+async function logout() {
+  await auth.logout()
+  await router.replace({ name: 'PicacomicLoginPage' })
+}
+</script>
+
+<style scoped>
+.pica-page {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 20px 16px 48px;
+}
+
+.pica-card,
+.state-card {
+  border: 1px solid rgb(245 210 188 / 0.7);
+  border-radius: 16px;
+  background: #fffaf6;
+  box-shadow: 0 10px 28px rgb(76 42 24 / 0.06);
+}
+
+.search-card {
+  padding: 20px;
+}
+
+.section-heading,
+.search-row,
+.result-summary,
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.section-heading,
+.result-summary {
+  justify-content: space-between;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: #bd652a;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+h1 {
+  margin: 0;
+  color: #4c2a18;
+  font-size: 22px;
+}
+
+.session-chip {
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: #f6e1d4;
+  color: #8a6048;
+  font-size: 12px;
+}
+
+.search-row {
+  align-items: end;
+  margin-top: 18px;
+}
+
+.search-row ion-input {
+  flex: 1;
+}
+
+.hint,
+.result-summary {
+  color: #806451;
+  font-size: 12px;
+}
+
+.hint {
+  margin: 10px 0 0;
+}
+
+.result-section {
+  margin-top: 16px;
+}
+
+.state-card {
+  padding: 28px 20px;
+  color: #806451;
+  text-align: center;
+}
+
+.state-card p {
+  margin: 0 0 12px;
+}
+
+.error-state {
+  color: var(--ion-color-danger);
+}
+
+.result-summary {
+  padding: 4px 2px 10px;
+}
+
+.catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.catalog-card {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid rgb(245 210 188 / 0.72);
+  border-radius: 14px;
+  background: #fffaf6;
+  color: #4c2a18;
+  text-align: start;
+  cursor: pointer;
+}
+
+.catalog-card:active {
+  transform: scale(0.985);
+}
+
+.cover-wrap {
+  display: block;
+  aspect-ratio: 3 / 4;
+  background: #f3e9e2;
+}
+
+.cover-image,
+.cover-placeholder {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-placeholder {
+  display: grid;
+  place-items: center;
+  color: #bd9a85;
+  font-size: 12px;
+}
+
+.catalog-copy {
+  display: grid;
+  gap: 4px;
+  padding: 11px;
+}
+
+.catalog-copy strong {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 14px;
+}
+
+.catalog-copy small {
+  overflow: hidden;
+  color: #806451;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pagination {
+  justify-content: center;
+  margin-top: 18px;
+}
+</style>

--- a/src/features/picacomic/pages/PicacomicLoginPage.vue
+++ b/src/features/picacomic/pages/PicacomicLoginPage.vue
@@ -1,0 +1,181 @@
+<template>
+  <IonPage>
+    <IonHeader class="ion-no-border">
+      <IonToolbar>
+        <IonButtons slot="start">
+          <IonButton fill="clear" aria-label="返回首页" @click="goHome">返回</IonButton>
+        </IonButtons>
+        <IonTitle>PicaComic 试验入口</IonTitle>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent>
+      <main class="pica-page pica-login-page">
+        <section class="pica-card login-card" aria-labelledby="pica-login-title">
+          <p class="eyebrow">DEBUG ONLY · FAKE CONTRACT</p>
+          <h1 id="pica-login-title">登录 PicaComic</h1>
+          <p class="page-copy">
+            这是仅供验证的只读入口。登录状态只保留在当前进程，关闭应用后需要重新登录。
+          </p>
+          <form data-testid="picacomic-login-form" @submit.prevent="submit">
+            <IonInput
+              v-model="usernameOrEmail"
+              label="用户名或邮箱"
+              label-placement="stacked"
+              placeholder="fixture-user"
+              autocomplete="username"
+              :disabled="loading"
+              data-testid="picacomic-username"
+            />
+            <IonInput
+              v-model="password"
+              type="password"
+              label="密码"
+              label-placement="stacked"
+              placeholder="fixture-password"
+              autocomplete="current-password"
+              :disabled="loading"
+              data-testid="picacomic-password"
+            />
+            <p v-if="errorMessage" class="error-message" role="alert">{{ errorMessage }}</p>
+            <IonButton
+              type="submit"
+              expand="block"
+              :disabled="!canSubmit || loading"
+              data-testid="picacomic-login-submit"
+            >
+              <IonSpinner v-if="loading" slot="start" name="crescent" />
+              {{ loading ? '登录中…' : '登录并开始浏览' }}
+            </IonButton>
+          </form>
+          <p class="privacy-note">不会保存原始密码或 token，也不会发起真实 PicaComic 网络请求。</p>
+        </section>
+      </main>
+    </IonContent>
+  </IonPage>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: 'PicacomicLoginPage' })
+
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonInput,
+  IonPage,
+  IonSpinner,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/vue'
+import { usePicacomicAuth } from '../auth'
+import { picacomicErrorMessage } from '../service'
+
+const router = useRouter()
+const auth = usePicacomicAuth()
+
+const usernameOrEmail = ref('')
+const password = ref('')
+const loading = ref(false)
+const errorMessage = ref('')
+const canSubmit = computed(
+  () => usernameOrEmail.value.trim().length > 0 && password.value.length > 0 && !loading.value,
+)
+
+onMounted(async () => {
+  try {
+    const state = await auth.refresh()
+    if (state.state === 'signed_in') await router.replace({ name: 'PicacomicBrowsePage' })
+  } catch {
+    // The form remains usable when the bridge is unavailable.
+  }
+})
+
+async function submit() {
+  if (!canSubmit.value) return
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    await auth.login(usernameOrEmail.value.trim(), password.value)
+    const redirect = auth.consumeRedirect()
+    password.value = ''
+    await router.replace(redirect ?? { name: 'PicacomicBrowsePage' })
+  } catch (error) {
+    errorMessage.value = picacomicErrorMessage(error, '登录失败，请重试')
+    password.value = ''
+  } finally {
+    loading.value = false
+  }
+}
+
+function goHome() {
+  void router.replace('/home')
+}
+</script>
+
+<style scoped>
+.pica-page {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 24px 16px 48px;
+}
+
+.pica-login-page {
+  min-height: 100%;
+  display: grid;
+  place-items: center;
+}
+
+.pica-card {
+  width: min(100%, 520px);
+  padding: 24px;
+  border: 1px solid rgb(245 210 188 / 0.7);
+  border-radius: 18px;
+  background: #fffaf6;
+  box-shadow: 0 12px 32px rgb(76 42 24 / 0.08);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #bd652a;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+h1 {
+  margin: 0;
+  color: #4c2a18;
+  font-size: 25px;
+}
+
+.page-copy,
+.privacy-note {
+  color: #806451;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.page-copy {
+  margin: 10px 0 22px;
+}
+
+form {
+  display: grid;
+  gap: 14px;
+}
+
+.error-message {
+  margin: 0;
+  color: var(--ion-color-danger);
+  font-size: 13px;
+}
+
+.privacy-note {
+  margin: 18px 0 0;
+  font-size: 11px;
+}
+</style>

--- a/src/features/picacomic/pages/PicacomicReaderPage.vue
+++ b/src/features/picacomic/pages/PicacomicReaderPage.vue
@@ -1,0 +1,382 @@
+<template>
+  <IonPage>
+    <IonHeader class="ion-no-border">
+      <IonToolbar>
+        <IonButtons slot="start">
+          <IonButton fill="clear" aria-label="返回详情" @click="goAlbum">返回</IonButton>
+        </IonButtons>
+        <IonTitle>{{ chapter?.title || 'PicaComic 阅读' }}</IonTitle>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent>
+      <main class="reader-page">
+        <div v-if="loading" class="reader-state" data-testid="picacomic-reader-loading">
+          正在准备图片…
+        </div>
+        <div
+          v-else-if="errorMessage"
+          class="reader-state error-state"
+          data-testid="picacomic-reader-error"
+        >
+          <p>{{ errorMessage }}</p>
+          <IonButton fill="outline" @click="loadChapter">重试章节</IonButton>
+        </div>
+        <template v-else-if="chapter">
+          <section class="reader-toolbar" aria-label="章节导航">
+            <IonButton
+              fill="outline"
+              :disabled="!previousChapter"
+              data-testid="picacomic-previous-chapter"
+              @click="switchChapter(previousChapter)"
+            >
+              上一章
+            </IonButton>
+            <select
+              :value="chapter.ref.chapterId"
+              aria-label="选择章节"
+              data-testid="picacomic-chapter-select"
+              @change="selectChapter"
+            >
+              <option
+                v-for="item in chapters"
+                :key="item.ref.chapterId"
+                :value="item.ref.chapterId"
+              >
+                第{{ item.ref.order }}话 {{ item.title }}
+              </option>
+            </select>
+            <IonButton
+              fill="outline"
+              :disabled="!nextChapter"
+              data-testid="picacomic-next-chapter"
+              @click="switchChapter(nextChapter)"
+            >
+              下一章
+            </IonButton>
+          </section>
+
+          <p class="reader-summary">
+            第 {{ chapter.ref.order }} 话 · {{ chapter.images.length }} 页
+          </p>
+          <section class="image-list" data-testid="picacomic-reader-images">
+            <article v-for="image in chapter.images" :key="image.imageKey" class="image-card">
+              <img
+                v-if="imageUrls.has(image.imageKey)"
+                :src="imageUrls.get(image.imageKey)"
+                :alt="`第 ${image.pageIndex} 页`"
+                class="reader-image"
+                @error="markFailed(image.imageKey)"
+              />
+              <div
+                v-else-if="failedImages.has(image.imageKey)"
+                class="image-failed"
+                data-testid="picacomic-image-failed"
+              >
+                <span>第 {{ image.pageIndex }} 页加载失败</span>
+                <IonButton
+                  fill="outline"
+                  size="small"
+                  :disabled="retryingImages.has(image.imageKey)"
+                  :data-testid="`picacomic-retry-${image.pageIndex}`"
+                  @click="retryImage(image.imageKey)"
+                >
+                  {{ retryingImages.has(image.imageKey) ? '重试中…' : '重试' }}
+                </IonButton>
+              </div>
+              <div v-else class="image-skeleton" :aria-label="`第 ${image.pageIndex} 页加载中`">
+                第 {{ image.pageIndex }} 页加载中…
+              </div>
+            </article>
+          </section>
+        </template>
+      </main>
+    </IonContent>
+  </IonPage>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: 'PicacomicReaderPage' })
+
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/vue'
+import { picacomicErrorMessage, picacomicService, type PicacomicImageScope } from '../service'
+import type { PicacomicAlbumDetail, PicacomicChapterDetail, PicacomicChapterRef } from '../types'
+import { routeForPicacomicError } from '../routeGate'
+
+const route = useRoute()
+const router = useRouter()
+const album = ref<PicacomicAlbumDetail | null>(null)
+const chapter = ref<PicacomicChapterDetail | null>(null)
+const chapters = computed(() => album.value?.chapters ?? [])
+const loading = ref(true)
+const errorMessage = ref('')
+const imageUrls = ref(new Map<string, string>())
+const failedImages = ref(new Set<string>())
+const retryingImages = ref(new Set<string>())
+let imageScope: PicacomicImageScope | null = null
+let loadGeneration = 0
+
+const albumId = computed(() => String(route.params.albumId ?? ''))
+const chapterId = computed(() => String(route.params.chapterId ?? ''))
+const previousChapter = computed(() => adjacentChapter(-1))
+const nextChapter = computed(() => adjacentChapter(1))
+
+onMounted(() => {
+  void loadChapter()
+})
+
+watch([albumId, chapterId], () => {
+  void loadChapter()
+})
+
+onBeforeUnmount(() => {
+  loadGeneration++
+  void disposeImageScope()
+})
+
+async function loadChapter() {
+  const generation = ++loadGeneration
+  loading.value = true
+  errorMessage.value = ''
+  imageUrls.value = new Map()
+  failedImages.value = new Set()
+  retryingImages.value = new Set()
+  await disposeImageScope()
+  try {
+    const nextAlbum = await picacomicService.getAlbum(albumId.value)
+    if (generation !== loadGeneration) return
+    const target = nextAlbum.chapters.find((item) => item.ref.chapterId === chapterId.value)
+    if (!target) {
+      const stale = new Error('stale chapter') as Error & { code: string }
+      stale.code = 'PICACOMIC_STALE_RESOURCE'
+      throw stale
+    }
+    const nextChapter = await picacomicService.getPhoto(target.ref)
+    if (generation !== loadGeneration) return
+    album.value = nextAlbum
+    chapter.value = nextChapter
+    await loadImages(nextChapter, generation)
+  } catch (error) {
+    if (generation !== loadGeneration) return
+    const redirect = routeForPicacomicError(error)
+    if (redirect) {
+      await router.replace(redirect)
+      return
+    }
+    errorMessage.value = picacomicErrorMessage(error, '章节加载失败')
+  } finally {
+    if (generation === loadGeneration) loading.value = false
+  }
+}
+
+async function loadImages(nextChapter: PicacomicChapterDetail, generation: number) {
+  const scope = picacomicService.createImageScope({
+    onReady: (event) => {
+      if (generation !== loadGeneration) return
+      const image = nextChapter.images.find((candidate) => candidate.imageKey === event.imageKey)
+      if (!image) return
+      const next = new Map(imageUrls.value)
+      next.set(image.imageKey, image.cacheUrl)
+      imageUrls.value = next
+      const failed = new Set(failedImages.value)
+      failed.delete(image.imageKey)
+      failedImages.value = failed
+    },
+    onFailed: (event) => {
+      if (generation !== loadGeneration) return
+      const failed = new Set(failedImages.value)
+      failed.add(event.imageKey)
+      failedImages.value = failed
+    },
+  })
+  imageScope = scope
+  await scope.start()
+  const result = await scope.request(nextChapter.images.map((image) => image.imageKey))
+  if (generation !== loadGeneration) return
+  const nextUrls = new Map(imageUrls.value)
+  for (const image of nextChapter.images) {
+    if (result.cached.includes(image.imageKey)) nextUrls.set(image.imageKey, image.cacheUrl)
+  }
+  imageUrls.value = nextUrls
+}
+
+async function retryImage(imageKey: string) {
+  const scope = imageScope
+  const currentChapter = chapter.value
+  if (!scope || !currentChapter) return
+  const retrying = new Set(retryingImages.value)
+  retrying.add(imageKey)
+  retryingImages.value = retrying
+  const failed = new Set(failedImages.value)
+  failed.delete(imageKey)
+  failedImages.value = failed
+  try {
+    const result = await scope.retry(imageKey)
+    const image = currentChapter.images.find((candidate) => candidate.imageKey === imageKey)
+    if (image && result.cached.includes(imageKey)) {
+      const next = new Map(imageUrls.value)
+      next.set(imageKey, image.cacheUrl)
+      imageUrls.value = next
+    }
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error) {
+      const nextFailed = new Set(failedImages.value)
+      nextFailed.add(imageKey)
+      failedImages.value = nextFailed
+    }
+  } finally {
+    const nextRetrying = new Set(retryingImages.value)
+    nextRetrying.delete(imageKey)
+    retryingImages.value = nextRetrying
+  }
+}
+
+function markFailed(imageKey: string) {
+  const next = new Set(failedImages.value)
+  next.add(imageKey)
+  failedImages.value = next
+  const urls = new Map(imageUrls.value)
+  urls.delete(imageKey)
+  imageUrls.value = urls
+}
+
+function adjacentChapter(delta: number): PicacomicChapterRef | null {
+  const index = chapters.value.findIndex((item) => item.ref.chapterId === chapterId.value)
+  const target = chapters.value[index + delta]
+  return target?.ref ?? null
+}
+
+function switchChapter(ref: PicacomicChapterRef | null) {
+  if (!ref) return
+  void router.replace({
+    name: 'PicacomicReaderPage',
+    params: { albumId: ref.albumId, chapterId: ref.chapterId },
+  })
+}
+
+function selectChapter(event: Event) {
+  const target = event.target as HTMLSelectElement
+  const selected = chapters.value.find((item) => item.ref.chapterId === target.value)
+  switchChapter(selected?.ref ?? null)
+}
+
+async function disposeImageScope() {
+  const scope = imageScope
+  imageScope = null
+  if (scope) await scope.dispose()
+}
+
+function goAlbum() {
+  void router.replace({ name: 'PicacomicAlbumPage', params: { albumId: albumId.value } })
+}
+</script>
+
+<style scoped>
+.reader-page {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 16px 12px 42px;
+}
+
+.reader-state {
+  padding: 36px 20px;
+  color: #806451;
+  text-align: center;
+}
+
+.reader-state p {
+  margin: 0 0 14px;
+}
+
+.error-state {
+  color: var(--ion-color-danger);
+}
+
+.reader-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px;
+  border: 1px solid rgb(245 210 188 / 0.7);
+  border-radius: 12px;
+  background: rgb(255 250 246 / 0.94);
+  backdrop-filter: blur(8px);
+}
+
+.reader-toolbar select {
+  min-width: 0;
+  height: 36px;
+  padding: 0 8px;
+  border: 1px solid rgb(245 210 188 / 0.7);
+  border-radius: 8px;
+  background: #fff;
+  color: #4c2a18;
+  font-size: 12px;
+}
+
+.reader-summary {
+  margin: 14px 4px 10px;
+  color: #806451;
+  font-size: 12px;
+}
+
+.image-list {
+  display: grid;
+  gap: 10px;
+}
+
+.image-card {
+  min-height: 220px;
+  overflow: hidden;
+  border-radius: 10px;
+  background: #f3e9e2;
+}
+
+.reader-image {
+  display: block;
+  width: 100%;
+  min-height: 220px;
+  object-fit: contain;
+  background: #f3e9e2;
+}
+
+.image-skeleton,
+.image-failed {
+  display: grid;
+  place-items: center;
+  min-height: 220px;
+  gap: 10px;
+  color: #9a7660;
+  font-size: 13px;
+}
+
+.image-failed {
+  color: var(--ion-color-danger);
+}
+
+@media (max-width: 520px) {
+  .reader-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .reader-toolbar select {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    width: 100%;
+  }
+}
+</style>

--- a/src/features/picacomic/routeGate.ts
+++ b/src/features/picacomic/routeGate.ts
@@ -1,0 +1,58 @@
+import type { RouteLocationNormalized } from 'vue-router'
+import { picacomicNativeClient } from './client'
+import { isPicacomicRouteName, usePicacomicAuth } from './auth'
+import type { PicacomicPluginClient, PicacomicRedirect } from './types'
+
+export function shouldExposePicacomicRoutes(mode: string, nativeDebugUiEnabled = false): boolean {
+  return mode === 'test' || mode === 'development' || nativeDebugUiEnabled
+}
+
+export async function isPicacomicDebugUiEnabled(
+  client: Pick<PicacomicPluginClient, 'getBuildInfo'> = picacomicNativeClient,
+): Promise<boolean> {
+  if (shouldExposePicacomicRoutes(import.meta.env.MODE, false)) return true
+  try {
+    const info = await client.getBuildInfo()
+    return shouldExposePicacomicRoutes(import.meta.env.MODE, info.debugUiEnabled === true)
+  } catch {
+    return false
+  }
+}
+
+export function redirectFromPicacomicRoute(
+  route: Pick<RouteLocationNormalized, 'name' | 'params'>,
+): PicacomicRedirect | null {
+  if (!isPicacomicRouteName(route.name)) return null
+  const params: Record<string, string> = {}
+  for (const key of ['albumId', 'chapterId']) {
+    const value = route.params[key]
+    if (typeof value === 'string' && value.length > 0) params[key] = value
+  }
+  return { name: route.name, params }
+}
+
+export async function picacomicAuthGuard(to: RouteLocationNormalized) {
+  if (to.name === 'PicacomicLoginPage') return true
+  const auth = usePicacomicAuth()
+  try {
+    const state = await auth.refresh()
+    if (state.state === 'signed_in') return true
+  } catch {
+    // Treat bridge failures as signed out for an internal debug route.
+  }
+  const redirect = redirectFromPicacomicRoute(to)
+  if (redirect) auth.captureRedirect(redirect)
+  return { name: 'PicacomicLoginPage' }
+}
+
+export function routeForPicacomicError(error: unknown) {
+  const auth = usePicacomicAuth()
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code
+    if (code === 'PICACOMIC_AUTH_REQUIRED' || code === 'PICACOMIC_AUTH_EXPIRED') {
+      auth.captureRedirect({ name: 'PicacomicBrowsePage', params: {} })
+      return { name: 'PicacomicLoginPage' }
+    }
+  }
+  return null
+}

--- a/src/features/picacomic/routes.ts
+++ b/src/features/picacomic/routes.ts
@@ -1,0 +1,36 @@
+import type { RouteRecordRaw } from 'vue-router'
+import { picacomicAuthGuard } from './routeGate'
+
+export const PICACOMIC_ROUTE_PREFIX = '/__picacomic'
+
+export function createPicacomicRoutes(): RouteRecordRaw[] {
+  return [
+    {
+      path: `${PICACOMIC_ROUTE_PREFIX}/login`,
+      name: 'PicacomicLoginPage',
+      component: () => import('./pages/PicacomicLoginPage.vue'),
+      meta: { menu: false, picacomicInternal: true },
+    },
+    {
+      path: `${PICACOMIC_ROUTE_PREFIX}/browse`,
+      name: 'PicacomicBrowsePage',
+      component: () => import('./pages/PicacomicBrowsePage.vue'),
+      beforeEnter: picacomicAuthGuard,
+      meta: { menu: false, picacomicInternal: true },
+    },
+    {
+      path: `${PICACOMIC_ROUTE_PREFIX}/album/:albumId`,
+      name: 'PicacomicAlbumPage',
+      component: () => import('./pages/PicacomicAlbumPage.vue'),
+      beforeEnter: picacomicAuthGuard,
+      meta: { menu: false, picacomicInternal: true },
+    },
+    {
+      path: `${PICACOMIC_ROUTE_PREFIX}/read/:albumId/:chapterId`,
+      name: 'PicacomicReaderPage',
+      component: () => import('./pages/PicacomicReaderPage.vue'),
+      beforeEnter: picacomicAuthGuard,
+      meta: { menu: false, picacomicInternal: true },
+    },
+  ]
+}

--- a/src/features/picacomic/service.ts
+++ b/src/features/picacomic/service.ts
@@ -1,0 +1,422 @@
+import { picacomicNativeClient } from './client'
+import { createPicacomicFixtureClient } from './fixture'
+import { PicacomicServiceError } from './errors'
+import type {
+  PicacomicAlbumDetail,
+  PicacomicAlbumRef,
+  PicacomicAuthState,
+  PicacomicBuildInfo,
+  PicacomicCatalogItem,
+  PicacomicCatalogPage,
+  PicacomicChapterDetail,
+  PicacomicChapterRef,
+  PicacomicChapterSummary,
+  PicacomicErrorCode,
+  PicacomicImageFailedEvent,
+  PicacomicImageReadyEvent,
+  PicacomicImageRef,
+  PicacomicImageRequestResult,
+  PicacomicListenerHandle,
+  PicacomicPluginClient,
+  RawPicacomicAlbumDetail,
+  RawPicacomicCatalogItem,
+  RawPicacomicChapterDetail,
+  RawPicacomicChapterSummary,
+} from './types'
+import { isPicacomicErrorCode } from './types'
+
+export { PicacomicServiceError } from './errors'
+
+const DEFAULT_ERROR_MESSAGE: Record<PicacomicErrorCode, string> = {
+  PICACOMIC_INVALID_ARGUMENT: '请输入有效的 PicaComic 信息',
+  PICACOMIC_AUTH_REQUIRED: '请先登录 PicaComic',
+  PICACOMIC_AUTH_EXPIRED: '登录已过期，请重新登录',
+  PICACOMIC_NOT_FOUND: '没有找到这本漫画',
+  PICACOMIC_RATE_LIMITED: '请求过于频繁，请稍后再试',
+  PICACOMIC_NETWORK: '网络请求失败，请检查连接后重试',
+  PICACOMIC_INVALID_RESPONSE: '服务返回了无法识别的数据',
+  PICACOMIC_STALE_RESOURCE: '章节已变化，请刷新目录后重试',
+  PICACOMIC_CANCELLED: '请求已取消',
+  PICACOMIC_UPSTREAM: 'PicaComic 服务暂时不可用',
+  PICACOMIC_INTERNAL: 'PicaComic 功能暂时不可用',
+}
+
+export function picacomicErrorMessage(error: unknown, fallback = 'PicaComic 请求失败') {
+  const normalized = normalizePicacomicError(error, 'view')
+  return DEFAULT_ERROR_MESSAGE[normalized.code] ?? fallback
+}
+
+export function isPicacomicAuthError(error: unknown) {
+  const code = normalizePicacomicError(error, 'auth').code
+  return code === 'PICACOMIC_AUTH_REQUIRED' || code === 'PICACOMIC_AUTH_EXPIRED'
+}
+
+export function normalizePicacomicError(error: unknown, operation: string) {
+  if (error instanceof PicacomicServiceError) return error
+
+  const candidate = asRecord(error)
+  const rawCode = candidate?.code ?? candidate?.errorCode
+  if (isPicacomicErrorCode(rawCode)) {
+    return new PicacomicServiceError(rawCode, operation, error)
+  }
+
+  const status = candidate?.status ?? candidate?.statusCode
+  if (status === 401) return new PicacomicServiceError('PICACOMIC_AUTH_EXPIRED', operation, error)
+  if (status === 403) return new PicacomicServiceError('PICACOMIC_AUTH_REQUIRED', operation, error)
+  if (status === 404) return new PicacomicServiceError('PICACOMIC_NOT_FOUND', operation, error)
+  if (status === 429) return new PicacomicServiceError('PICACOMIC_RATE_LIMITED', operation, error)
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return new PicacomicServiceError('PICACOMIC_CANCELLED', operation, error)
+  }
+  return new PicacomicServiceError('PICACOMIC_INTERNAL', operation, error)
+}
+
+export interface PicacomicImageScopeHandlers {
+  onReady: (event: PicacomicImageReadyEvent) => void
+  onFailed: (event: PicacomicImageFailedEvent) => void
+}
+
+export interface PicacomicImageScope {
+  start: () => Promise<void>
+  request: (imageKeys: string[], replacePending?: boolean) => Promise<PicacomicImageRequestResult>
+  retry: (imageKey: string) => Promise<PicacomicImageRequestResult>
+  dispose: () => Promise<void>
+}
+
+export class PicacomicService {
+  constructor(readonly client: PicacomicPluginClient) {}
+
+  getBuildInfo(): Promise<PicacomicBuildInfo> {
+    return this.client.getBuildInfo()
+  }
+
+  async getAuthState(): Promise<PicacomicAuthState> {
+    try {
+      return normalizeAuthState(await this.client.getAuthState())
+    } catch (error) {
+      throw normalizePicacomicError(error, 'auth state')
+    }
+  }
+
+  async login(usernameOrEmail: string, password: string): Promise<PicacomicAuthState> {
+    if (!usernameOrEmail.trim() || !password) {
+      throw new PicacomicServiceError('PICACOMIC_INVALID_ARGUMENT', 'login')
+    }
+    try {
+      return normalizeAuthState(await this.client.login({ usernameOrEmail, password }))
+    } catch (error) {
+      throw normalizePicacomicError(error, 'login')
+    }
+  }
+
+  async logout(): Promise<PicacomicAuthState> {
+    try {
+      return normalizeAuthState(await this.client.logout())
+    } catch (error) {
+      throw normalizePicacomicError(error, 'logout')
+    }
+  }
+
+  async search(query: string, page = 1, order = 'latest'): Promise<PicacomicCatalogPage> {
+    try {
+      return normalizeCatalogPage(await this.client.search({ query, page, order }))
+    } catch (error) {
+      throw normalizePicacomicError(error, 'search')
+    }
+  }
+
+  async categories(category = 'all', page = 1, order = 'latest') {
+    try {
+      return normalizeCatalogPage(await this.client.categories({ category, page, order }))
+    } catch (error) {
+      throw normalizePicacomicError(error, 'categories')
+    }
+  }
+
+  async getAlbum(albumId: string): Promise<PicacomicAlbumDetail> {
+    if (!albumId.trim()) throw new PicacomicServiceError('PICACOMIC_INVALID_ARGUMENT', 'album')
+    try {
+      return normalizeAlbum(await this.client.getAlbum({ albumId }))
+    } catch (error) {
+      throw normalizePicacomicError(error, 'album')
+    }
+  }
+
+  async getPhoto(ref: PicacomicChapterRef): Promise<PicacomicChapterDetail> {
+    if (!ref.albumId.trim() || !ref.chapterId.trim() || ref.order <= 0) {
+      throw new PicacomicServiceError('PICACOMIC_INVALID_ARGUMENT', 'chapter')
+    }
+    try {
+      return normalizeChapter(await this.client.getPhoto(ref))
+    } catch (error) {
+      throw normalizePicacomicError(error, 'chapter')
+    }
+  }
+
+  createImageScope(handlers: PicacomicImageScopeHandlers): PicacomicImageScope {
+    let active = true
+    let started = false
+    let startPromise: Promise<void> | null = null
+    let readyHandle: PicacomicListenerHandle | null = null
+    let failedHandle: PicacomicListenerHandle | null = null
+    const acceptedKeys = new Set<string>()
+
+    const onReady = (event: PicacomicImageReadyEvent) => {
+      if (active && acceptedKeys.has(event.imageKey)) handlers.onReady(event)
+    }
+    const onFailed = (event: PicacomicImageFailedEvent) => {
+      if (active && acceptedKeys.has(event.imageKey)) handlers.onFailed(event)
+    }
+
+    const start = async () => {
+      if (!active) throw new PicacomicServiceError('PICACOMIC_CANCELLED', 'images')
+      if (started) return startPromise ?? Promise.resolve()
+      started = true
+      startPromise = Promise.all([
+        this.client.addListener('picacomicImageReady', (event) =>
+          onReady(event as PicacomicImageReadyEvent),
+        ),
+        this.client.addListener('picacomicImageFailed', (event) =>
+          onFailed(event as PicacomicImageFailedEvent),
+        ),
+      ])
+        .then(([ready, failed]) => {
+          readyHandle = ready
+          failedHandle = failed
+        })
+        .catch((error) => {
+          throw normalizePicacomicError(error, 'image listener')
+        })
+      return startPromise
+    }
+
+    const request = async (imageKeys: string[], replacePending = false) => {
+      await start()
+      if (!active) throw new PicacomicServiceError('PICACOMIC_CANCELLED', 'images')
+      for (const key of imageKeys) acceptedKeys.add(key)
+      try {
+        return await this.client.requestImages({ imageKeys, replacePending })
+      } catch (error) {
+        throw normalizePicacomicError(error, 'images')
+      }
+    }
+
+    const retry = async (imageKey: string) => {
+      await start()
+      if (!active) throw new PicacomicServiceError('PICACOMIC_CANCELLED', 'image retry')
+      acceptedKeys.add(imageKey)
+      try {
+        return await this.client.retryImage({ imageKey })
+      } catch (error) {
+        throw normalizePicacomicError(error, 'image retry')
+      }
+    }
+
+    const dispose = async () => {
+      active = false
+      acceptedKeys.clear()
+      const handles = [readyHandle, failedHandle].filter(
+        (handle): handle is PicacomicListenerHandle => handle !== null,
+      )
+      readyHandle = null
+      failedHandle = null
+      await Promise.allSettled(handles.map((handle) => handle.remove()))
+    }
+
+    return { start, request, retry, dispose }
+  }
+}
+
+const defaultPicacomicClient =
+  import.meta.env.DEV || import.meta.env.MODE === 'test'
+    ? createPicacomicFixtureClient()
+    : picacomicNativeClient
+
+export const picacomicService = new PicacomicService(defaultPicacomicClient)
+
+function normalizeAuthState(value: unknown): PicacomicAuthState {
+  const record = requireRecord(value, 'auth state')
+  const state = record.state
+  if (
+    state !== 'signed_out' &&
+    state !== 'authenticating' &&
+    state !== 'signed_in' &&
+    state !== 'expired'
+  ) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'auth state')
+  }
+  const userRecord = asRecord(record.user)
+  if (
+    state === 'signed_in' &&
+    (!userRecord || !text(userRecord.id) || !text(userRecord.username))
+  ) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'auth state')
+  }
+  return {
+    state,
+    ...(userRecord
+      ? { user: { id: text(userRecord.id), username: text(userRecord.username) } }
+      : {}),
+  }
+}
+
+function normalizeCatalogPage(value: unknown): PicacomicCatalogPage {
+  const record = requireRecord(value, 'catalog')
+  const currentPage = positiveInteger(record.currentPage)
+  const totalPages = nonNegativeInteger(record.totalPages)
+  const totalItems = nonNegativeInteger(record.totalItems)
+  if (
+    !currentPage ||
+    totalPages === null ||
+    totalItems === null ||
+    totalPages < 0 ||
+    totalItems < 0 ||
+    (totalPages > 0 && currentPage > totalPages)
+  ) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'catalog')
+  }
+  const rawItems = Array.isArray(record.items) ? record.items : null
+  if (!rawItems) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'catalog')
+  return {
+    currentPage,
+    totalPages,
+    totalItems,
+    items: rawItems.map((item) => normalizeCatalogItem(item)),
+  }
+}
+
+function normalizeCatalogItem(value: unknown): PicacomicCatalogItem {
+  const item = asRecord(value) as RawPicacomicCatalogItem | null
+  if (!item) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'catalog')
+  const ref = normalizeAlbumRef(item, 'catalog')
+  return {
+    ref,
+    title: text(item.title),
+    authors: strings(item.authors),
+    translator: text(item.translator),
+    cover:
+      item.cover === null || item.cover === undefined ? null : normalizeImage(item.cover, 'cover'),
+    pagesCount: nonNegativeInteger(item.pagesCount) ?? 0,
+    finished: item.finished === true,
+  }
+}
+
+function normalizeAlbum(value: unknown): PicacomicAlbumDetail {
+  const album = asRecord(value) as RawPicacomicAlbumDetail | null
+  if (!album) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'album')
+  const ref = normalizeAlbumRef(album, 'album')
+  const rawChapters = Array.isArray(album.chapters) ? album.chapters : null
+  if (!rawChapters) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'album')
+  const chapters = rawChapters.map((chapter) => normalizeChapterSummary(chapter, ref.albumId))
+  return {
+    ref,
+    title: text(album.title),
+    authors: strings(album.authors),
+    translator: text(album.translator),
+    categories: strings(album.categories),
+    tags: strings(album.tags),
+    cover:
+      album.cover === null || album.cover === undefined
+        ? null
+        : normalizeImage(album.cover, 'cover'),
+    description: text(album.description),
+    pagesCount: nonNegativeInteger(album.pagesCount) ?? 0,
+    epsCount: nonNegativeInteger(album.epsCount) ?? chapters.length,
+    finished: album.finished === true,
+    createdAt: text(album.createdAt),
+    updatedAt: text(album.updatedAt),
+    chapters: chapters.sort((a, b) => a.ref.order - b.ref.order),
+  }
+}
+
+function normalizeChapter(value: unknown): PicacomicChapterDetail {
+  const chapter = asRecord(value) as RawPicacomicChapterDetail | null
+  if (!chapter) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'chapter')
+  const summary = normalizeChapterSummary(chapter)
+  const rawImages = Array.isArray(chapter.images) ? chapter.images : null
+  if (!rawImages || rawImages.length === 0) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'chapter')
+  }
+  return {
+    ...summary,
+    contentRevision: text(chapter.contentRevision),
+    isSingleChapterAlbum: chapter.isSingleChapterAlbum === true,
+    images: rawImages.map((image) => normalizeImage(image, 'chapter')),
+  }
+}
+
+function normalizeChapterSummary(value: unknown, albumIdHint = ''): PicacomicChapterSummary {
+  const chapter = asRecord(value) as RawPicacomicChapterSummary | null
+  if (!chapter) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'chapter')
+  const refRecord = asRecord(chapter.ref)
+  const albumId = text(refRecord?.albumId ?? chapter.albumId ?? albumIdHint)
+  const chapterId = text(refRecord?.chapterId ?? chapter.chapterId)
+  const order = positiveInteger(refRecord?.order ?? chapter.order)
+  if (!albumId || !chapterId || !order) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'chapter')
+  }
+  if (refRecord?.provider !== undefined && refRecord.provider !== 'picacomic') {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', 'chapter')
+  }
+  return {
+    ref: { provider: 'picacomic', albumId, chapterId, order },
+    title: text(chapter.title),
+    updatedAt: text(chapter.updatedAt),
+  }
+}
+
+function normalizeAlbumRef(value: unknown, operation: string): PicacomicAlbumRef {
+  const source = asRecord(value) as {
+    ref?: Partial<PicacomicAlbumRef>
+    provider?: string
+    albumId?: string
+  } | null
+  if (!source) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', operation)
+  const ref = asRecord(source.ref)
+  const provider = ref?.provider ?? source.provider
+  const albumId = text(ref?.albumId ?? source.albumId)
+  if ((provider !== undefined && provider !== 'picacomic') || !albumId) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', operation)
+  }
+  return { provider: 'picacomic', albumId }
+}
+
+function normalizeImage(value: unknown, operation: string): PicacomicImageRef {
+  const image = asRecord(value) as Partial<PicacomicImageRef> | null
+  if (!image) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', operation)
+  const imageKey = text(image.imageKey)
+  const cacheUrl = text(image.cacheUrl)
+  const pageIndex = positiveInteger(image.pageIndex)
+  if (!imageKey || !cacheUrl || !pageIndex || !imageKey.startsWith('pica-')) {
+    throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', operation)
+  }
+  return { imageKey, pageIndex, cacheUrl }
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
+}
+
+function requireRecord(value: unknown, operation: string): Record<string, any> {
+  const record = asRecord(value)
+  if (!record) throw new PicacomicServiceError('PICACOMIC_INVALID_RESPONSE', operation)
+  return record
+}
+
+function asRecord(value: unknown): Record<string, any> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, any>) : null
+}
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' ? value : fallback
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : null
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null
+}

--- a/src/features/picacomic/types.ts
+++ b/src/features/picacomic/types.ts
@@ -1,0 +1,236 @@
+export const PICACOMIC_PROVIDER = 'picacomic' as const
+
+export type PicacomicAuthStateName = 'signed_out' | 'authenticating' | 'signed_in' | 'expired'
+
+export type PicacomicErrorCode =
+  | 'PICACOMIC_INVALID_ARGUMENT'
+  | 'PICACOMIC_AUTH_REQUIRED'
+  | 'PICACOMIC_AUTH_EXPIRED'
+  | 'PICACOMIC_NOT_FOUND'
+  | 'PICACOMIC_RATE_LIMITED'
+  | 'PICACOMIC_NETWORK'
+  | 'PICACOMIC_INVALID_RESPONSE'
+  | 'PICACOMIC_STALE_RESOURCE'
+  | 'PICACOMIC_CANCELLED'
+  | 'PICACOMIC_UPSTREAM'
+  | 'PICACOMIC_INTERNAL'
+
+export interface PicacomicUser {
+  id: string
+  username: string
+}
+
+export interface PicacomicAuthState {
+  state: PicacomicAuthStateName
+  user?: PicacomicUser
+}
+
+export interface PicacomicAlbumRef {
+  provider: typeof PICACOMIC_PROVIDER
+  albumId: string
+}
+
+export interface PicacomicChapterRef extends PicacomicAlbumRef {
+  chapterId: string
+  order: number
+}
+
+export interface PicacomicImageRef {
+  imageKey: string
+  pageIndex: number
+  cacheUrl: string
+}
+
+export interface PicacomicCatalogItem {
+  ref: PicacomicAlbumRef
+  title: string
+  authors: string[]
+  translator: string
+  cover: PicacomicImageRef | null
+  pagesCount: number
+  finished: boolean
+}
+
+export interface PicacomicCatalogPage {
+  currentPage: number
+  totalPages: number
+  totalItems: number
+  items: PicacomicCatalogItem[]
+}
+
+export interface PicacomicChapterSummary {
+  ref: PicacomicChapterRef
+  title: string
+  updatedAt: string
+}
+
+export interface PicacomicAlbumDetail {
+  ref: PicacomicAlbumRef
+  title: string
+  authors: string[]
+  translator: string
+  categories: string[]
+  tags: string[]
+  cover: PicacomicImageRef | null
+  description: string
+  pagesCount: number
+  epsCount: number
+  finished: boolean
+  createdAt: string
+  updatedAt: string
+  chapters: PicacomicChapterSummary[]
+}
+
+export interface PicacomicChapterDetail extends PicacomicChapterSummary {
+  contentRevision: string
+  isSingleChapterAlbum: boolean
+  images: PicacomicImageRef[]
+}
+
+export interface PicacomicImageReadyEvent {
+  imageKey: string
+}
+
+export interface PicacomicImageFailedEvent {
+  imageKey: string
+  code: PicacomicErrorCode
+  retryable: boolean
+}
+
+export type PicacomicImageEventName = 'picacomicImageReady' | 'picacomicImageFailed'
+
+export interface PicacomicImageRequestResult {
+  cached: string[]
+  pending: string[]
+}
+
+export interface PicacomicBuildInfo {
+  debugUiEnabled: boolean
+}
+
+export interface PicacomicListenerHandle {
+  remove: () => Promise<void>
+}
+
+export interface PicacomicPluginClient {
+  getBuildInfo(): Promise<PicacomicBuildInfo>
+  getAuthState(): Promise<PicacomicAuthState>
+  login(options: { usernameOrEmail: string; password: string }): Promise<PicacomicAuthState>
+  logout(): Promise<PicacomicAuthState>
+  search(options: {
+    query: string
+    order?: string
+    page?: number
+  }): Promise<RawPicacomicCatalogPage>
+  categories(options: {
+    category: string
+    order?: string
+    page?: number
+  }): Promise<RawPicacomicCatalogPage>
+  getAlbum(options: { albumId: string }): Promise<RawPicacomicAlbumDetail>
+  getPhoto(options: {
+    albumId: string
+    chapterId: string
+    order: number
+  }): Promise<RawPicacomicChapterDetail>
+  requestImages(options: {
+    imageKeys: string[]
+    replacePending?: boolean
+  }): Promise<PicacomicImageRequestResult>
+  retryImage(options: { imageKey: string }): Promise<PicacomicImageRequestResult>
+  addListener(
+    event: PicacomicImageEventName,
+    handler: (event: PicacomicImageReadyEvent | PicacomicImageFailedEvent) => void,
+  ): Promise<PicacomicListenerHandle>
+}
+
+export interface RawPicacomicCatalogPage {
+  currentPage: number
+  totalPages: number
+  totalItems: number
+  items: RawPicacomicCatalogItem[]
+}
+
+export interface RawPicacomicCatalogItem {
+  ref?: Partial<PicacomicAlbumRef>
+  provider?: string
+  albumId?: string
+  title?: string
+  authors?: unknown
+  translator?: string
+  cover?: Partial<PicacomicImageRef> | null
+  pagesCount?: number
+  finished?: boolean
+}
+
+export interface RawPicacomicAlbumDetail {
+  ref?: Partial<PicacomicAlbumRef>
+  provider?: string
+  albumId?: string
+  title?: string
+  authors?: unknown
+  translator?: string
+  categories?: unknown
+  tags?: unknown
+  cover?: Partial<PicacomicImageRef> | null
+  description?: string
+  pagesCount?: number
+  epsCount?: number
+  finished?: boolean
+  createdAt?: string
+  updatedAt?: string
+  chapters?: RawPicacomicChapterDetail[]
+}
+
+export interface RawPicacomicChapterSummary {
+  ref?: Partial<PicacomicChapterRef>
+  provider?: string
+  albumId?: string
+  chapterId?: string
+  order?: number
+  title?: string
+  updatedAt?: string
+}
+
+export interface RawPicacomicChapterDetail extends RawPicacomicChapterSummary {
+  contentRevision?: string
+  isSingleChapterAlbum?: boolean
+  images?: Array<Partial<PicacomicImageRef>>
+}
+
+export type PicacomicRouteName =
+  | 'PicacomicLoginPage'
+  | 'PicacomicBrowsePage'
+  | 'PicacomicAlbumPage'
+  | 'PicacomicReaderPage'
+
+export interface PicacomicRedirect {
+  name: PicacomicRouteName
+  params: Record<string, string>
+}
+
+export const PICACOMIC_ROUTE_NAMES: readonly PicacomicRouteName[] = [
+  'PicacomicLoginPage',
+  'PicacomicBrowsePage',
+  'PicacomicAlbumPage',
+  'PicacomicReaderPage',
+]
+
+export function isPicacomicErrorCode(value: unknown): value is PicacomicErrorCode {
+  return (
+    typeof value === 'string' &&
+    [
+      'PICACOMIC_INVALID_ARGUMENT',
+      'PICACOMIC_AUTH_REQUIRED',
+      'PICACOMIC_AUTH_EXPIRED',
+      'PICACOMIC_NOT_FOUND',
+      'PICACOMIC_RATE_LIMITED',
+      'PICACOMIC_NETWORK',
+      'PICACOMIC_INVALID_RESPONSE',
+      'PICACOMIC_STALE_RESOURCE',
+      'PICACOMIC_CANCELLED',
+      'PICACOMIC_UPSTREAM',
+      'PICACOMIC_INTERNAL',
+    ].includes(value)
+  )
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import App from './App.vue'
 import router from './router'
 
 import { IonicVue } from '@ionic/vue'
+import { registerPicacomicRoutes } from './router'
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/vue/css/core.css'
@@ -35,6 +36,10 @@ import './theme/variables.css'
 
 const app = createApp(App).use(IonicVue).use(router)
 
-router.isReady().then(() => {
+async function bootstrap() {
+  await registerPicacomicRoutes()
+  await router.isReady()
   app.mount('#app')
-})
+}
+
+void bootstrap()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router'
 import type { RouteRecordRaw } from 'vue-router'
+import { createPicacomicRoutes } from '@/features/picacomic/routes'
+import { isPicacomicDebugUiEnabled } from '@/features/picacomic/routeGate'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -117,5 +119,16 @@ const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
+
+let picacomicRoutesRegistered = false
+
+/** Register the internal Pica routes only for Vite test/dev or native debug builds. */
+export async function registerPicacomicRoutes(): Promise<boolean> {
+  if (picacomicRoutesRegistered) return true
+  if (!(await isPicacomicDebugUiEnabled())) return false
+  for (const route of createPicacomicRoutes()) router.addRoute(route)
+  picacomicRoutesRegistered = true
+  return true
+}
 
 export default router

--- a/tests/unit/PicacomicPages.test.ts
+++ b/tests/unit/PicacomicPages.test.ts
@@ -1,0 +1,294 @@
+/* eslint-disable vue/one-component-per-file -- Ionic primitives are test fixtures. */
+import { flushPromises, mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  route: {
+    params: { albumId: 'fixture-album-1', chapterId: 'chapter-1' },
+  },
+  router: {
+    push: vi.fn(() => Promise.resolve()),
+    replace: vi.fn(() => Promise.resolve()),
+  },
+  auth: {
+    user: { value: { id: 'fixture-user', username: 'fixture-user' } },
+    refresh: vi.fn(() => Promise.resolve({ state: 'signed_in' })),
+    login: vi.fn(() => Promise.resolve({ state: 'signed_in' })),
+    logout: vi.fn(() => Promise.resolve()),
+    consumeRedirect: vi.fn(() => null),
+  },
+  service: {
+    search: vi.fn(),
+    categories: vi.fn(),
+    getAlbum: vi.fn(),
+    getPhoto: vi.fn(),
+    createImageScope: vi.fn(),
+  },
+  scopeHandlers: null as null | { onReady: (event: any) => void; onFailed: (event: any) => void },
+  scopeResponse: (keys: string[]) => ({ cached: keys, pending: [] as string[] }),
+  scope: null as null | {
+    start: ReturnType<typeof vi.fn>
+    request: ReturnType<typeof vi.fn>
+    retry: ReturnType<typeof vi.fn>
+    dispose: ReturnType<typeof vi.fn>
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => mocks.router,
+}))
+
+vi.mock('@ionic/vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  const ionic = (name: string, tag: string, input = false) =>
+    defineComponent({
+      name,
+      inheritAttrs: false,
+      props: { modelValue: { type: [String, Number], default: '' } },
+      emits: ['update:modelValue'],
+      setup(props, { attrs, emit, slots }) {
+        return () =>
+          h(
+            tag,
+            {
+              ...attrs,
+              ...(input
+                ? {
+                    value: props.modelValue,
+                    onInput: (event: Event) =>
+                      emit('update:modelValue', (event.target as HTMLInputElement).value),
+                  }
+                : {}),
+            },
+            slots.default?.(),
+          )
+      },
+    })
+  return {
+    IonButton: ionic('IonButton', 'button'),
+    IonButtons: ionic('IonButtons', 'div'),
+    IonContent: ionic('IonContent', 'main'),
+    IonHeader: ionic('IonHeader', 'header'),
+    IonInput: ionic('IonInput', 'input', true),
+    IonPage: ionic('IonPage', 'div'),
+    IonSpinner: ionic('IonSpinner', 'span'),
+    IonTitle: ionic('IonTitle', 'h2'),
+    IonToolbar: ionic('IonToolbar', 'div'),
+  }
+})
+
+vi.mock('@/features/picacomic/auth', () => ({
+  usePicacomicAuth: () => mocks.auth,
+}))
+
+vi.mock('@/features/picacomic/service', () => ({
+  picacomicService: mocks.service,
+  picacomicErrorMessage: vi.fn(() => 'Pica fixture error'),
+  isPicacomicAuthError: vi.fn(() => false),
+}))
+
+vi.mock('@/features/picacomic/routeGate', () => ({
+  routeForPicacomicError: vi.fn(() => null),
+}))
+
+import PicacomicAlbumPage from '@/features/picacomic/pages/PicacomicAlbumPage.vue'
+import PicacomicBrowsePage from '@/features/picacomic/pages/PicacomicBrowsePage.vue'
+import PicacomicLoginPage from '@/features/picacomic/pages/PicacomicLoginPage.vue'
+import PicacomicReaderPage from '@/features/picacomic/pages/PicacomicReaderPage.vue'
+
+const image = (key: string, pageIndex: number) => ({
+  imageKey: key,
+  pageIndex,
+  cacheUrl: `https://jqviewer.local/picacomic/${key}/${pageIndex}`,
+})
+
+const chapterOne = {
+  ref: {
+    provider: 'picacomic' as const,
+    albumId: 'fixture-album-1',
+    chapterId: 'chapter-1',
+    order: 1,
+  },
+  title: '第一章',
+  updatedAt: '2026-08-01',
+  contentRevision: 'revision-1',
+  isSingleChapterAlbum: false,
+  images: [image('pica-fixture-page-1', 1), image('pica-fixture-page-2', 2)],
+}
+
+const chapterTwo = {
+  ref: {
+    provider: 'picacomic' as const,
+    albumId: 'fixture-album-1',
+    chapterId: 'chapter-2',
+    order: 2,
+  },
+  title: '第二章',
+  updatedAt: '2026-08-02',
+  contentRevision: 'revision-2',
+  isSingleChapterAlbum: false,
+  images: [image('pica-fixture-page-3', 1)],
+}
+
+const album = {
+  ref: { provider: 'picacomic' as const, albumId: 'fixture-album-1' },
+  title: 'Fixture Album',
+  authors: ['Fixture Author'],
+  translator: 'Fixture Team',
+  categories: ['debug'],
+  tags: ['fixture'],
+  cover: image('pica-fixture-cover', 1),
+  description: 'A fake album',
+  pagesCount: 3,
+  epsCount: 2,
+  finished: false,
+  createdAt: '2026-08-01',
+  updatedAt: '2026-08-02',
+  chapters: [chapterOne, chapterTwo].map(
+    ({ images: _images, contentRevision: _revision, isSingleChapterAlbum: _single, ...summary }) =>
+      summary,
+  ),
+}
+
+const catalogPage = {
+  currentPage: 1,
+  totalPages: 2,
+  totalItems: 2,
+  items: [
+    {
+      ref: album.ref,
+      title: album.title,
+      authors: album.authors,
+      translator: album.translator,
+      cover: album.cover,
+      pagesCount: album.pagesCount,
+      finished: album.finished,
+    },
+  ],
+}
+
+function configureScope() {
+  mocks.scopeHandlers = null
+  mocks.scope = {
+    start: vi.fn(() => Promise.resolve()),
+    request: vi.fn((keys: string[]) => Promise.resolve(mocks.scopeResponse(keys))),
+    retry: vi.fn((key: string) => {
+      mocks.scopeHandlers?.onReady({ imageKey: key })
+      return Promise.resolve({ cached: [key], pending: [] })
+    }),
+    dispose: vi.fn(() => Promise.resolve()),
+  }
+  mocks.service.createImageScope.mockImplementation((handlers: typeof mocks.scopeHandlers) => {
+    mocks.scopeHandlers = handlers
+    return mocks.scope
+  })
+}
+
+beforeEach(() => {
+  mocks.route.params = { albumId: 'fixture-album-1', chapterId: 'chapter-1' }
+  mocks.router.push.mockClear()
+  mocks.router.replace.mockClear()
+  mocks.auth.user.value = { id: 'fixture-user', username: 'fixture-user' }
+  mocks.auth.refresh.mockReset()
+  mocks.auth.refresh.mockResolvedValue({ state: 'signed_in' })
+  mocks.auth.login.mockReset()
+  mocks.auth.login.mockResolvedValue({ state: 'signed_in' })
+  mocks.auth.logout.mockReset()
+  mocks.auth.logout.mockResolvedValue(undefined)
+  mocks.auth.consumeRedirect.mockReset()
+  mocks.auth.consumeRedirect.mockReturnValue(null)
+  mocks.service.search.mockReset()
+  mocks.service.categories.mockReset()
+  mocks.service.getAlbum.mockReset()
+  mocks.service.getPhoto.mockReset()
+  mocks.service.search.mockResolvedValue(catalogPage)
+  mocks.service.categories.mockResolvedValue(catalogPage)
+  mocks.service.getAlbum.mockResolvedValue(album)
+  mocks.service.getPhoto.mockResolvedValue(chapterOne)
+  mocks.scopeResponse = (keys: string[]) => ({ cached: keys, pending: [] })
+  configureScope()
+})
+
+describe('Picacomic fake debug pages', () => {
+  test('login uses the isolated auth controller and structured browse navigation', async () => {
+    mocks.auth.refresh.mockResolvedValue({ state: 'signed_out' })
+    const wrapper = mount(PicacomicLoginPage)
+    await flushPromises()
+
+    await wrapper.find('[data-testid="picacomic-username"]').setValue('fixture-user')
+    await wrapper.find('[data-testid="picacomic-password"]').setValue('fixture-password')
+    await wrapper.find('[data-testid="picacomic-login-form"]').trigger('submit')
+    await flushPromises()
+
+    expect(mocks.auth.login).toHaveBeenCalledWith('fixture-user', 'fixture-password')
+    expect(mocks.router.replace).toHaveBeenCalledWith({ name: 'PicacomicBrowsePage' })
+    expect(mocks.router.replace.mock.calls[0][0]).not.toHaveProperty('query')
+  })
+
+  test('browse covers search, category, empty state, pagination and safe album navigation', async () => {
+    const wrapper = mount(PicacomicBrowsePage)
+    await flushPromises()
+
+    await wrapper.find('[data-testid="picacomic-search-form"]').trigger('submit')
+    await flushPromises()
+    expect(mocks.service.search).toHaveBeenCalledWith('', 1)
+    expect(wrapper.find('[data-testid="picacomic-results"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="picacomic-album-fixture-album-1"]').trigger('click')
+    expect(mocks.router.push).toHaveBeenCalledWith({
+      name: 'PicacomicAlbumPage',
+      params: { albumId: 'fixture-album-1' },
+    })
+
+    await wrapper.find('[data-testid="picacomic-page-next"]').trigger('click')
+    await flushPromises()
+    expect(mocks.service.search).toHaveBeenCalledWith('', 2)
+
+    mocks.service.categories.mockResolvedValue({ ...catalogPage, items: [] })
+    await wrapper.find('[data-testid="picacomic-category-submit"]').trigger('click')
+    await flushPromises()
+    expect(mocks.service.categories).toHaveBeenCalledWith('all', 1)
+    expect(wrapper.find('[data-testid="picacomic-empty"]').exists()).toBe(true)
+  })
+
+  test('album exposes chapters and reader navigation carries only stable identity', async () => {
+    const wrapper = mount(PicacomicAlbumPage)
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="picacomic-chapters"]').exists()).toBe(true)
+    await wrapper.find('[data-testid="picacomic-chapter-chapter-1"]').trigger('click')
+    expect(mocks.router.push).toHaveBeenCalledWith({
+      name: 'PicacomicReaderPage',
+      params: { albumId: 'fixture-album-1', chapterId: 'chapter-1' },
+    })
+  })
+
+  test('reader isolates failed image events and retries one image through native scope', async () => {
+    mocks.scopeResponse = (keys: string[]) => ({ cached: [], pending: keys })
+    const wrapper = mount(PicacomicReaderPage)
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="picacomic-reader-images"]').exists()).toBe(true)
+    const failedKey = chapterOne.images[0].imageKey
+    mocks.scopeHandlers?.onFailed({
+      imageKey: failedKey,
+      code: 'PICACOMIC_NETWORK',
+      retryable: true,
+    })
+    await nextTick()
+    expect(wrapper.find('[data-testid="picacomic-image-failed"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="picacomic-retry-1"]').trigger('click')
+    await flushPromises()
+    expect(mocks.scope?.retry).toHaveBeenCalledWith(failedKey)
+    expect(wrapper.find('[data-testid="picacomic-image-failed"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="picacomic-next-chapter"]').trigger('click')
+    expect(mocks.router.replace).toHaveBeenCalledWith({
+      name: 'PicacomicReaderPage',
+      params: { albumId: 'fixture-album-1', chapterId: 'chapter-2' },
+    })
+  })
+})

--- a/tests/unit/picacomicRouteGate.test.ts
+++ b/tests/unit/picacomicRouteGate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+import router, { registerPicacomicRoutes } from '@/router'
+import {
+  picacomicAuthGuard,
+  redirectFromPicacomicRoute,
+  shouldExposePicacomicRoutes,
+} from '@/features/picacomic/routeGate'
+import { usePicacomicAuth } from '@/features/picacomic/auth'
+import { createPicacomicRoutes } from '@/features/picacomic/routes'
+
+describe('Picacomic debug route gate', () => {
+  test('only test/development or native debug builds expose the route set', () => {
+    expect(shouldExposePicacomicRoutes('production')).toBe(false)
+    expect(shouldExposePicacomicRoutes('production', true)).toBe(true)
+    expect(shouldExposePicacomicRoutes('development')).toBe(true)
+    expect(shouldExposePicacomicRoutes('test')).toBe(true)
+  })
+
+  test('safe redirect contains only structured route identity', () => {
+    expect(
+      redirectFromPicacomicRoute({
+        name: 'PicacomicReaderPage',
+        params: { albumId: 'album-1', chapterId: 'chapter-1' },
+      } as never),
+    ).toEqual({
+      name: 'PicacomicReaderPage',
+      params: { albumId: 'album-1', chapterId: 'chapter-1' },
+    })
+    expect(
+      JSON.stringify(
+        redirectFromPicacomicRoute({
+          name: 'PicacomicReaderPage',
+          params: { albumId: 'album-1', chapterId: 'chapter-1' },
+        } as never),
+      ),
+    ).not.toMatch(/password|token|https?:\/\//i)
+  })
+
+  test('route records stay internal and out of the main menu', () => {
+    const routes = createPicacomicRoutes()
+    expect(routes.map((route) => route.name)).toEqual([
+      'PicacomicLoginPage',
+      'PicacomicBrowsePage',
+      'PicacomicAlbumPage',
+      'PicacomicReaderPage',
+    ])
+    expect(routes.every((route) => route.meta?.menu === false)).toBe(true)
+    expect(routes.every((route) => route.meta?.picacomicInternal === true)).toBe(true)
+    expect(router.getRoutes().some((route) => route.name === 'PicacomicBrowsePage')).toBe(false)
+  })
+
+  test('auth guard stores only a structured redirect for signed-out readers', async () => {
+    const result = await picacomicAuthGuard({
+      name: 'PicacomicReaderPage',
+      params: { albumId: 'fixture-album-1', chapterId: 'chapter-1' },
+    } as never)
+
+    expect(result).toEqual({ name: 'PicacomicLoginPage' })
+    expect(usePicacomicAuth().consumeRedirect()).toEqual({
+      name: 'PicacomicReaderPage',
+      params: { albumId: 'fixture-album-1', chapterId: 'chapter-1' },
+    })
+  })
+
+  test('test mode registers the isolated route set dynamically', async () => {
+    await expect(registerPicacomicRoutes()).resolves.toBe(true)
+    expect(router.getRoutes().map((route) => route.name)).toContain('PicacomicBrowsePage')
+  })
+})

--- a/tests/unit/picacomicService.test.ts
+++ b/tests/unit/picacomicService.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest'
+import { createPicacomicFixtureClient } from '@/features/picacomic/fixture'
+import {
+  PicacomicService,
+  PicacomicServiceError,
+  picacomicErrorMessage,
+} from '@/features/picacomic/service'
+
+describe('PicacomicService fake contract', () => {
+  test('normal mapping and pagination stay inside the Picacomic façade', async () => {
+    const fixture = createPicacomicFixtureClient()
+    const service = new PicacomicService(fixture)
+
+    await expect(service.getAuthState()).resolves.toEqual({ state: 'signed_out' })
+    await service.login('fixture-user', 'fixture-password')
+
+    const first = await service.search('fixture', 1)
+    const second = await service.search('fixture', 2)
+
+    expect(first).toMatchObject({ currentPage: 1, totalPages: 2, totalItems: 2 })
+    expect(first.items[0].ref).toEqual({ provider: 'picacomic', albumId: 'fixture-album-1' })
+    expect(second.items[0].ref.albumId).toBe('fixture-album-2')
+    expect(first.items[0].cover?.cacheUrl).toContain('/picacomic/')
+    expect(fixture.calls).not.toContain('jmcomic')
+  })
+
+  test('empty results are a valid page rather than an error', async () => {
+    const fixture = createPicacomicFixtureClient({ initiallySignedIn: true })
+    const service = new PicacomicService(fixture)
+
+    await expect(service.search('empty', 1)).resolves.toEqual({
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 0,
+      items: [],
+    })
+  })
+
+  test('401/403, network/parse and stale chapter retain stable UI codes', async () => {
+    const fixture = createPicacomicFixtureClient({ initiallySignedIn: true })
+    const service = new PicacomicService(fixture)
+
+    const scenarios: Array<[string, string]> = [
+      ['401', 'PICACOMIC_AUTH_EXPIRED'],
+      ['403', 'PICACOMIC_AUTH_REQUIRED'],
+      ['network', 'PICACOMIC_NETWORK'],
+      ['parse', 'PICACOMIC_INVALID_RESPONSE'],
+    ]
+    for (const [query, code] of scenarios) {
+      await expect(service.search(query)).rejects.toMatchObject({ code })
+    }
+
+    await expect(
+      service.getPhoto({
+        provider: 'picacomic',
+        albumId: 'fixture-album-1',
+        chapterId: 'stale',
+        order: 1,
+      }),
+    ).rejects.toMatchObject({ code: 'PICACOMIC_STALE_RESOURCE' })
+    expect(picacomicErrorMessage(new PicacomicServiceError('PICACOMIC_NETWORK', 'test'))).toContain(
+      '网络',
+    )
+  })
+
+  test('image scope rejects late events after chapter navigation and supports retry', async () => {
+    const fixture = createPicacomicFixtureClient({
+      initiallySignedIn: true,
+      failImageKeys: ['pica-fixture-fixture-album-1-chapter-1-1'],
+      deferImageEvents: true,
+    })
+    const service = new PicacomicService(fixture)
+    const retryKey = 'pica-fixture-fixture-album-1-chapter-1-1'
+    const lateKey = 'pica-fixture-fixture-album-1-chapter-1-2'
+    const nextKey = 'pica-fixture-fixture-album-1-chapter-2-1'
+    const ready: string[] = []
+    const failed: string[] = []
+    const scopeA = service.createImageScope({
+      onReady: (event) => ready.push(`a:${event.imageKey}`),
+      onFailed: (event) => failed.push(`a:${event.imageKey}`),
+    })
+    await scopeA.start()
+    await scopeA.request([lateKey])
+    await scopeA.dispose()
+
+    const scopeB = service.createImageScope({
+      onReady: (event) => ready.push(`b:${event.imageKey}`),
+      onFailed: (event) => failed.push(`b:${event.imageKey}`),
+    })
+    await scopeB.start()
+    await scopeB.request([nextKey])
+    fixture.flushImageEvents()
+    await Promise.resolve()
+
+    expect(failed).toEqual([])
+    expect(ready).toEqual([`b:${nextKey}`])
+    await expect(scopeA.request([lateKey])).rejects.toMatchObject({ code: 'PICACOMIC_CANCELLED' })
+
+    const retryScope = service.createImageScope({
+      onReady: (event) => ready.push(`retry:${event.imageKey}`),
+      onFailed: (event) => failed.push(`retry:${event.imageKey}`),
+    })
+    await retryScope.start()
+    await retryScope.request([retryKey])
+    fixture.flushImageEvents()
+    await Promise.resolve()
+    expect(failed).toEqual([`retry:${retryKey}`])
+    await retryScope.retry(retryKey)
+    fixture.flushImageEvents()
+    await Promise.resolve()
+    expect(ready).toContain(`retry:${retryKey}`)
+    await retryScope.dispose()
+    await scopeB.dispose()
+  })
+
+  test('logout clears only the fixture session and scope lifecycle is idempotent', async () => {
+    const fixture = createPicacomicFixtureClient({ initiallySignedIn: true })
+    const service = new PicacomicService(fixture)
+    const scope = service.createImageScope({ onReady: () => {}, onFailed: () => {} })
+    await scope.start()
+    await service.logout()
+    await scope.dispose()
+    await scope.dispose()
+
+    expect(await service.getAuthState()).toEqual({ state: 'signed_out' })
+    expect(fixture.calls).toContain('logout')
+  })
+})


### PR DESCRIPTION
## Summary

- Add an isolated `src/features/picacomic/` fake read-only flow: login, browse/search/category pagination, album/chapter detail, reader navigation, image ready/failed/retry, and lifecycle-safe image scopes.
- Register the internal routes dynamically only in Vite test/development or when the native Android `Picacomic` plugin reports a debug build. The main menu, settings, release route table, and JMComic services remain unchanged.
- Use the CP2 native bridge/runtime/image registry/cache in Android debug builds through a deterministic no-network fixture; no PicaComic artifact, credential, or network dependency is added.

## Dependency and retarget plan

Depends on #123. This is a stacked Ready PR based on `agent/arcana/ASTRA-41-cp2-fake-contract` at PR #123 head `180859800058d5a5b95d9acaee1db5fde300ad3b`.

After #123 is merged, retarget this PR to `master`, fetch the merged base, and rebase the CP3 commit onto the merge result (for example, rebase the CP3 commit with `git rebase --onto master 180859800058d5a5b95d9acaee1db5fde300ad3b agent/arcana/ASTRA-41-cp3-fake-ui`). Re-run the frontend and Android checks, then update the PR head as required. No merge is performed in this PR.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:version`
- `npx vitest run tests/unit/picacomicService.test.ts tests/unit/picacomicRouteGate.test.ts tests/unit/PicacomicPages.test.ts` — 14 passed.
- `npm run test:unit` — 51 files / 294 tests collected; 271 passed and 23 existing Node 26/Vitest `localStorage` environment failures, with no changes to those JM/PDF tests.
- Android debug fixture contract is in `androidTest`; the current local runner has no Android SDK, so local Gradle/instrumentation execution is not claimed.
