### PR TITLE
ASTRA-40: 完成共享侧边栏宽屏适配

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,16 @@
 <template>
   <ion-app>
-    <MainMenu content-id="main-content" :disabled="route.meta.menu !== true"></MainMenu>
-    <div id="main-content" class="ion-page-container">
-      <router-view v-slot="{ Component }">
-        <transition :name="transitionName" mode="out-in" @after-enter="onAfterEnter">
-          <keep-alive :include="keepAliveNames" :exclude="keepAliveExclude">
-            <component :is="Component" />
-          </keep-alive>
-        </transition>
-      </router-view>
+    <div class="app-shell">
+      <MainMenu content-id="main-content" :disabled="route.meta.menu !== true"></MainMenu>
+      <div id="main-content" class="ion-page-container">
+        <router-view v-slot="{ Component }">
+          <transition :name="transitionName" mode="out-in" @after-enter="onAfterEnter">
+            <keep-alive :include="keepAliveNames" :exclude="keepAliveExclude">
+              <component :is="Component" />
+            </keep-alive>
+          </transition>
+        </router-view>
+      </div>
     </div>
   </ion-app>
 </template>
@@ -350,12 +352,24 @@ onBeforeUnmount(() => {
 </script>
 
 <style>
+.app-shell {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .ion-page-container {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  position: relative;
+  flex: 1 1 auto;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
   contain: layout size style;
   z-index: 0;
   overflow: hidden;

--- a/src/components/common/MenuToggleButton.vue
+++ b/src/components/common/MenuToggleButton.vue
@@ -1,5 +1,11 @@
 <template>
-  <button type="button" class="menu-toggle-btn" @click="openMenu">
+  <button
+    v-if="!isWideMenu"
+    type="button"
+    class="menu-toggle-btn"
+    aria-label="打开侧边栏"
+    @click="openMenu"
+  >
     <IonIcon :icon="menuOutline" />
   </button>
 </template>
@@ -9,7 +15,7 @@ defineOptions({ name: 'MenuToggleButton' })
 
 import { IonIcon } from '@ionic/vue'
 import { menuOutline } from 'ionicons/icons'
-import { openLeftMenu } from '@/composables/useSideMenuState'
+import { isWideMenu, openLeftMenu } from '@/composables/useSideMenuState'
 
 const openMenu = () => {
   openLeftMenu()

--- a/src/components/menu/MainMenu.vue
+++ b/src/components/menu/MainMenu.vue
@@ -1,6 +1,15 @@
 <template>
-  <div class="main-menu" :class="{ interactive: isInteractive }" :aria-hidden="!isInteractive">
+  <div
+    class="main-menu"
+    :class="{
+      interactive: isInteractive,
+      'wide-menu': isWideMenuActive,
+      'wide-menu-collapsed': isWideMenuActive && wideMenuCollapsed,
+    }"
+    :aria-hidden="menuAriaHidden ? 'true' : undefined"
+  >
     <button
+      v-if="!isWideMenuActive"
       type="button"
       class="main-menu-backdrop"
       aria-label="关闭侧边栏"
@@ -10,36 +19,54 @@
     />
 
     <aside
+      id="main-menu-panel"
       ref="panelRef"
       class="main-menu-panel"
-      role="dialog"
-      aria-modal="true"
+      :role="isWideMenuActive ? 'navigation' : 'dialog'"
+      :aria-modal="isWideMenuActive ? undefined : 'true'"
       aria-label="主菜单"
       tabindex="-1"
       :style="panelStyle"
     >
       <IonHeader class="ion-no-border menu-header">
-        <button type="button" class="menu-hero" @click="goUser">
-          <img
-            v-if="isLoggedIn && userInfo"
-            :src="userInfo.avatarUrl"
-            class="user-avatar"
-            alt="头像"
-          />
-          <IonIcon v-else :icon="personCircleOutline" class="user-avatar-placeholder" />
-          <div class="hero-copy">
-            <div class="hero-title">
-              {{ isLoggedIn && userInfo ? userInfo.username : '未登录' }}
+        <div class="menu-header-row">
+          <button type="button" class="menu-hero" :aria-label="accountButtonLabel" @click="goUser">
+            <img
+              v-if="isLoggedIn && userInfo"
+              :src="userInfo.avatarUrl"
+              class="user-avatar"
+              alt="头像"
+            />
+            <IonIcon v-else :icon="personCircleOutline" class="user-avatar-placeholder" />
+            <div class="hero-copy">
+              <div class="hero-title">
+                {{ isLoggedIn && userInfo ? userInfo.username : '未登录' }}
+              </div>
+              <div class="hero-subtitle">
+                {{
+                  isLoggedIn && userInfo
+                    ? 'Lv.' + userInfo.level + ' ' + userInfo.levelName
+                    : '点击查看账号信息'
+                }}
+              </div>
             </div>
-            <div class="hero-subtitle">
-              {{
-                isLoggedIn && userInfo
-                  ? 'Lv.' + userInfo.level + ' ' + userInfo.levelName
-                  : '点击查看账号信息'
-              }}
-            </div>
-          </div>
-        </button>
+          </button>
+          <button
+            v-if="isWideMenuActive"
+            type="button"
+            class="menu-collapse-button"
+            :aria-controls="'main-menu-panel'"
+            :aria-expanded="!wideMenuCollapsed"
+            :aria-label="wideMenuCollapsed ? '展开主菜单' : '收起主菜单'"
+            @click="toggleWideMenu"
+          >
+            <IonIcon
+              :icon="wideMenuCollapsed ? chevronForwardOutline : chevronBackOutline"
+              aria-hidden="true"
+            />
+            <span class="menu-collapse-text">{{ wideMenuCollapsed ? '展开' : '收起' }}</span>
+          </button>
+        </div>
       </IonHeader>
       <IonContent class="menu-content">
         <IonList lines="none" class="menu-list">
@@ -189,6 +216,8 @@ import {
 import type { PluginListenerHandle } from '@capacitor/core'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import {
+  chevronBackOutline,
+  chevronForwardOutline,
   downloadSharp,
   heart,
   homeSharp,
@@ -200,12 +229,18 @@ import {
 import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '@/composables/useAuth'
 import {
+  collapseWideMenu,
   closeLeftMenu,
+  expandWideMenu,
+  isWideMenu,
   leftMenuGestureEnabled,
   leftMenuOpen,
   isMenuNavigation,
   openLeftMenu,
   rightMenuOpen,
+  startWideMenuTracking,
+  stopWideMenuTracking,
+  wideMenuCollapsed,
 } from '@/composables/useSideMenuState'
 import { JmcomicService } from '@/services/JmcomicService'
 import type {
@@ -630,17 +665,33 @@ const setupTaskProgress = async () => {
   ])
 }
 
+const isWideMenuActive = computed(() => isWideMenu.value && !props.disabled)
 const isInteractive = computed(
-  () => leftMenuOpen.value || (isDragging.value && dragProgress.value > 0),
+  () =>
+    !isWideMenu.value &&
+    !props.disabled &&
+    (leftMenuOpen.value || (isDragging.value && dragProgress.value > 0)),
+)
+const menuAriaHidden = computed(
+  () => props.disabled || (!isWideMenuActive.value && !isInteractive.value),
+)
+const accountButtonLabel = computed(() =>
+  isLoggedIn.value && userInfo.value
+    ? `查看账号信息（${userInfo.value.username}）`
+    : '查看账号信息',
 )
 const currentProgress = computed(() =>
-  isDragging.value ? dragProgress.value : leftMenuOpen.value ? 1 : 0,
+  isInteractive.value ? (isDragging.value ? dragProgress.value : leftMenuOpen.value ? 1 : 0) : 0,
 )
 const panelStyle = computed(() => ({
-  transform: `translate3d(${(currentProgress.value - 1) * 100}%, 0, 0)`,
-  transition: isDragging.value
+  transform: isWideMenuActive.value
     ? 'none'
-    : `transform ${MAIN_MENU_TRANSITION_MS}ms cubic-bezier(0.22, 0.61, 0.36, 1)`,
+    : `translate3d(${(currentProgress.value - 1) * 100}%, 0, 0)`,
+  transition: isWideMenuActive.value
+    ? 'none'
+    : isDragging.value
+      ? 'none'
+      : `transform ${MAIN_MENU_TRANSITION_MS}ms cubic-bezier(0.22, 0.61, 0.36, 1)`,
 }))
 const backdropStyle = computed(() => ({
   opacity: isInteractive.value ? 0.32 : 0,
@@ -659,6 +710,7 @@ const isBlockedTarget = (target: EventTarget | null) => {
 }
 
 const canStartGesture = (detail: { event: UIEvent }) => {
+  if (isWideMenu.value) return false
   const menuIsOpen = leftMenuOpen.value
   if (!menuIsOpen && (props.disabled || !leftMenuGestureEnabled.value || rightMenuOpen.value)) {
     return false
@@ -719,6 +771,11 @@ const closeMenu = () => {
   closeLeftMenu()
 }
 
+const toggleWideMenu = () => {
+  if (wideMenuCollapsed.value) expandWideMenu()
+  else collapseWideMenu()
+}
+
 const updateContentAccessibility = (open: boolean) => {
   const content = document.getElementById(props.contentId)
   if (open) {
@@ -765,7 +822,12 @@ function handleMenuClick() {
   closeMenu()
 }
 
-watch(leftMenuOpen, (open) => updateContentAccessibility(open))
+watch([leftMenuOpen, isWideMenu, () => props.disabled], ([open, wide, disabled]) =>
+  updateContentAccessibility(Boolean(open && !wide && !disabled)),
+)
+watch(isWideMenu, (wide) => {
+  if (wide) closeLeftMenu()
+})
 watch(
   () => props.disabled,
   (disabled) => {
@@ -775,6 +837,7 @@ watch(
 
 onMounted(() => {
   progressUnmounted = false
+  startWideMenuTracking()
   void setupTaskProgress()
   setupGesture()
   document.addEventListener('keydown', handleKeyDown)
@@ -799,6 +862,7 @@ onUnmounted(() => {
   pdfEventSequence = 0
   gesture?.destroy()
   document.removeEventListener('keydown', handleKeyDown)
+  stopWideMenuTracking()
   updateContentAccessibility(false)
 })
 </script>
@@ -813,6 +877,24 @@ onUnmounted(() => {
 
 .main-menu.interactive {
   pointer-events: auto;
+}
+
+.main-menu.wide-menu {
+  position: relative;
+  inset: auto;
+  z-index: 1;
+  flex: 0 0 304px;
+  width: 304px;
+  height: 100%;
+  pointer-events: auto;
+  transition:
+    flex-basis 220ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    width 220ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.main-menu.wide-menu.wide-menu-collapsed {
+  flex-basis: 80px;
+  width: 80px;
 }
 
 .main-menu-backdrop {
@@ -846,6 +928,16 @@ onUnmounted(() => {
   will-change: transform;
 }
 
+.main-menu.wide-menu .main-menu-panel {
+  position: relative;
+  inset: auto;
+  width: 100%;
+  height: 100%;
+  transform: none;
+  box-shadow: 4px 0 16px rgb(76 42 24 / 0.18);
+  touch-action: pan-y;
+}
+
 .main-menu-panel:focus {
   outline: none;
 }
@@ -867,6 +959,52 @@ onUnmounted(() => {
   cursor: pointer;
   text-align: left;
   font: inherit;
+}
+
+.menu-header-row {
+  display: flex;
+  align-items: flex-start;
+}
+
+.menu-hero {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.menu-collapse-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  margin: calc(18px + var(--ion-safe-area-top)) 12px 0 0;
+  padding: 0;
+  border: 1px solid rgb(245 210 188 / 0.85);
+  border-radius: 13px;
+  background: rgb(255 255 255 / 0.58);
+  color: #9a6040;
+  font-size: 18px;
+  box-shadow: -3px -2px 8px rgb(115 67 38 / 0.08);
+}
+
+.menu-collapse-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.menu-collapse-button:focus-visible,
+.menu-hero:focus-visible,
+.menu-item:focus-visible {
+  outline: 3px solid rgb(232 132 60 / 0.62);
+  outline-offset: 2px;
 }
 
 .user-avatar {
@@ -905,6 +1043,38 @@ onUnmounted(() => {
   background: transparent;
 }
 
+.main-menu.wide-menu.wide-menu-collapsed .menu-header-row {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .menu-hero {
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: calc(14px + var(--ion-safe-area-top)) 4px 8px;
+  text-align: center;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .user-avatar {
+  width: 42px;
+  height: 42px;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .user-avatar-placeholder {
+  font-size: 38px;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .hero-copy {
+  display: none;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .menu-collapse-button {
+  align-self: center;
+  margin: 0 auto 10px;
+}
+
 .menu-content {
   --background: transparent;
   flex: 1;
@@ -915,6 +1085,10 @@ onUnmounted(() => {
   --ion-item-background: transparent;
   padding: 14px 14px 0;
   background: transparent !important;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .menu-list {
+  padding: 8px 6px 0;
 }
 
 .menu-item {
@@ -929,6 +1103,39 @@ onUnmounted(() => {
   border: 1px solid rgb(245 210 188 / 0.72);
   border-radius: 20px;
   box-shadow: -6px -4px 12px rgb(115 67 38 / 0.1);
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .menu-item {
+  --padding-start: 6px;
+  --inner-padding-end: 6px;
+  --min-height: 58px;
+  margin-bottom: 8px;
+  border-radius: 16px;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .menu-icon {
+  margin-right: 6px;
+  font-size: 17px;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .item-title {
+  font-size: 12px;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .item-subtitle {
+  display: none;
+}
+
+.main-menu.wide-menu.wide-menu-collapsed .task-progress-copy {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .task-progress-background {
@@ -1095,6 +1302,10 @@ onUnmounted(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .main-menu.wide-menu {
+    transition: none;
+  }
+
   .task-progress-band {
     transition: none;
   }

--- a/src/composables/useSideMenuState.ts
+++ b/src/composables/useSideMenuState.ts
@@ -1,7 +1,15 @@
 import { ref } from 'vue'
 
+export const WIDE_MENU_MEDIA_QUERY = '(min-width: 992px)'
+
 /** 左侧主菜单是否打开 */
 export const leftMenuOpen = ref(false)
+
+/** 当前窗口是否满足宽屏侧栏断点 */
+export const isWideMenu = ref(false)
+
+/** 宽屏侧栏是否收起为紧凑 rail；仅在当前运行期间保留 */
+export const wideMenuCollapsed = ref(false)
 
 /** 详情页等局部横滑手势生效时，暂时禁用全局左侧栏开启手势 */
 export const leftMenuGestureEnabled = ref(true)
@@ -21,13 +29,61 @@ export const isSnappingClosed = ref(false)
 /** 当前导航是否由侧边栏菜单触发 */
 export const isMenuNavigation = ref(false)
 
+let wideMenuMediaQuery: MediaQueryList | null = null
+let wideMenuChangeListener: ((event: MediaQueryListEvent) => void) | null = null
+
+const syncWideMenu = (matches: boolean) => {
+  isWideMenu.value = matches
+  // overlay 只属于窄屏，跨断点时立即收起，避免旧状态覆盖正文。
+  leftMenuOpen.value = false
+}
+
+/** 开始监听宽屏断点。调用方应在所属组件卸载时调用 stopWideMenuTracking。 */
+export function startWideMenuTracking() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    syncWideMenu(false)
+    return
+  }
+  if (wideMenuMediaQuery) return
+
+  wideMenuMediaQuery = window.matchMedia(WIDE_MENU_MEDIA_QUERY)
+  syncWideMenu(wideMenuMediaQuery.matches)
+  wideMenuChangeListener = (event) => syncWideMenu(event.matches)
+  wideMenuMediaQuery.addEventListener('change', wideMenuChangeListener)
+}
+
+/** 停止监听宽屏断点并清理组件所属的运行期状态。 */
+export function stopWideMenuTracking() {
+  if (wideMenuMediaQuery && wideMenuChangeListener) {
+    wideMenuMediaQuery.removeEventListener('change', wideMenuChangeListener)
+  }
+  wideMenuMediaQuery = null
+  wideMenuChangeListener = null
+  syncWideMenu(false)
+}
+
 export function openLeftMenu() {
   rightMenuOpen.value = false
+  if (isWideMenu.value) {
+    wideMenuCollapsed.value = false
+    return
+  }
   leftMenuOpen.value = true
 }
 
 export function closeLeftMenu() {
   leftMenuOpen.value = false
+}
+
+export function collapseWideMenu() {
+  rightMenuOpen.value = false
+  wideMenuCollapsed.value = true
+  leftMenuOpen.value = false
+}
+
+export function expandWideMenu() {
+  rightMenuOpen.value = false
+  wideMenuCollapsed.value = false
 }
 
 export function setLeftMenuGestureEnabled(enabled: boolean) {
@@ -37,6 +93,8 @@ export function setLeftMenuGestureEnabled(enabled: boolean) {
 export function useSideMenuState() {
   return {
     leftMenuOpen,
+    isWideMenu,
+    wideMenuCollapsed,
     leftMenuGestureEnabled,
     rightMenuOpen,
     rightDragProgress,
@@ -45,6 +103,10 @@ export function useSideMenuState() {
     isMenuNavigation,
     openLeftMenu,
     closeLeftMenu,
+    collapseWideMenu,
+    expandWideMenu,
     setLeftMenuGestureEnabled,
+    startWideMenuTracking,
+    stopWideMenuTracking,
   }
 }

--- a/tests/unit/MainMenu.test.ts
+++ b/tests/unit/MainMenu.test.ts
@@ -3,10 +3,12 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import MainMenu from '@/components/menu/MainMenu.vue'
 import {
+  isWideMenu,
   isMenuNavigation,
   leftMenuGestureEnabled,
   leftMenuOpen,
   rightMenuOpen,
+  wideMenuCollapsed,
 } from '@/composables/useSideMenuState'
 
 const mocks = vi.hoisted(() => ({
@@ -79,6 +81,8 @@ const getGesture = () => {
 
 beforeEach(() => {
   leftMenuOpen.value = false
+  isWideMenu.value = false
+  wideMenuCollapsed.value = false
   leftMenuGestureEnabled.value = true
   rightMenuOpen.value = false
   isMenuNavigation.value = false
@@ -106,6 +110,8 @@ beforeEach(() => {
 afterEach(() => {
   document.getElementById('main-content')?.remove()
   leftMenuOpen.value = false
+  isWideMenu.value = false
+  wideMenuCollapsed.value = false
   leftMenuGestureEnabled.value = true
   rightMenuOpen.value = false
   isMenuNavigation.value = false
@@ -308,6 +314,75 @@ describe('MainMenu 自定义左侧手势', () => {
     rightMenuOpen.value = false
     expect(gesture.canStart({ event: { target: range } })).toBe(false)
 
+    wrapper.unmount()
+  })
+})
+
+describe('MainMenu 宽屏三态布局', () => {
+  test('宽屏默认显示导航、隐藏 overlay 控制并可收起为 rail', async () => {
+    const wrapper = mountMenu()
+    isWideMenu.value = true
+    await nextTick()
+
+    const menu = wrapper.find('.main-menu')
+    const panel = wrapper.find('.main-menu-panel')
+    const collapseButton = wrapper.find('.menu-collapse-button')
+
+    expect(menu.classes()).toContain('wide-menu')
+    expect(menu.classes()).not.toContain('wide-menu-collapsed')
+    expect(menu.attributes('aria-hidden')).toBeUndefined()
+    expect(panel.attributes('role')).toBe('navigation')
+    expect(panel.attributes('aria-modal')).toBeUndefined()
+    expect(wrapper.find('.main-menu-backdrop').exists()).toBe(false)
+    expect(collapseButton.attributes('aria-controls')).toBe('main-menu-panel')
+    expect(collapseButton.attributes('aria-expanded')).toBe('true')
+    expect(collapseButton.attributes('aria-label')).toBe('收起主菜单')
+    expect(getGesture().canStart({ event: { target: document.body } })).toBe(false)
+
+    await collapseButton.trigger('click')
+    await nextTick()
+    expect(wideMenuCollapsed.value).toBe(true)
+    expect(menu.classes()).toContain('wide-menu-collapsed')
+    expect(collapseButton.attributes('aria-expanded')).toBe('false')
+    expect(collapseButton.attributes('aria-label')).toBe('展开主菜单')
+
+    await collapseButton.trigger('click')
+    await nextTick()
+    expect(wideMenuCollapsed.value).toBe(false)
+    expect(menu.classes()).not.toContain('wide-menu-collapsed')
+    wrapper.unmount()
+  })
+
+  test('跨越宽屏断点会关闭 overlay，返回窄屏后保留窄屏手势', async () => {
+    const wrapper = mountMenu()
+    leftMenuOpen.value = true
+    await nextTick()
+    const content = document.getElementById('main-content')!
+    expect(content.hasAttribute('inert')).toBe(true)
+
+    isWideMenu.value = true
+    await nextTick()
+    expect(leftMenuOpen.value).toBe(false)
+    expect(content.hasAttribute('inert')).toBe(false)
+    expect(wrapper.find('.main-menu').classes()).toContain('wide-menu')
+
+    isWideMenu.value = false
+    await nextTick()
+    expect(wrapper.find('.main-menu').classes()).not.toContain('wide-menu')
+    expect(getGesture().canStart({ event: { target: document.body } })).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('宽屏菜单项导航不会意外收起 rail', async () => {
+    const wrapper = mountMenu()
+    isWideMenu.value = true
+    wideMenuCollapsed.value = true
+    await nextTick()
+
+    await wrapper.find('.menu-item').trigger('click')
+    await nextTick()
+    expect(wideMenuCollapsed.value).toBe(true)
+    expect(leftMenuOpen.value).toBe(false)
     wrapper.unmount()
   })
 })

--- a/tests/unit/MenuToggleButton.test.ts
+++ b/tests/unit/MenuToggleButton.test.ts
@@ -1,0 +1,40 @@
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import MenuToggleButton from '@/components/common/MenuToggleButton.vue'
+import { isWideMenu, leftMenuOpen } from '@/composables/useSideMenuState'
+
+vi.mock('@ionic/vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    IonIcon: defineComponent({
+      name: 'IonIcon',
+      render: () => h('span'),
+    }),
+  }
+})
+
+afterEach(() => {
+  isWideMenu.value = false
+  leftMenuOpen.value = false
+})
+
+describe('MenuToggleButton', () => {
+  test('窄屏显示 overlay 入口并打开左侧菜单', async () => {
+    const wrapper = mount(MenuToggleButton)
+
+    expect(wrapper.find('button').attributes('aria-label')).toBe('打开侧边栏')
+    await wrapper.find('button').trigger('click')
+    expect(leftMenuOpen.value).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('宽屏不重复渲染窄屏 overlay 入口', async () => {
+    const wrapper = mount(MenuToggleButton)
+    isWideMenu.value = true
+    await nextTick()
+
+    expect(wrapper.find('button').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/useSideMenuState.test.ts
+++ b/tests/unit/useSideMenuState.test.ts
@@ -1,10 +1,30 @@
-import { describe, expect, test } from 'vitest'
-import { useSideMenuState } from '@/composables/useSideMenuState'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  collapseWideMenu,
+  expandWideMenu,
+  leftMenuOpen,
+  isWideMenu,
+  openLeftMenu,
+  startWideMenuTracking,
+  stopWideMenuTracking,
+  useSideMenuState,
+  WIDE_MENU_MEDIA_QUERY,
+  wideMenuCollapsed,
+} from '@/composables/useSideMenuState'
+
+afterEach(() => {
+  stopWideMenuTracking()
+  isWideMenu.value = false
+  wideMenuCollapsed.value = false
+  vi.unstubAllGlobals()
+})
 
 describe('useSideMenuState', () => {
   test('所有菜单状态初始为关闭', () => {
     const state = useSideMenuState()
     expect(state.leftMenuOpen.value).toBe(false)
+    expect(state.isWideMenu.value).toBe(false)
+    expect(state.wideMenuCollapsed.value).toBe(false)
     expect(state.leftMenuGestureEnabled.value).toBe(true)
     expect(state.rightMenuOpen.value).toBe(false)
     expect(state.isDraggingRight.value).toBe(false)
@@ -48,5 +68,51 @@ describe('useSideMenuState', () => {
     expect(state.leftMenuGestureEnabled.value).toBe(false)
     state.closeLeftMenu()
     state.setLeftMenuGestureEnabled(true)
+  })
+
+  test('宽屏断点在 992px 边界动态切换并关闭窄屏 overlay', () => {
+    let changeListener: ((event: MediaQueryListEvent) => void) | undefined
+    const mediaQuery = {
+      matches: false,
+      addEventListener: vi.fn((_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        changeListener = listener
+      }),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList
+    const matchMedia = vi.fn(() => mediaQuery)
+    vi.stubGlobal('matchMedia', matchMedia)
+
+    startWideMenuTracking()
+    expect(matchMedia).toHaveBeenCalledWith(WIDE_MENU_MEDIA_QUERY)
+    expect(isWideMenu.value).toBe(false)
+
+    leftMenuOpen.value = true
+    changeListener?.({ matches: true } as MediaQueryListEvent)
+    expect(isWideMenu.value).toBe(true)
+    expect(leftMenuOpen.value).toBe(false)
+
+    changeListener?.({ matches: false } as MediaQueryListEvent)
+    expect(isWideMenu.value).toBe(false)
+    expect(leftMenuOpen.value).toBe(false)
+    stopWideMenuTracking()
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', changeListener)
+  })
+
+  test('宽屏打开操作展开 rail，收起状态在运行期间保留', () => {
+    isWideMenu.value = true
+    collapseWideMenu()
+    expect(wideMenuCollapsed.value).toBe(true)
+    expect(leftMenuOpen.value).toBe(false)
+
+    openLeftMenu()
+    expect(wideMenuCollapsed.value).toBe(false)
+    expect(leftMenuOpen.value).toBe(false)
+
+    collapseWideMenu()
+    isWideMenu.value = false
+    isWideMenu.value = true
+    expect(wideMenuCollapsed.value).toBe(true)
+    expandWideMenu()
+    expect(wideMenuCollapsed.value).toBe(false)
   })
 })


### PR DESCRIPTION
## 变更

- 应用壳改为全屏 flex 布局；菜单路由下正文自动占据侧栏右侧剩余空间，无菜单路由保持全宽。
- 新增 `(min-width: 992px)` 运行期断点监听：宽屏默认显示 `304px` 侧栏，可收起为 `80px` rail；窄屏继续使用现有 overlay、手势和焦点隔离。
- 宽屏侧栏使用导航语义，收放按钮提供 `aria-controls`、`aria-expanded` 和中文标签；rail 保留头像、图标、短标题、进度色带及无障碍进度播报。
- 窄屏 `MenuToggleButton` 保持 overlay 入口，宽屏不重复渲染；收起状态只在当前运行期间记忆。
- 补充断点、状态清理、rail 收放、导航行为和入口组件单测；未增加持久化、依赖或页面专属布局改动。

## 验证

- `npx vitest run tests/unit/useSideMenuState.test.ts tests/unit/MainMenu.test.ts tests/unit/MenuToggleButton.test.ts`（32/32）
- `NODE_OPTIONS=--no-experimental-webstorage npm run test:unit`（50 个测试文件，295/295）
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`

Closes #105
