### PR TITLE
ASTRA-30: PDF 阅读页宽屏适配

### DIFF
--- a/src/views/PdfReaderPage.vue
+++ b/src/views/PdfReaderPage.vue
@@ -95,8 +95,10 @@ const SPEED_THRESHOLD = 10
 const EXPAND_EXPIRE_MS = 2000
 const DRAG_PREVIEW_DELAY_MS = 500
 const PDF_RENDER_CONCURRENCY = 2
+const PDF_RENDER_DENSITY = 2
 const NATIVE_PDF_MIN_RENDER_WIDTH = 1440
 const NATIVE_PDF_MAX_RENDER_WIDTH = 2400
+const READER_CONTENT_MAX_WIDTH = 720
 
 const route = useRoute()
 const router = useRouter()
@@ -147,9 +149,41 @@ let activeRenderRange: { start: number; end: number; center: number } | null = n
 let pendingSeekIndex: number | null = null
 let dragPreviewTimer: ReturnType<typeof setTimeout> | null = null
 let activeRenderCount = 0
+let renderTargetWidth = 0
+let renderResizeObserver: ResizeObserver | null = null
 
 const verticalViewRef = ref<InstanceType<typeof VerticalScrollView> | null>(null)
 const horizontalViewRef = ref<InstanceType<typeof HorizontalPageView> | null>(null)
+
+const getRenderContainer = (vertical = isVertical.value): HTMLElement | null => {
+  const view = (vertical ? verticalViewRef.value : horizontalViewRef.value) as {
+    $el?: Element | null
+  } | null
+  const element = view?.$el as HTMLElement | null | undefined
+  if (!element || typeof element.clientWidth !== 'number') return null
+  return element
+}
+
+const getReaderContentWidth = (vertical = isVertical.value): number => {
+  const measuredWidth = getRenderContainer(vertical)?.clientWidth ?? 0
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth || 360 : 360
+  const width = measuredWidth > 0 ? measuredWidth : viewportWidth
+  return Math.max(1, vertical ? Math.min(width, READER_CONTENT_MAX_WIDTH) : width)
+}
+
+const getRenderTargetWidth = (
+  vertical = isVertical.value,
+  useNativeRenderer = nativePdfMode,
+): number => {
+  const contentWidth = getReaderContentWidth(vertical)
+  if (!useNativeRenderer) return Math.max(1, Math.ceil(contentWidth * PDF_RENDER_DENSITY))
+
+  const pixelRatio = Math.max(typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1, 3)
+  return Math.min(
+    NATIVE_PDF_MAX_RENDER_WIDTH,
+    Math.max(NATIVE_PDF_MIN_RENDER_WIDTH, Math.ceil(contentWidth * pixelRatio)),
+  )
+}
 
 // ---- 工具栏 ----
 // 工具栏显示时仅恢复系统栏；阅读内容始终保持 edge-to-edge，不随系统栏改变尺寸。
