### PR TITLE
ASTRA-58: 修复详情页误报网络不可用

### DIFF
--- a/src/components/album/AlbumHeader.vue
+++ b/src/components/album/AlbumHeader.vue
@@ -44,9 +44,7 @@
               <div v-if="sourceMenuOpen" class="source-menu">
                 <button
                   type="button"
-                  class="source-btn source-network"
-                  :class="{ available: networkAvailable }"
-                  :disabled="!networkAvailable"
+                  class="source-btn source-network available"
                   aria-label="网络图片阅读"
                   @click="$emit('select-source', 'network')"
                 >
@@ -108,7 +106,6 @@ defineProps<{
   loading: boolean
   chapterLoading?: boolean
   sourceMenuOpen: boolean
-  networkAvailable: boolean
   imageAvailable: boolean
   pdfAvailable: boolean
 }>()

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -13,7 +13,6 @@
             :loading="loading"
             :chapter-loading="chapterLoading"
             :source-menu-open="sourceMenuOpen"
-            :network-available="networkAvailable"
             :image-available="selectedChapterHasDownload"
             :pdf-available="Boolean(selectedChapterPdf)"
             @back="goBack"
@@ -251,14 +250,9 @@ type ReaderSource = 'network' | 'download' | 'pdf'
 type PreviewSource = 'network' | 'download' | 'pdf'
 
 const sourceMenuOpen = ref(false)
-const networkAvailable = ref(typeof navigator === 'undefined' ? true : navigator.onLine)
 const previewLoadedKey = ref('')
 let previewPdfDoc: pdfjsLib.PDFDocumentProxy | null = null
 const previewObjectUrls = new Set<string>()
