### PR TITLE
ASTRA-70: 支持新建在线与本地收藏夹

### DIFF
--- a/src/components/favorite/FavoriteFolderPicker.vue
+++ b/src/components/favorite/FavoriteFolderPicker.vue
@@ -4,14 +4,6 @@
       <div class="picker-header">
         <span class="picker-title">选择收藏夹</span>
         <div class="picker-header-actions">
-          <button
-            type="button"
-            class="picker-add-btn"
-            aria-label="新建收藏夹"
-            @click="$emit('add-folder')"
-          >
-            <IonIcon :icon="addOutline" />
-          </button>
           <button type="button" class="picker-close-btn" @click="close">
             <IonIcon :icon="closeOutline" />
           </button>
@@ -19,8 +11,18 @@
       </div>
 
       <div class="picker-body">
-        <template v-if="!hideOnline && onlineFolders.length > 0">
-          <div class="section-title">在线收藏夹</div>
+        <template v-if="!hideOnline">
+          <div class="section-header">
+            <span class="section-title">在线收藏夹</span>
+            <button
+              type="button"
+              class="section-add-btn"
+              aria-label="新建在线收藏夹"
+              @click="emit('add-folder', 'online')"
+            >
+              <IonIcon :icon="addCircleOutline" />
+            </button>
+          </div>
           <div class="folder-list">
             <button
               v-for="folder in onlineFolders"
@@ -38,7 +40,17 @@
           </div>
         </template>
 
-        <div class="section-title">离线收藏夹</div>
+        <div class="section-header">
+          <span class="section-title">离线收藏夹</span>
+          <button
+            type="button"
+            class="section-add-btn"
+            aria-label="新建离线收藏夹"
+            @click="emit('add-folder', 'offline')"
+          >
+            <IonIcon :icon="addCircleOutline" />
+          </button>
+        </div>
         <div class="folder-list">
           <button
             v-for="folder in offlineFolders"
@@ -53,8 +65,15 @@
           </button>
         </div>
 
-        <div v-if="onlineFolders.length === 0 && offlineFolders.length === 0" class="empty-state">
-          暂无收藏夹，请点击 + 创建
+        <div
+          v-if="
+            hideOnline
+              ? offlineFolders.length === 0
+              : onlineFolders.length === 0 && offlineFolders.length === 0
+          "
+          class="empty-state"
+        >
+          暂无收藏夹
         </div>
       </div>
     </div>
@@ -62,6 +81,10 @@
 </template>
 
 <script setup lang="ts">
+import { IonIcon } from '@ionic/vue'
+import { addCircleOutline, closeOutline, folderOpenOutline } from 'ionicons/icons'
+import type { FolderEntry } from '@/services/JmcomicTypes'
+
 defineOptions({ name: 'FavoriteFolderPicker' })
 
 defineProps<{
@@ -73,12 +96,9 @@ defineProps<{
 }>()
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
-  'add-folder': []
+  'add-folder': [source: 'online' | 'offline']
   select: [payload: { folderId: string; source: 'online' | 'offline' }]
 }>()