@@ -225,6 +259,9 @@ const onDisplayModeChange = (vertical: boolean) => {
   syncReaderState()
   nextTick(() => {
     requestAnimationFrame(() => {
+      bindRenderResizeObserver()
+      const { increased } = updateRenderTargetWidth()
+      if (increased) invalidateActiveRenderWindow()
       goToIndex(targetIndex, 'mode')
     })
   })
@@ -302,10 +339,12 @@ const deactivateReaderRuntime = () => {
 }
 
 // ---- 渲染分辨率 ----
-const calcBaseScale = (viewport: pdfjsLib.PageViewport): number => {
-  const containerWidth = window.innerWidth
-  let scale = (containerWidth / viewport.width) * 2.0
-  const maxScale = (containerWidth * 2.5) / viewport.width
+const calcBaseScale = (
+  viewport: pdfjsLib.PageViewport,
+  contentWidth = getReaderContentWidth(),
+): number => {
+  let scale = (contentWidth / viewport.width) * PDF_RENDER_DENSITY
+  const maxScale = (contentWidth * 2.5) / viewport.width
   if (scale > maxScale) scale = maxScale
   return scale
 }
@@ -313,20 +352,20 @@ const calcBaseScale = (viewport: pdfjsLib.PageViewport): number => {
 // ---- PDF 页面渲染 ----
 const renderPageToBlob = async (pageNum: number): Promise<string | null> => {
   if (nativePdfMode) {
-    const pixelRatio = Math.max(window.devicePixelRatio || 1, 3)
-    const targetWidth = Math.min(
-      NATIVE_PDF_MAX_RENDER_WIDTH,
-      Math.max(NATIVE_PDF_MIN_RENDER_WIDTH, Math.ceil((window.innerWidth || 360) * pixelRatio)),
-    )
-    const result = await JmcomicService.renderPdfPage(filePath, pageNum, targetWidth)
-    return result.imageUrl
+    try {
+      const targetWidth = getRenderTargetWidth(isVertical.value, true)
+      const result = await JmcomicService.renderPdfPage(filePath, pageNum, targetWidth)
+      return result.imageUrl
+    } catch {
+      return null
+    }
   }
 
   if (!pdfDoc) return null
   let page: pdfjsLib.PDFPageProxy | null = null
   try {
     page = await pdfDoc.getPage(pageNum)
-    const scale = calcBaseScale(page.getViewport({ scale: 1 }))
+    const scale = calcBaseScale(page.getViewport({ scale: 1 }), getReaderContentWidth())
     const viewport = page.getViewport({ scale })
 
     const canvas = document.createElement('canvas')
@@ -525,6 +564,56 @@ const clampIndex = (index: number) => {
   return Math.min(totalCount.value - 1, Math.max(0, index))
 }
 
+const updateRenderTargetWidth = () => {
+  const next = getRenderTargetWidth()
+  const previous = renderTargetWidth
+  renderTargetWidth = next
+  return { previous, next, increased: previous > 0 && next > previous }
+}
+
+const getActiveRenderWindow = (center: number) => {
+  const windowOrders = new Set(calcWindow(center))
+  if (isVertical.value && activeRenderRange) {
+    for (let i = activeRenderRange.start; i < activeRenderRange.end; i++) {
+      if (i >= 0 && i < totalCount.value) windowOrders.add(i + 1)
+    }
+  }
+  return windowOrders
+}
+
+const invalidateActiveRenderWindow = () => {
+  const activePages = getActiveRenderWindow(currentIndex.value)
+  for (const pageNum of activePages) {
+    // 让已在途的旧 renderer 结果只能走过期分支，不能覆盖新的尺寸批次。
+    pageRenderGenerations.delete(pageNum)
+    pendingRenderPriorities.delete(pageNum)
+    pendingRenderQueue.delete(pageNum)
+
+    const url = renderedPages.get(pageNum)
+    if (url) releaseRenderedUrl(url)
+    renderedPages.delete(pageNum)
+    imageMap.value.delete(pageNum)
+  }
+  applyImageMap()
+}
+
+const bindRenderResizeObserver = () => {
+  renderResizeObserver?.disconnect()
+  renderResizeObserver = null
+
+  const element = getRenderContainer()
+  if (renderTargetWidth <= 0) renderTargetWidth = getRenderTargetWidth()
+  if (!element || typeof ResizeObserver === 'undefined') return
+
+  renderResizeObserver = new ResizeObserver(() => {
+    const { increased } = updateRenderTargetWidth()
+    if (!increased || (!pdfDoc && !nativePdfMode)) return
+    invalidateActiveRenderWindow()
+    updateWindow(currentIndex.value)
+  })
+  renderResizeObserver.observe(element)
+}
+
 const hasPendingInRange = (center: number, dir: 'forward' | 'backward'): boolean => {
   let checkStart: number, checkEnd: number
   if (dir === 'forward') {
@@ -543,12 +632,7 @@ const hasPendingInRange = (center: number, dir: 'forward' | 'backward'): boolean
 const updateWindow = (center: number) => {
   if (!pdfDoc && !nativePdfMode) return
   const generation = ++renderGeneration
-  const windowOrders = new Set(calcWindow(center))
-  if (activeRenderRange) {
-    for (let i = activeRenderRange.start; i < activeRenderRange.end; i++) {
-      if (i >= 0 && i < totalCount.value) windowOrders.add(i + 1)
-    }
-  }
+  const windowOrders = getActiveRenderWindow(center)
 
   // 清理窗口外页面
   const cleanBackward = expandDirection === 'backward' ? N_FAST : Math.floor(M / 2)
@@ -782,6 +866,7 @@ onMounted(async () => {
   }
 
   activateReaderRuntime()
+  bindRenderResizeObserver()
   activeRenderRange = null
   pendingSeekIndex = null
   if (dragPreviewTimer) {
@@ -792,6 +877,8 @@ onMounted(async () => {
   try {
     const total = await loadPdfDocument()
     if (total <= 0) throw new Error('PDF 页数异常')
+    // pdf.js 失败后可能切换到 native renderer；以实际 renderer 的限制重新建立基线。
+    renderTargetWidth = getRenderTargetWidth()
     const initialPage = ReadingProgressService.getInitialPage(
       route.query.page,
       albumId.value,
@@ -845,6 +932,8 @@ onDeactivated(() => {
 onUnmounted(() => {
   clearToolbarTapTimer()
   deactivateReaderRuntime()
+  renderResizeObserver?.disconnect()
+  renderResizeObserver = null
   if (revertTimer) clearTimeout(revertTimer)
   if (dragPreviewTimer) clearTimeout(dragPreviewTimer)
   cancelAllRenderTasks()

--- a/tests/unit/PdfReaderPage.test.ts
+++ b/tests/unit/PdfReaderPage.test.ts
@@ -1,0 +1,512 @@
+/* eslint-disable vue/one-component-per-file -- test-only reader fixtures */
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, onMounted, ref, type PropType } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+const mocks = vi.hoisted(() => ({
+  route: {
+    query: {
+      path: '/books/test.pdf',
+      title: '测试 PDF',
+      albumId: 'album-1',
+      chapterId: 'chapter-1',
+      page: '1',
+    } as Record<string, string>,
+  },
+  setRouteQuery: undefined as undefined | ((query: Record<string, string>) => void),
+  router: {
+    back: vi.fn(),
+    push: vi.fn(),
+  },
+  displayMode: 'vertical',
+  fetchPdfArrayBuffer: vi.fn(),
+  buildPdfDocumentParams: vi.fn(),
+  getDocument: vi.fn(),
+  getPdfInfo: vi.fn(),
+  renderPdfPage: vi.fn(),
+  createObjectURL: vi.fn(),
+  revokeObjectURL: vi.fn(),
+  showToast: vi.fn(),
+  addVolumeKeyListener: vi.fn(),
+  getAlbum: vi.fn(),
+  getInitialPage: vi.fn(),
+  recordProgress: vi.fn(),
+  recordBrowse: vi.fn(),
+}))
+
+const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL')
+const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL')
+
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue')
+  const route = reactive(mocks.route)
+  mocks.setRouteQuery = (query) => {
+    for (const key of Object.keys(route.query)) delete route.query[key]
+    Object.assign(route.query, query)
+  }
+  return {
+    useRoute: () => route,
+    useRouter: () => mocks.router,
+  }
+})
+
+vi.mock('@ionic/vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    IonPage: defineComponent({
+      name: 'IonPage',
+      setup(_, { slots }) {
+        return () => h('div', slots.default?.())
+      },
+    }),
+  }
+})
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: mocks.getDocument,
+}))
+
+vi.mock('@/services/PdfReaderService', () => ({
+  buildPdfDocumentParams: mocks.buildPdfDocumentParams,
+  fetchPdfArrayBuffer: mocks.fetchPdfArrayBuffer,
+  PdfLoadError: class PdfLoadError extends Error {},
+}))
+
+vi.mock('@/services/JmcomicService', () => ({
+  showToast: mocks.showToast,
+  JmcomicService: {
+    addVolumeKeyListener: mocks.addVolumeKeyListener,
+    getAlbum: mocks.getAlbum,
+    getPdfInfo: mocks.getPdfInfo,
+    renderPdfPage: mocks.renderPdfPage,
+    setReaderBrightness: vi.fn(() => Promise.resolve()),
+    setReaderFullscreen: vi.fn(() => Promise.resolve()),
+    setReaderKeepScreenOn: vi.fn(() => Promise.resolve()),
+    setReaderScreenOrientation: vi.fn(() => Promise.resolve()),
+    setReaderState: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock('@/services/SettingsService', () => ({
+  SettingsStore: {
+    getReaderDisplayMode: () => mocks.displayMode,
+    getReaderPreloadPages: () => 1,
+    getReaderScreenOrientation: () => 'auto',
+    getReaderBrightness: () => -1,
+    getReaderKeepScreenOn: () => false,
+  },
+}))
+
+vi.mock('@/services/HistoryService', () => ({
+  HistoryService: { recordBrowse: mocks.recordBrowse },
+}))
+
+vi.mock('@/services/ReadingProgressService', () => ({
+  ReadingProgressService: {
+    getInitialPage: mocks.getInitialPage,
+    record: mocks.recordProgress,
+  },
+}))
+
+type RenderCall = {
+  pageNum: number
+  canvas: HTMLCanvasElement
+}
+
+let renderCalls: RenderCall[] = []
+let pendingRenders: Array<Deferred<void>> = []
+let renderBehavior: 'resolved' | 'deferred' = 'resolved'
+let objectUrlIndex = 0
+let pdfDocument: ReturnType<typeof createPdfDocument>
+const viewWidths = { vertical: 400, horizontal: 900 }
+const mountedViews: { vertical: HTMLElement | null; horizontal: HTMLElement | null } = {
+  vertical: null,
+  horizontal: null,
+}
+
+function createPdfDocument(pageCount = 3) {
+  const pages = new Map<
+    number,
+    { getViewport: ReturnType<typeof vi.fn>; render: ReturnType<typeof vi.fn> }
+  >()
+  const document = {
+    numPages: pageCount,
+    getPage: vi.fn((pageNum: number) => {
+      let page = pages.get(pageNum)
+      if (!page) {
+        page = {
+          getViewport: vi.fn(({ scale }: { scale: number }) => ({
+            width: 600 * scale,
+            height: 800 * scale,
+          })),
+          render: vi.fn(({ canvas }: { canvas: HTMLCanvasElement }) => {
+            renderCalls.push({ pageNum, canvas })
+            const renderDeferred = deferred<void>()
+            pendingRenders.push(renderDeferred)
+            return {
+              promise: renderBehavior === 'deferred' ? renderDeferred.promise : Promise.resolve(),
+              cancel: vi.fn(),
+            }
+          }),
+        }
+        pages.set(pageNum, page)
+      }
+      return Promise.resolve({ ...page, cleanup: vi.fn() })
+    }),
+    destroy: vi.fn(() => Promise.resolve()),
+  }
+  return document
+}
+
+class ResizeObserverMock {
+  static active: ResizeObserverMock | null = null
+
+  private readonly callback: ResizeObserverCallback
+  disconnected = false
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    ResizeObserverMock.active = this
+  }
+
+  observe() {}
+
+  disconnect() {
+    this.disconnected = true
+    if (ResizeObserverMock.active === this) ResizeObserverMock.active = null
+  }
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver)
+  }
+}
+
+function setClientWidth(element: HTMLElement, width: number) {
+  Object.defineProperty(element, 'clientWidth', {
+    configurable: true,
+    value: width,
+  })
+}
+
+const VerticalViewStub = defineComponent({
+  name: 'VerticalScrollView',
+  props: {
+    imageMap: { type: Object as PropType<Map<number, string>>, required: true },
+    totalCount: { type: Number, required: true },
+    currentIndex: { type: Number, required: true },
+  },
+  emits: ['update:current-index', 'request-range'],
+  setup(_, { expose }) {
+    const elementRef = ref<HTMLElement | null>(null)
+    const scrollToIndex = vi.fn()
+    expose({ scrollToIndex })
+    onMounted(() => {
+      if (!elementRef.value) return
+      setClientWidth(elementRef.value, viewWidths.vertical)
+      mountedViews.vertical = elementRef.value
+    })
+    return () => h('div', { ref: elementRef, class: 'vertical-container-stub' })
+  },
+})
+
+const HorizontalViewStub = defineComponent({
+  name: 'HorizontalPageView',
+  props: {
+    imageMap: { type: Object as PropType<Map<number, string>>, required: true },
+    totalCount: { type: Number, required: true },
+    currentIndex: { type: Number, required: true },
+  },
+  emits: ['update:current-index', 'toggle-toolbar'],
+  setup(_, { expose }) {
+    const elementRef = ref<HTMLElement | null>(null)
+    const scrollToIndex = vi.fn()
+    expose({ scrollToIndex })
+    onMounted(() => {
+      if (!elementRef.value) return
+      setClientWidth(elementRef.value, viewWidths.horizontal)
+      mountedViews.horizontal = elementRef.value
+    })
+    return () => h('div', { ref: elementRef, class: 'horizontal-container-stub' })
+  },
+})
+
+const ReaderBottomToolbarStub = defineComponent({
+  name: 'ReaderBottomToolbar',
+  props: {
+    current: { type: Number, required: true },
+    total: { type: Number, required: true },
+  },
+  emits: [
+    'open-settings',
+    'update:current',
+    'update:current-input',
+    'progress-drag-start',
+    'progress-drag-end',
+  ],
+  setup() {
+    return () => h('div', { class: 'reader-bottom-toolbar-stub' })
+  },
+})
+
+const ReaderSettingsPanelStub = defineComponent({
+  name: 'ReaderSettingsPanel',
+  props: { isVertical: { type: Boolean, required: true } },
+  emits: ['close', 'update:display-mode'],
+  setup() {
+    return () => h('div', { class: 'reader-settings-panel-stub' })
+  },
+})
+
+const EmptyStub = defineComponent({
+  setup() {
+    return () => h('div')
+  },
+})
+
+import PdfReaderPage from '@/views/PdfReaderPage.vue'
+
+const mountPage = () =>
+  mount(PdfReaderPage, {
+    global: {
+      stubs: {
+        ReaderTopToolbar: EmptyStub,
+        ReaderBottomToolbar: ReaderBottomToolbarStub,
+        ReaderSettingsPanel: ReaderSettingsPanelStub,
+        VerticalScrollView: VerticalViewStub,
+        HorizontalPageView: HorizontalViewStub,
+      },
+    },
+  })
+
+async function settle() {
+  for (let i = 0; i < 8; i++) {
+    await flushPromises()
+    await nextTick()
+  }
+}
+
+function currentView(wrapper: ReturnType<typeof mountPage>) {
+  if (wrapper.findComponent(VerticalViewStub).exists()) {
+    return wrapper.findComponent(VerticalViewStub)
+  }
+  return wrapper.findComponent(HorizontalViewStub)
+}
+
+function triggerResize() {
+  ResizeObserverMock.active?.trigger()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.displayMode = 'vertical'
+  mocks.setRouteQuery?.({
+    path: '/books/test.pdf',
+    title: '测试 PDF',
+    albumId: 'album-1',
+    chapterId: 'chapter-1',
+    page: '1',
+  })
+  mocks.fetchPdfArrayBuffer.mockResolvedValue(new ArrayBuffer(8))
+  mocks.buildPdfDocumentParams.mockImplementation((data: ArrayBuffer) => ({ data }))
+  mocks.getPdfInfo.mockResolvedValue({ pageCount: 3 })
+  mocks.renderPdfPage.mockImplementation(
+    (_filePath: string, pageNum: number, targetWidth: number) =>
+      Promise.resolve({ imageUrl: `native:${pageNum}:${targetWidth}` }),
+  )
+  mocks.getAlbum.mockResolvedValue({ title: '测试专辑', image: '', authors: [] })
+  mocks.getInitialPage.mockImplementation((page: string | undefined) => Number(page) || 1)
+  mocks.addVolumeKeyListener.mockResolvedValue({ remove: vi.fn(() => Promise.resolve()) })
+  mocks.showToast.mockResolvedValue(undefined)
+
+  renderCalls = []
+  pendingRenders = []
+  renderBehavior = 'resolved'
+  objectUrlIndex = 0
+  pdfDocument = createPdfDocument()
+  mocks.getDocument.mockReturnValue({ promise: Promise.resolve(pdfDocument) })
+  mocks.createObjectURL.mockImplementation(() => `blob:${++objectUrlIndex}`)
+  mocks.revokeObjectURL.mockImplementation(() => {})
+
+  viewWidths.vertical = 400
+  viewWidths.horizontal = 900
+  mountedViews.vertical = null
+  mountedViews.horizontal = null
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    queueMicrotask(() => callback(performance.now()))
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: mocks.createObjectURL,
+  })
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: mocks.revokeObjectURL,
+  })
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((callback) => {
+    callback(new Blob(['rendered'], { type: 'image/png' }))
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  if (originalCreateObjectURL) {
+    Object.defineProperty(URL, 'createObjectURL', originalCreateObjectURL)
+  } else {
+    delete (URL as unknown as Record<string, unknown>).createObjectURL
+  }
+  if (originalRevokeObjectURL) {
+    Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL)
+  } else {
+    delete (URL as unknown as Record<string, unknown>).revokeObjectURL
+  }
+  ResizeObserverMock.active = null
+})
+
+describe('PdfReaderPage PDF 专属渲染尺寸', () => {
+  test('pdf.js 纵向渲染使用实际 720px 阅读轨道并保持 2 倍密度', async () => {
+    viewWidths.vertical = 1440
+    const wrapper = mountPage()
+    await settle()
+
+    expect(renderCalls.length).toBeGreaterThan(0)
+    expect(renderCalls.map(({ canvas }) => canvas.width)).toEqual(expect.arrayContaining([1440]))
+    expect(renderCalls.every(({ canvas }) => canvas.width === 1440)).toBe(true)
+    expect(mocks.renderPdfPage).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  test('pdf.js 横向渲染使用实际 reader 容器宽度', async () => {
+    mocks.displayMode = 'horizontal'
+    viewWidths.horizontal = 900
+    const wrapper = mountPage()
+    await settle()
+
+    expect(renderCalls.length).toBeGreaterThan(0)
+    expect(renderCalls.every(({ canvas }) => canvas.width === 1800)).toBe(true)
+    expect(wrapper.findComponent(HorizontalViewStub).props('currentIndex')).toBe(0)
+    wrapper.unmount()
+  })
+
+  test('pdf.js 失败后 native renderer 使用实际宽度并保留最大像素限制', async () => {
+    mocks.displayMode = 'horizontal'
+    viewWidths.horizontal = 1000
+    const loadFailure = deferred<never>()
+    mocks.getDocument.mockReturnValue({ promise: loadFailure.promise })
+    const wrapper = mountPage()
+    loadFailure.reject(new Error('unsupported'))
+    await settle()
+
+    expect(mocks.getPdfInfo).toHaveBeenCalledWith('/books/test.pdf')
+    expect(mocks.renderPdfPage).toHaveBeenCalled()
+    expect(mocks.renderPdfPage.mock.calls.every((call) => call[2] === 2400)).toBe(true)
+    expect(renderCalls).toHaveLength(0)
+    wrapper.unmount()
+  })
+
+  test('容器变窄不重渲染，变宽只失效并重渲染活动窗口', async () => {
+    pdfDocument = createPdfDocument(4)
+    mocks.getDocument.mockReturnValue({ promise: Promise.resolve(pdfDocument) })
+    viewWidths.vertical = 400
+    const wrapper = mountPage()
+    await settle()
+    const initialCount = renderCalls.length
+
+    setClientWidth(mountedViews.vertical!, 300)
+    triggerResize()
+    await settle()
+    expect(renderCalls).toHaveLength(initialCount)
+
+    wrapper.findComponent(ReaderBottomToolbarStub).vm.$emit('update:current', 4)
+    await settle()
+    wrapper.findComponent(ReaderBottomToolbarStub).vm.$emit('update:current', 2)
+    await settle()
+    const beforeWidening = renderCalls.length
+    const page4BeforeWidening = currentView(wrapper).props('imageMap').get(4)
+
+    setClientWidth(mountedViews.vertical!, 600)
+    triggerResize()
+    await settle()
+
+    expect(renderCalls.length - beforeWidening).toBe(3)
+    expect(renderCalls.slice(-3).map(({ pageNum }) => pageNum)).toEqual(
+      expect.arrayContaining([1, 2, 3]),
+    )
+    expect(currentView(wrapper).props('imageMap').get(4)).toBe(page4BeforeWidening)
+    expect(currentView(wrapper).props('currentIndex')).toBe(1)
+    wrapper.unmount()
+  })
+
+  test('尺寸批次变更后忽略过期 renderer 结果', async () => {
+    renderBehavior = 'deferred'
+    pdfDocument = createPdfDocument(1)
+    mocks.getDocument.mockReturnValue({ promise: Promise.resolve(pdfDocument) })
+    const wrapper = mountPage()
+    await settle()
+    expect(renderCalls).toHaveLength(1)
+    expect(pendingRenders).toHaveLength(1)
+
+    setClientWidth(mountedViews.vertical!, 600)
+    triggerResize()
+    await settle()
+    expect(currentView(wrapper).props('imageMap').has(1)).toBe(false)
+
+    pendingRenders[0].resolve()
+    await settle()
+    expect(renderCalls).toHaveLength(2)
+    expect(mocks.revokeObjectURL).toHaveBeenCalledWith('blob:1')
+
+    pendingRenders[1].resolve()
+    await settle()
+    expect(currentView(wrapper).props('imageMap').get(1)).toBe('blob:2')
+    wrapper.unmount()
+  })
+
+  test('模式切换保持当前页和进度，并在所需像素宽度上升时只重渲染活动窗口', async () => {
+    mocks.setRouteQuery?.({
+      path: '/books/test.pdf',
+      albumId: 'album-1',
+      chapterId: 'chapter-1',
+      page: '2',
+    })
+    viewWidths.vertical = 400
+    viewWidths.horizontal = 900
+    const wrapper = mountPage()
+    await settle()
+    const initialCount = renderCalls.length
+    expect(currentView(wrapper).props('currentIndex')).toBe(1)
+
+    wrapper.findComponent(ReaderBottomToolbarStub).vm.$emit('open-settings')
+    await nextTick()
+    wrapper.findComponent(ReaderSettingsPanelStub).vm.$emit('update:display-mode', false)
+    await settle()
+
+    expect(wrapper.findComponent(VerticalViewStub).exists()).toBe(false)
+    expect(wrapper.findComponent(HorizontalViewStub).props('currentIndex')).toBe(1)
+    expect(renderCalls.length - initialCount).toBe(3)
+    expect(renderCalls.slice(-3).every(({ canvas }) => canvas.width === 1800)).toBe(true)
+    expect(mocks.recordProgress).toHaveBeenLastCalledWith('album-1', 'chapter-1', 2, 3)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 变更

- PDF.js 纵向渲染按实际阅读轨道宽度 `min(containerWidth, 720px)` 计算，并保持 2 倍渲染密度；横向渲染按实际 reader 容器宽度计算。
- native renderer 沿用现有 `1440–2400px` fallback 限制。
- 监听当前 reader 容器尺寸；仅在所需像素宽度上升时失效并重渲染活动窗口，保留当前页、进度、滚动锚点和窗口外缓存。
- 通过 generation 忽略过期 pdf.js/native 任务结果；模式切换在新模式需要更高像素宽度时复用同一窗口失效逻辑。
- 新增 PDF 阅读页单测，覆盖两种 renderer、`ResizeObserver`、缩小不重渲染、过期任务和模式切换。

## 验证

- `npx vitest run tests/unit/PdfReaderPage.test.ts tests/unit/HorizontalPageView.test.ts tests/unit/VerticalScrollView.test.ts tests/unit/ReaderBottomToolbar.test.ts tests/unit/ReaderPage.test.ts`
- `NODE_OPTIONS=--localstorage-file=<临时文件> npm run test:unit`（50 个文件、294 个测试通过）
- `npm run lint`
- `npm run typecheck`
- `npm run build`

基于已合并的 ASTRA-26 / PR #117 共享 reader 基线。

Closes #95