-
-const updateNetworkAvailable = () => {
-  networkAvailable.value = typeof navigator === 'undefined' ? true : navigator.onLine
-}
 
 const refreshDownloadStatuses = async () => {
   try {
@@ -680,10 +674,7 @@ const loadAlbumData = async (force = false) => {
 }
 
 onMounted(() => {
-  updateNetworkAvailable()
   setLeftMenuGestureEnabled(false)
-  window.addEventListener('online', updateNetworkAvailable)
-  window.addEventListener('offline', updateNetworkAvailable)
   loadAlbumData()
   nextTick(() => {
     setupTabSwipeGesture()
@@ -940,10 +931,6 @@ const openReaderBySource = (source: ReaderSource, page?: number) => {
   }
 
   if (source === 'download' && !selectedChapterHasDownload.value) return
-  if (source === 'network' && !networkAvailable.value) {
-    void showToast('当前网络不可用', 'medium')
-    return
-  }
 
   void router.push({
     path: `/album/${albumId.value}/read/${chapterId}`,
@@ -1319,8 +1306,6 @@ onUnmounted(() => {
   setLeftMenuGestureEnabled(true)
   invalidatePreviewRequest()
   downloadProgressHandle?.remove()
-  window.removeEventListener('online', updateNetworkAvailable)
-  window.removeEventListener('offline', updateNetworkAvailable)
 })
 
 const loadMorePreview = async () => {

--- a/tests/unit/AlbumDetailPage.test.ts
+++ b/tests/unit/AlbumDetailPage.test.ts
@@ -571,6 +571,31 @@ describe('AlbumDetailPage 章节路由定位', () => {
   })
 })
 
+describe('AlbumDetailPage 阅读入口', () => {
+  test('navigator.onLine 为 false 时主按钮和网络来源仍进入阅读路由', async () => {
+    const onLineSpy = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
+    const wrapper = await mountLoadedPage()
+
+    try {
+      const header = wrapper.findComponent({ name: 'AlbumHeader' })
+      header.vm.$emit('start-reading')
+      header.vm.$emit('select-source', 'network')
+      await nextTick()
+
+      const expectedRoute = {
+        path: '/album/123/read/chapter-1',
+        query: { title: '测试本子', total: '2' },
+      }
+      expect(mocks.router.push).toHaveBeenNthCalledWith(1, expectedRoute)
+      expect(mocks.router.push).toHaveBeenNthCalledWith(2, expectedRoute)
+      expect(mocks.showToast).not.toHaveBeenCalledWith('当前网络不可用', 'medium')
+    } finally {
+      wrapper.unmount()
+      onLineSpy.mockRestore()
+    }
+  })
+})
+
 describe('AlbumDetailPage 批量下载', () => {
   test('离开详情页后继续使用提交时的专辑上下文', async () => {
     const firstSubmit = deferred<{ taskId: string }>()

--- a/tests/unit/AlbumHeader.test.ts
+++ b/tests/unit/AlbumHeader.test.ts
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+import AlbumHeader from '@/components/album/AlbumHeader.vue'
+
+vi.mock('@ionic/vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    IonIcon: defineComponent({
+      name: 'IonIcon',
+      render: () => h('span'),
+    }),
+  }
+})
+
+vi.mock('ionicons/icons', () => ({
+  arrowBack: 'arrow-back',
+  documentOutline: 'document',
+  ellipsisVertical: 'ellipsis',
+  globeOutline: 'globe',
+  imageOutline: 'image',
+}))
+
+const baseProps = {
+  coverUrl: '',
+  title: '测试本子',
+  authors: '作者',
+  pageCount: 2,
+  loading: false,
+  sourceMenuOpen: true,
+  imageAvailable: false,
+  pdfAvailable: false,
+}
+
+describe('AlbumHeader 阅读来源', () => {
+  test('网络图片阅读始终可选择并发出网络来源事件', async () => {
+    const wrapper = mount(AlbumHeader, { props: baseProps })
+    const networkButton = wrapper.get('[aria-label="网络图片阅读"]')
+
+    expect((networkButton.element as HTMLButtonElement).disabled).toBe(false)
+    expect(networkButton.classes()).toContain('available')
+
+    await networkButton.trigger('click')
+
+    expect(wrapper.emitted('select-source')).toEqual([['network']])
+  })
+
+  test('下载和 PDF 按钮仍按本地资源状态控制', async () => {
+    const wrapper = mount(AlbumHeader, { props: baseProps })
+    const imageButton = wrapper.get('[aria-label="本地图片阅读"]')
+    const pdfButton = wrapper.get('[aria-label="PDF 阅读"]')
+
+    expect((imageButton.element as HTMLButtonElement).disabled).toBe(true)
+    expect((pdfButton.element as HTMLButtonElement).disabled).toBe(true)
+
+    await wrapper.setProps({ imageAvailable: true, pdfAvailable: true })
+    expect((imageButton.element as HTMLButtonElement).disabled).toBe(false)
+    expect((pdfButton.element as HTMLButtonElement).disabled).toBe(false)
+
+    await imageButton.trigger('click')
+    await pdfButton.trigger('click')
+
+    expect(wrapper.emitted('select-source')).toEqual([['download'], ['pdf']])
+  })
+})


### PR DESCRIPTION
## 变更

- 删除详情页基于 `navigator.onLine` 的网络阅读准入门禁、状态同步和 `online`/`offline` 监听。
- 网络图片阅读来源始终可选择；下载和 PDF 来源仍按本地资源状态控制。
- 增加离线标志下阅读入口和来源按钮的回归测试。

## 验证

- `npm run test:unit -- tests/unit/AlbumDetailPage.test.ts tests/unit/AlbumHeader.test.ts tests/unit/ReaderPage.test.ts`（33 个测试通过）
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Closes #128
Refs ASTRA-58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 网络图片阅读入口现始终可点击，不再因设备网络状态被禁用。
  * 即使处于离线状态，点击阅读入口仍可直接进入当前章节阅读页面。
  * 移除网络不可用提示，简化阅读操作流程。

* **测试**
  * 新增阅读入口及不同阅读来源的交互测试，覆盖按钮状态与导航行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->