-import { IonIcon } from '@ionic/vue'
-import { addOutline, closeOutline, folderOpenOutline } from 'ionicons/icons'
-import type { FolderEntry } from '@/services/JmcomicTypes'
 
 const close = () => {
   emit('update:modelValue', false)
@@ -134,7 +154,6 @@ const select = (folderId: string, source: 'online' | 'offline') => {
   gap: 8px;
 }
 
-.picker-add-btn,
 .picker-close-btn {
   display: inline-flex;
   align-items: center;
@@ -150,20 +169,21 @@ const select = (folderId: string, source: 'online' | 'offline') => {
   cursor: pointer;
 }
 
-.picker-add-btn:active,
-.picker-close-btn:active {
-  transform: scale(0.94);
-}
-
 .picker-body {
   flex: 1;
   overflow-y: auto;
   padding: 14px 16px 18px;
 }
 
-.section-title {
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 10px;
-  margin-top: 8px;
+  margin-top: 10px;
+}
+
+.section-title {
   color: #7a5743;
   font-size: 11px;
   font-weight: 700;
@@ -171,8 +191,25 @@ const select = (folderId: string, source: 'online' | 'offline') => {
   text-transform: uppercase;
 }
 
-.section-title + .section-title {
-  margin-top: 20px;
+.section-add-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #c96d3a;
+  font-size: 18px;
+  cursor: pointer;
+  transition: transform 0.12s ease;
+}
+
+.section-add-btn:active {
+  transform: scale(0.8);
+  background: #ffece0;
+  box-shadow: 0 2px 8px rgb(115 67 38 / 0.2);
 }
 
 .folder-list {
@@ -238,5 +275,12 @@ const select = (folderId: string, source: 'online' | 'offline') => {
   min-height: 80px;
   color: #9e7d6a;
   font-size: 13px;
+}
+
+.picker-close-btn:focus-visible,
+.section-add-btn:focus-visible,
+.folder-item:focus-visible {
+  outline: 3px solid rgb(201 109 58 / 0.45);
+  outline-offset: 2px;
 }
 </style>

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -119,6 +119,7 @@
       :online-folders="pickerOnlineFolders"
       :offline-folders="pickerOfflineFolders"
       :online-folder-counts="onlineFolderCounts"
+      :hide-online="!isLoggedIn"
       @select="onPickerSelect"
       @add-folder="onPickerAddFolder"
     />
@@ -376,7 +377,7 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
   }
 }
 
-async function onPickerAddFolder() {
+async function onPickerAddFolder(source: 'online' | 'offline') {
   const alert = await createAppAlert({
     header: '新建收藏夹',
     inputs: [{ name: 'name', type: 'text', placeholder: '收藏夹名称' }],
@@ -388,7 +389,7 @@ async function onPickerAddFolder() {
           const name = data?.name?.trim()
           if (!name) return
 
-          if (isLoggedIn.value) {
+          if (source === 'online') {
             try {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {
@@ -423,7 +424,7 @@ async function onPickerAddFolder() {
               /* ignore */
             }
           } else {
-            OfflineFavoriteService.createFolder(name)
+            await OfflineFavoriteService.createFolder(name)
             pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
             await showToast('收藏夹已创建', 'success')
           }

--- a/src/views/BatchParsePage.vue
+++ b/src/views/BatchParsePage.vue
@@ -204,6 +204,7 @@
       :online-folders="pickerOnlineFolders"
       :offline-folders="pickerOfflineFolders"
       :online-folder-counts="pickerOnlineFolderCounts"
+      :hide-online="!isLoggedIn"
       @select="onPickerSelect"
       @add-folder="onPickerAddFolder"
     />
@@ -1111,7 +1112,7 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
   }
 }
 
-async function onPickerAddFolder() {
+async function onPickerAddFolder(source: 'online' | 'offline') {
   const alert = await createAppAlert({
     header: '新建收藏夹',
     inputs: [{ name: 'name', type: 'text', placeholder: '收藏夹名称' }],
@@ -1123,7 +1124,7 @@ async function onPickerAddFolder() {
           const name = data?.name?.trim()
           if (!name) return
 
-          if (isLoggedIn.value) {
+          if (source === 'online') {
             try {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {

--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -69,6 +69,7 @@
         :online-folders="pickerOnlineFolders"
         :offline-folders="pickerOfflineFolders"
         :online-folder-counts="pickerOnlineFolderCounts"
+        :hide-online="!isLoggedIn"
         @select="onPickerSelect"
         @add-folder="onPickerAddFolder"
       />
@@ -544,7 +545,7 @@ async function executeFavorite(
   }
 }
 
-async function onPickerAddFolder() {
+async function onPickerAddFolder(source: 'online' | 'offline') {
   const alert = await createAppAlert({
     header: '新建收藏夹',
     inputs: [{ name: 'name', type: 'text', placeholder: '收藏夹名称' }],
@@ -556,7 +557,7 @@ async function onPickerAddFolder() {
           const name = data?.name?.trim()
           if (!name) return
 
-          if (isLoggedIn.value) {
+          if (source === 'online') {
             try {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -75,6 +75,7 @@
         :online-folders="pickerOnlineFolders"
         :offline-folders="pickerOfflineFolders"
         :online-folder-counts="pickerOnlineFolderCounts"
+        :hide-online="!isLoggedIn"
         @select="onPickerSelect"
         @add-folder="onPickerAddFolder"
       />
@@ -645,7 +646,7 @@ async function executeFavorite(
   }
 }
 
-async function onPickerAddFolder() {
+async function onPickerAddFolder(source: 'online' | 'offline') {
   const alert = await createAppAlert({
     header: '新建收藏夹',
     inputs: [{ name: 'name', type: 'text', placeholder: '收藏夹名称' }],
@@ -657,7 +658,7 @@ async function onPickerAddFolder() {
           const name = data?.name?.trim()
           if (!name) return
 
-          if (isLoggedIn.value) {
+          if (source === 'online') {
             try {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {

--- a/tests/unit/FavoriteFolderPicker.test.ts
+++ b/tests/unit/FavoriteFolderPicker.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable vue/one-component-per-file -- test-only Ionic fixture */
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('@ionic/vue', () => ({
+  IonIcon: defineComponent({
+    name: 'IonIcon',
+    setup: () => () => h('span'),
+  }),
+}))
+
+vi.mock('ionicons/icons', () => ({
+  addCircleOutline: 'add-circle',
+  closeOutline: 'close',
+  folderOpenOutline: 'folder',
+}))
+
+import FavoriteFolderPicker from '@/components/favorite/FavoriteFolderPicker.vue'
+
+const baseProps = {
+  modelValue: true,
+  onlineFolders: [{ id: 'online-1', name: '在线收藏夹', count: 0 }],
+  offlineFolders: [{ id: 'offline-1', name: '离线收藏夹', count: 2 }],
+  onlineFolderCounts: { 'online-1': 4 },
+}
+
+describe('FavoriteFolderPicker 新建入口', () => {
+  test('在线和离线按钮分别发出对应来源', async () => {
+    const wrapper = mount(FavoriteFolderPicker, { props: baseProps })
+
+    const addButtons = wrapper.findAll('.section-add-btn')
+    expect(addButtons).toHaveLength(2)
+    expect(addButtons[0].element.parentElement?.textContent).toContain('在线收藏夹')
+    expect(addButtons[0].element.parentElement?.lastElementChild).toBe(addButtons[0].element)
+    expect(addButtons[1].element.parentElement?.textContent).toContain('离线收藏夹')
+    expect(addButtons[1].element.parentElement?.lastElementChild).toBe(addButtons[1].element)
+
+    await addButtons[0].trigger('click')
+    await addButtons[1].trigger('click')
+
+    expect(wrapper.emitted('add-folder')).toEqual([['online'], ['offline']])
+  })
+
+  test('隐藏在线入口时只显示离线新建按钮', () => {
+    const wrapper = mount(FavoriteFolderPicker, {
+      props: { ...baseProps, hideOnline: true },
+    })
+
+    expect(wrapper.find('[aria-label="新建在线收藏夹"]').exists()).toBe(false)
+    expect(wrapper.find('[aria-label="新建离线收藏夹"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('在线收藏夹')
+  })
+
+  test('列表为空时仍保留可用的新建入口', () => {
+    const wrapper = mount(FavoriteFolderPicker, {
+      props: {
+        ...baseProps,
+        onlineFolders: [],
+        offlineFolders: [],
+      },
+    })
+
+    expect(wrapper.find('[aria-label="新建在线收藏夹"]').exists()).toBe(true)
+    expect(wrapper.find('[aria-label="新建离线收藏夹"]').exists()).toBe(true)
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## 变更

- 将收藏夹选择器的新建入口拆分到“在线收藏夹”和“离线收藏夹”分区标题右侧，复用现有侧栏按钮风格，并由事件显式携带收藏夹来源。
- 详情、搜索、分类和批量解析页按用户选择的来源创建收藏夹；未登录时隐藏在线入口，PDF 导入继续仅提供离线入口。
- 创建成功后刷新对应分区并保留当前收藏流程；离线创建完成后再读取缓存，避免新收藏夹未及时出现。
- 新增选择器单元测试，覆盖来源事件、在线入口隐藏和空列表新建入口。

## 验证

- `npx vitest run tests/unit/FavoriteFolderPicker.test.ts tests/unit/AlbumDetailPage.test.ts tests/unit/SearchPage.test.ts tests/unit/CategoryPage.test.ts tests/unit/BatchParsePage.test.ts`（5 个测试文件、38 个测试通过）
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`

## 限制

- 全量 Vitest 在当前 Node 26/jsdom 环境中仍有 23 个既有测试因 `localStorage` 未定义而失败；本次相关测试均通过。

Closes #133
Refs ASTRA-70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 收藏夹选择弹窗按在线、离线分区展示，并分别提供“新建收藏夹”入口。
  * 新建操作会根据所选分区创建在线或离线收藏夹。
  * 未登录时隐藏在线收藏夹分区。
* **界面优化**
  * 空列表仍保留对应分区及新建入口，空状态提示调整为“暂无收藏夹”。
  * 更新新增按钮图标与焦点可见样式。
* **测试**
  * 增加在线/离线新建入口、隐藏在线分区及空列表场景的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->