### PR TITLE
ASTRA-71: 改善收藏夹刷新体验

### DIFF
--- a/src/components/favorite/FavoriteFolderPicker.vue
+++ b/src/components/favorite/FavoriteFolderPicker.vue
@@ -2,7 +2,15 @@
   <div v-if="modelValue" class="picker-backdrop" @click.self="close">
     <div class="picker-panel">
       <div class="picker-header">
-        <span class="picker-title">选择收藏夹</span>
+        <div class="picker-title">
+          <span>选择收藏夹</span>
+          <IonSpinner
+            v-if="!hideOnline && (onlineRefreshing || onlineLoading)"
+            name="circular"
+            class="folder-loading-spinner"
+            aria-label="正在更新收藏夹"
+          />
+        </div>
         <div class="picker-header-actions">
           <button type="button" class="picker-close-btn" @click="close">
             <IonIcon :icon="closeOutline" />
@@ -23,7 +31,23 @@
               <IonIcon :icon="addCircleOutline" />
             </button>
           </div>
-          <div class="folder-list">
+          <div
+            v-if="onlineLoading && !hasOnlineData"
+            class="folder-status loading-state"
+            role="status"
+          >
+            <IonSpinner name="dots" aria-hidden="true" />
+            <span>正在加载收藏夹</span>
+          </div>
+          <div
+            v-else-if="onlineErrorMessage && !hasOnlineData"
+            class="folder-status error-state"
+            role="alert"
+          >
+            <span>{{ onlineErrorMessage }}</span>
+            <button type="button" class="retry-btn" @click="emit('retry-online')">重试</button>
+          </div>
+          <div v-else class="folder-list">
             <button
               v-for="folder in onlineFolders"
               :key="'online-' + folder.id"
@@ -37,6 +61,10 @@
                 {{ onlineFolderCounts[folder.id] }}
               </span>
             </button>
+          </div>
+          <div v-if="onlineErrorMessage && hasOnlineData" class="refresh-error" role="status">
+            <span>更新失败，正在显示上次结果：{{ onlineErrorMessage }}</span>
+            <button type="button" class="retry-btn" @click="emit('retry-online')">重试</button>
           </div>
         </template>
 
@@ -67,9 +95,11 @@
 
         <div
           v-if="
-            hideOnline
-              ? offlineFolders.length === 0
-              : onlineFolders.length === 0 && offlineFolders.length === 0
+            !onlineLoading &&
+            !onlineErrorMessage &&
+            (hideOnline || hasOnlineData) &&
+            (hideOnline ? offlineFolders.length === 0 : onlineFolders.length === 0) &&
+            offlineFolders.length === 0
           "
           class="empty-state"
         >
@@ -81,24 +111,43 @@
 </template>
 
 <script setup lang="ts">
-import { IonIcon } from '@ionic/vue'
+import { computed } from 'vue'
+import { IonIcon, IonSpinner } from '@ionic/vue'
 import { addCircleOutline, closeOutline, folderOpenOutline } from 'ionicons/icons'
 import type { FolderEntry } from '@/services/JmcomicTypes'
 
 defineOptions({ name: 'FavoriteFolderPicker' })
 
-defineProps<{
-  modelValue: boolean
-  onlineFolders: FolderEntry[]
-  offlineFolders: FolderEntry[]
-  onlineFolderCounts: Record<string, number>
-  hideOnline?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    onlineFolders: FolderEntry[]
+    offlineFolders: FolderEntry[]
+    onlineFolderCounts: Record<string, number>
+    hideOnline?: boolean
+    onlineHasSuccessfulData?: boolean
+    onlineLoading?: boolean
+    onlineRefreshing?: boolean
+    onlineErrorMessage?: string
+  }>(),
+  {
+    hideOnline: false,
+    onlineHasSuccessfulData: undefined,
+    onlineLoading: false,
+    onlineRefreshing: false,
+    onlineErrorMessage: '',
+  },
+)
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
   'add-folder': [source: 'online' | 'offline']
+  'retry-online': []
   select: [payload: { folderId: string; source: 'online' | 'offline' }]
 }>()
+
+const hasOnlineData = computed(
+  () => props.onlineHasSuccessfulData ?? (!props.onlineLoading && !props.onlineErrorMessage),
+)
 
 const close = () => {
   emit('update:modelValue', false)
@@ -143,9 +192,20 @@ const select = (folderId: string, source: 'online' | 'offline') => {
 }
 
 .picker-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-size: 18px;
   font-weight: 700;
   color: #3a261d;
+}
+
+.folder-loading-spinner {
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
+  margin-left: 8px;
+  color: #e8843c;
 }
 
 .picker-header-actions {
@@ -218,6 +278,41 @@ const select = (folderId: string, source: 'online' | 'offline') => {
   gap: 6px;
 }
 
+.folder-status,
+.refresh-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 56px;
+  color: #9e7d6a;
+  font-size: 13px;
+}
+
+.error-state {
+  flex-direction: column;
+  color: #a6543c;
+}
+
+.refresh-error {
+  justify-content: flex-start;
+  min-height: 36px;
+  padding: 4px 8px 0;
+  color: #a6543c;
+  font-size: 12px;
+}
+
+.retry-btn {
+  border: 0;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: #fff0e7;
+  color: #b55e32;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 .folder-item {
   display: flex;
   align-items: center;
@@ -279,7 +374,8 @@ const select = (folderId: string, source: 'online' | 'offline') => {
 
 .picker-close-btn:focus-visible,
 .section-add-btn:focus-visible,
-.folder-item:focus-visible {
+.folder-item:focus-visible,
+.retry-btn:focus-visible {
   outline: 3px solid rgb(201 109 58 / 0.45);
   outline-offset: 2px;
 }

--- a/src/components/favorite/FavoriteSideMenu.vue
+++ b/src/components/favorite/FavoriteSideMenu.vue
@@ -17,63 +17,96 @@
       :style="panelStyle"
     >
       <div class="menu-header">
-        <div class="menu-title">收藏夹</div>
+        <div class="menu-title">
+          <span>收藏夹</span>
+          <IonSpinner
+            v-if="onlineRefreshing || onlineLoading"
+            name="circular"
+            class="folder-loading-spinner"
+            aria-label="正在更新收藏夹"
+          />
+        </div>
         <button type="button" class="menu-close-btn" aria-label="关闭收藏夹" @click="closeMenu">
           <IonIcon :icon="closeOutline" />
         </button>
       </div>
 
       <div class="menu-body">
-        <template v-if="onlineFolders.length > 0">
-          <div class="section-header">
-            <span class="section-title">在线收藏夹</span>
+        <div class="section-header">
+          <span class="section-title">在线收藏夹</span>
+          <button
+            type="button"
+            class="section-add-btn"
+            aria-label="新建在线收藏夹"
+            @click="emit('add-folder', 'online')"
+          >
+            <IonIcon :icon="addCircleOutline" />
+          </button>
+        </div>
+
+        <div
+          v-if="onlineLoading && !hasOnlineData"
+          class="folder-status loading-state"
+          role="status"
+        >
+          <IonSpinner name="dots" aria-hidden="true" />
+          <span>正在加载收藏夹</span>
+        </div>
+        <div
+          v-else-if="onlineErrorMessage && !hasOnlineData"
+          class="folder-status error-state"
+          role="alert"
+        >
+          <span>{{ onlineErrorMessage }}</span>
+          <button type="button" class="retry-btn" @click="emit('retry-online')">重试</button>
+        </div>
+        <div v-else-if="onlineFolders.length > 0" class="folder-list">
+          <div
+            v-for="folder in onlineFolders"
+            :key="folder.id"
+            class="folder-item-wrapper"
+            :style="{ position: 'relative' }"
+          >
             <button
               type="button"
-              class="section-add-btn"
-              aria-label="新建在线收藏夹"
-              @click="emit('add-folder', 'online')"
+              class="folder-item"
+              :class="{ selected: selectedOnlineId === folder.id }"
+              @click="selectOnlineFolder(folder.id)"
             >
-              <IonIcon :icon="addCircleOutline" />
+              <IonIcon :icon="folderOpenOutline" class="folder-icon" />
+              <span class="folder-name">{{ folder.name }}</span>
+              <span v-if="onlineFolderCounts[folder.id] !== undefined" class="folder-count">
+                {{ onlineFolderCounts[folder.id] }}
+              </span>
+            </button>
+            <button
+              type="button"
+              class="folder-more-btn"
+              :class="{ active: isContextMenuOpen(folder.id, true) }"
+              aria-label="更多操作"
+              :aria-expanded="isContextMenuOpen(folder.id, true)"
+              @click.stop="toggleContextMenu(folder, true, $event)"
+            >
+              <IonIcon :icon="ellipsisVertical" />
             </button>
           </div>
-          <div class="folder-list">
-            <div
-              v-for="folder in onlineFolders"
-              :key="folder.id"
-              class="folder-item-wrapper"
-              :style="{ position: 'relative' }"
-            >
-              <button
-                type="button"
-                class="folder-item"
-                :class="{ selected: selectedOnlineId === folder.id }"
-                @click="selectOnlineFolder(folder.id)"
-              >
-                <IonIcon :icon="folderOpenOutline" class="folder-icon" />
-                <span class="folder-name">{{ folder.name }}</span>
-                <span v-if="onlineFolderCounts[folder.id] !== undefined" class="folder-count">
-                  {{ onlineFolderCounts[folder.id] }}
-                </span>
-              </button>
-              <button
-                type="button"
-                class="folder-more-btn"
-                :class="{ active: isContextMenuOpen(folder.id, true) }"
-                aria-label="更多操作"
-                :aria-expanded="isContextMenuOpen(folder.id, true)"
-                @click.stop="toggleContextMenu(folder, true, $event)"
-              >
-                <IonIcon :icon="ellipsisVertical" />
-              </button>
-            </div>
-          </div>
-        </template>
+        </div>
 
-        <template v-if="onlineFolders.length > 0">
-          <div style="margin-top: 24px" />
-        </template>
+        <div v-if="onlineErrorMessage && hasOnlineData" class="refresh-error" role="status">
+          <span>更新失败，正在显示上次结果：{{ onlineErrorMessage }}</span>
+          <button type="button" class="retry-btn" @click="emit('retry-online')">重试</button>
+        </div>
 
-        <div v-if="onlineFolders.length === 0 && offlineFolders.length === 0" class="empty-state">
+        <div
+          v-if="
+            !onlineLoading &&
+            !onlineErrorMessage &&
+            hasOnlineData &&
+            onlineFolders.length === 0 &&
+            offlineFolders.length === 0
+          "
+          class="empty-state"
+        >
           暂无收藏夹
         </div>
 
@@ -131,7 +164,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { IonIcon } from '@ionic/vue'
+import { IonIcon, IonSpinner } from '@ionic/vue'
 import {
   addCircleOutline,
   closeOutline,
@@ -162,10 +195,18 @@ const props = withDefaults(
     selectedOnlineId: string
     selectedOfflineId: string
     onlineFolderCounts: Record<string, number>
+    onlineHasSuccessfulData?: boolean
+    onlineLoading?: boolean
+    onlineRefreshing?: boolean
+    onlineErrorMessage?: string
   }>(),
   {
     displayMode: 'overlay',
     paneOpen: false,
+    onlineHasSuccessfulData: undefined,
+    onlineLoading: false,
+    onlineRefreshing: false,
+    onlineErrorMessage: '',
   },
 )
 
@@ -175,12 +216,17 @@ const emit = defineEmits<{
   'select-online-folder': [folderId: string]
   'select-offline-folder': [folderId: string]
   'add-folder': [source: 'online' | 'offline']
+  'retry-online': []
   'rename-folder': [payload: { folderId: string; folderName: string; isOnline: boolean }]
   'delete-folder': [payload: { folderId: string; folderName: string; isOnline: boolean }]
   'move-folder': [payload: { folderId: string; folderName: string; isOnline: boolean }]
   'copy-folder': [payload: { folderId: string; folderName: string; isOnline: boolean }]
   'export-folder': [payload: { folderId: string; folderName: string; isOnline: boolean }]
 }>()
+
+const hasOnlineData = computed(
+  () => props.onlineHasSuccessfulData ?? (!props.onlineLoading && !props.onlineErrorMessage),
+)
 
 const { isDraggingRight, isSnappingClosed, rightDragProgress } = useSideMenuState()
 
@@ -379,9 +425,20 @@ defineExpose({ panelRef })
 }
 
 .menu-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-size: 18px;
   font-weight: 700;
   color: #3a261d;
+}
+
+.folder-loading-spinner {
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
+  margin-left: 8px;
+  color: #e8843c;
 }
 
 .menu-close-btn {
@@ -446,6 +503,41 @@ defineExpose({ panelRef })
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.folder-status,
+.refresh-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 56px;
+  color: #9e7d6a;
+  font-size: 13px;
+}
+
+.error-state {
+  flex-direction: column;
+  color: #a6543c;
+}
+
+.refresh-error {
+  justify-content: flex-start;
+  min-height: 36px;
+  padding: 4px 8px 0;
+  color: #a6543c;
+  font-size: 12px;
+}
+
+.retry-btn {
+  border: 0;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: #fff0e7;
+  color: #b55e32;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
 }
 
 .folder-item-wrapper {
@@ -544,7 +636,8 @@ defineExpose({ panelRef })
 .menu-close-btn:focus-visible,
 .section-add-btn:focus-visible,
 .folder-item:focus-visible,
-.folder-more-btn:focus-visible {
+.folder-more-btn:focus-visible,
+.retry-btn:focus-visible {
   outline: 3px solid rgb(201 109 58 / 0.45);
   outline-offset: 2px;
 }

--- a/src/components/search/SearchResultContainer.vue
+++ b/src/components/search/SearchResultContainer.vue
@@ -88,6 +88,7 @@
               itemCardClass,
               { downloaded: downloadedAlbumIds?.has(entry.item.id) },
               { 'entry-highlighted': activeEntryKey === getEntryKey(entry) },
+              { 'entry-removing': removingIds?.has(entry.item.id) },
               favBorderClassMap?.[entry.item.id],
             ]"
             @click="emit('item-click', entry.item)"
@@ -163,6 +164,7 @@ const props = withDefaults(
     loadedPageEnd?: number | null
     downloadedAlbumIds?: Set<string>
     favBorderClassMap?: Record<string, string>
+    removingIds?: Set<string>
     activeEntryKey?: string | null
     idleText?: string
     emptyText?: string
@@ -177,6 +179,7 @@ const props = withDefaults(
     loadedPageEnd: null,
     downloadedAlbumIds: () => new Set(),
     favBorderClassMap: () => ({}),
+    removingIds: () => new Set(),
     activeEntryKey: null,
     idleText: '搜索结果将在这里显示',
     emptyText: '没有搜索结果',
@@ -631,6 +634,22 @@ defineExpose<SearchResultContainerExposed>({
 .list-card.downloaded,
 .grid-card.downloaded {
   background: #f0faf3;
+}
+
+.list-card.entry-removing,
+.grid-card.entry-removing {
+  opacity: 0;
+  transform: scale(0.82);
+  transition:
+    opacity 0.26s ease,
+    transform 0.26s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .list-card.entry-removing,
+  .grid-card.entry-removing {
+    transition: none;
+  }
 }
 
 .cover-wrap {

--- a/src/composables/favoriteFolderStore.ts
+++ b/src/composables/favoriteFolderStore.ts
@@ -90,7 +90,13 @@ const refreshCounts = async (accountId: string, generation: number) => {
           folder.id === folderId ? { ...folder, count: result.totalItems } : folder,
         )
       } catch {
-        // A count is supplementary data. Keep its previous value, or leave it undefined.
+        if (!isCurrentRequest(accountId, generation)) return
+        const nextCounts = { ...state.counts }
+        delete nextCounts[folderId]
+        state.counts = nextCounts
+        state.folders = state.folders.map((folder) =>
+          folder.id === folderId ? { ...folder, count: 0 } : folder,
+        )
       }
     }),
   )

--- a/src/composables/favoriteFolderStore.ts
+++ b/src/composables/favoriteFolderStore.ts
@@ -1,0 +1,185 @@
+import { computed, reactive } from 'vue'
+import type { FolderEntry } from '@/services/JmcomicTypes'
+import { JmcomicService, sanitizeError } from '@/services/JmcomicService'
+
+export interface FavoriteFolderStoreState {
+  accountId: string | null
+  folders: FolderEntry[]
+  counts: Record<string, number>
+  hasSuccessfulData: boolean
+  isFetching: boolean
+  errorMessage: string
+}
+
+const state = reactive<FavoriteFolderStoreState>({
+  accountId: null,
+  folders: [],
+  counts: {},
+  hasSuccessfulData: false,
+  isFetching: false,
+  errorMessage: '',
+})
+
+let requestGeneration = 0
+let activeRequest: {
+  accountId: string
+  generation: number
+  promise: Promise<void>
+} | null = null
+
+const isCurrentRequest = (accountId: string, generation: number) =>
+  state.accountId === accountId && requestGeneration === generation
+
+const resetState = (accountId: string | null) => {
+  requestGeneration += 1
+  activeRequest = null
+  state.accountId = accountId
+  state.folders = []
+  state.counts = {}
+  state.hasSuccessfulData = false
+  state.isFetching = false
+  state.errorMessage = ''
+}
+
+const ensureAccount = (accountId: string) => {
+  if (state.accountId === accountId) return
+  resetState(accountId)
+}
+
+const folderEntriesFromMap = (
+  folderMap: Record<string, string>,
+  counts: Record<string, number>,
+): FolderEntry[] =>
+  Object.entries(folderMap).map(([id, name]) => ({
+    id,
+    name,
+    count: counts[id] ?? 0,
+  }))
+
+const retainKnownCounts = (folderMap: Record<string, string>) => {
+  const counts: Record<string, number> = {}
+  for (const id of Object.keys(folderMap)) {
+    const count = state.counts[id]
+    if (count !== undefined) counts[id] = count
+  }
+  return counts
+}
+
+const applyFolderMap = (
+  accountId: string,
+  generation: number,
+  folderMap: Record<string, string>,
+) => {
+  if (!isCurrentRequest(accountId, generation)) return false
+  state.counts = retainKnownCounts(folderMap)
+  state.folders = folderEntriesFromMap(folderMap, state.counts)
+  state.hasSuccessfulData = true
+  state.errorMessage = ''
+  return true
+}
+
+const refreshCounts = async (accountId: string, generation: number) => {
+  const folderIds = state.folders.map((folder) => folder.id)
+  await Promise.all(
+    folderIds.map(async (folderId) => {
+      try {
+        const result = await JmcomicService.favorites({ folderId, page: 1 })
+        if (!isCurrentRequest(accountId, generation)) return
+        state.counts = { ...state.counts, [folderId]: result.totalItems }
+        state.folders = state.folders.map((folder) =>
+          folder.id === folderId ? { ...folder, count: result.totalItems } : folder,
+        )
+      } catch {
+        // A count is supplementary data. Keep its previous value, or leave it undefined.
+      }
+    }),
+  )
+}
+
+/**
+ * Refresh the online folder names and their supplementary counts for one account.
+ * The names request is authoritative for the visible list; count requests never
+ * turn a failed count into zero.
+ */
+export function refreshFavoriteFolders(accountId: string | null): Promise<void> {
+  if (!accountId) {
+    if (state.accountId !== null || state.hasSuccessfulData) resetState(null)
+    return Promise.resolve()
+  }
+
+  ensureAccount(accountId)
+  if (activeRequest?.accountId === accountId) return activeRequest.promise
+
+  const generation = ++requestGeneration
+  state.isFetching = true
+  state.errorMessage = ''
+
+  const promise = (async () => {
+    try {
+      const result = await JmcomicService.favorites({ folderId: '0', page: 1 })
+      if (!isCurrentRequest(accountId, generation)) return
+
+      applyFolderMap(accountId, generation, result.folderList ?? {})
+      await refreshCounts(accountId, generation)
+    } catch (error) {
+      if (!isCurrentRequest(accountId, generation)) return
+      state.errorMessage = sanitizeError(error, '收藏夹列表加载失败')
+    } finally {
+      if (
+        activeRequest?.accountId === accountId &&
+        activeRequest.generation === generation &&
+        isCurrentRequest(accountId, generation)
+      ) {
+        state.isFetching = false
+        activeRequest = null
+      }
+    }
+  })()
+
+  activeRequest = { accountId, generation, promise }
+  return promise
+}
+
+/** Mark names/counts stale while retaining the last successful list on screen. */
+export function invalidateFavoriteFolders() {
+  requestGeneration += 1
+  activeRequest = null
+  state.isFetching = false
+  state.errorMessage = ''
+}
+
+/** Clear all online folder data, normally when the account logs out or changes. */
+export function clearFavoriteFolderStore() {
+  resetState(null)
+}
+
+/** Apply a trusted folder-list response without issuing another request. */
+export function applyFavoriteFolderList(accountId: string, folderMap: Record<string, string>) {
+  ensureAccount(accountId)
+  const generation = requestGeneration
+  applyFolderMap(accountId, generation, folderMap)
+}
+
+export const favoriteFolderState = state
+
+const onlineFolders = computed(() => state.folders)
+const onlineFolderCounts = computed(() => state.counts)
+const hasSuccessfulData = computed(() => state.hasSuccessfulData)
+const isFetching = computed(() => state.isFetching)
+const errorMessage = computed(() => state.errorMessage)
+const accountId = computed(() => state.accountId)
+
+export function useFavoriteFolderStore() {
+  return {
+    accountId,
+    folders: onlineFolders,
+    counts: onlineFolderCounts,
+    hasSuccessfulData,
+    isFetching,
+    errorMessage,
+    refresh: refreshFavoriteFolders,
+    invalidate: invalidateFavoriteFolders,
+    clear: clearFavoriteFolderStore,
+    applyFolderList: applyFavoriteFolderList,
+  }
+}

--- a/src/composables/favoritePageCache.ts
+++ b/src/composables/favoritePageCache.ts
@@ -2,6 +2,9 @@ import { ref } from 'vue'
 import type { SearchResult, SearchResultItem } from '@/services/JmcomicTypes'
 
 export interface FavoritePageCacheState {
+  accountId: string
+  keyword: string
+  stale: boolean
   folderSource: 'online' | 'offline'
   currentFolderId: string
   onlineFolderMap: Record<string, string>
@@ -13,6 +16,11 @@ export interface FavoritePageCacheState {
 
 /** 模块级缓存——组件销毁重建后仍保留 */
 export const cachedState = ref<FavoritePageCacheState | null>(null)
+
+/** 标记其他页面的收藏变更会影响已保存的收藏页快照。 */
+export function invalidateFavoritePageCache() {
+  if (cachedState.value) cachedState.value = { ...cachedState.value, stale: true }
+}
 
 /** 清除缓存（切换收藏夹、登出时调用） */
 export function clearFavoritePageCache() {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -1,9 +1,20 @@
 import { computed, ref } from 'vue'
 import type { UserInfo } from '@/services/JmcomicTypes'
 import { JmcomicService } from '@/services/JmcomicService'
+import { clearFavoriteFolderStore } from '@/composables/favoriteFolderStore'
+import { clearFavoritePageCache } from '@/composables/favoritePageCache'
 
 const userInfo = ref<UserInfo | null>(null)
 const isLoggedIn = computed(() => userInfo.value !== null)
+
+function updateUserInfo(next: UserInfo | null) {
+  const previousId = userInfo.value?.uid
+  if (previousId && next?.uid !== previousId) {
+    clearFavoriteFolderStore()
+    clearFavoritePageCache()
+  }
+  userInfo.value = next
+}
 
 export function useAuth() {
   /** 启动时调用，先检查本地登录态，如无则尝试自动登录（仅 App.vue onMounted 调用） */
@@ -11,13 +22,13 @@ export function useAuth() {
     try {
       const result = await JmcomicService.checkLoginState()
       if (result.loggedIn && result.userInfo) {
-        userInfo.value = result.userInfo
+        updateUserInfo(result.userInfo)
         return true
       }
       try {
         const autoResult = await JmcomicService.autoLogin()
         if (autoResult.userInfo) {
-          userInfo.value = autoResult.userInfo
+          updateUserInfo(autoResult.userInfo)
           return true
         }
       } catch {
@@ -26,20 +37,22 @@ export function useAuth() {
     } catch {
       // 检查失败视为未登录
     }
+    clearFavoriteFolderStore()
+    clearFavoritePageCache()
     return false
   }
 
   /** 登录并更新本地状态 */
   async function login(username: string, password: string): Promise<UserInfo> {
     const info = await JmcomicService.login(username, password)
-    userInfo.value = info
+    updateUserInfo(info)
     return info
   }
 
   /** 登出并清除本地状态 */
   async function logout(): Promise<void> {
     await JmcomicService.logout()
-    userInfo.value = null
+    updateUserInfo(null)
   }
 
   return { userInfo, isLoggedIn, initAuth, login, logout }

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -378,6 +378,7 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
         authors: albumDetail.value.authors,
         tags: albumDetail.value.tags,
       })
+      invalidateFavoritePageCache()
     }
     albumDetail.value.isFavorite = true
     await showToast('已收藏', 'success')
@@ -1404,6 +1405,9 @@ const handleToggleFavorite = async () => {
     actionBusy.favorite = true
     try {
       await JmcomicService.toggleAlbumFavorite(albumId.value)
+      invalidateFavoritePageCache()
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
       albumDetail.value.isFavorite = false
       await showToast('已取消收藏', 'success')
     } catch (e: any) {

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -119,9 +119,14 @@
       :online-folders="pickerOnlineFolders"
       :offline-folders="pickerOfflineFolders"
       :online-folder-counts="onlineFolderCounts"
+      :online-has-successful-data="onlineFolderHasSuccessfulData"
+      :online-loading="onlineFolderLoading"
+      :online-refreshing="onlineFolderRefreshing"
+      :online-error-message="onlineFolderErrorMessage"
       :hide-online="!isLoggedIn"
       @select="onPickerSelect"
       @add-folder="onPickerAddFolder"
+      @retry-online="refreshOnlineFolderData"
     />
   </IonPage>
 </template>
@@ -152,7 +157,6 @@ import type {
   AlbumDetail,
   AlbumMeta,
   CommentItem,
-  FavoriteResult,
   FolderEntry,
   ImportedPdf,
   PhotoDetail,
@@ -163,6 +167,8 @@ import { OfflineDownloadService } from '@/services/OfflineDownloadService'
 import { OfflineFavoriteService } from '@/services/OfflineFavoriteService'
 import { HistoryService } from '@/services/HistoryService'
 import { useAuth } from '@/composables/useAuth'
+import { useFavoriteFolderStore } from '@/composables/favoriteFolderStore'
+import { invalidateFavoritePageCache } from '@/composables/favoritePageCache'
 import { openLeftMenu, setLeftMenuGestureEnabled } from '@/composables/useSideMenuState'
 import { type PreviewImageSlotSetter, usePreviewBatches } from '@/composables/usePreviewBatches'
 import { getPreviewGridItemWidth } from '@/utils/previewGrid'
@@ -307,48 +313,50 @@ const refreshImportedPdfStatuses = async () => {
 const actionBusy = reactive({ like: false, favorite: false })
 
 // ---- 收藏夹选择弹窗 ----
-const { isLoggedIn } = useAuth()
+const auth = useAuth()
+const isLoggedIn = auth.isLoggedIn
+const userInfo = auth.userInfo
+const accountId = computed(
+  () => userInfo?.value?.uid ?? (isLoggedIn.value ? 'authenticated' : null),
+)
+const {
+  folders: pickerOnlineFolders,
+  counts: onlineFolderCounts,
+  hasSuccessfulData: onlineFolderHasSuccessfulData,
+  isFetching: onlineFolderRefreshing,
+  errorMessage: onlineFolderErrorMessage,
+  refresh: refreshFavoriteFolders,
+  invalidate: invalidateFavoriteFolders,
+  clear: clearFavoriteFolders,
+} = useFavoriteFolderStore()
+const onlineFolderLoading = computed(
+  () => onlineFolderRefreshing.value && !onlineFolderHasSuccessfulData.value,
+)
 const showFolderPicker = ref(false)
 
-const pickerOnlineFolders = ref<FolderEntry[]>([])
 const pickerOfflineFolders = ref<FolderEntry[]>([])
-const onlineFolderCounts = ref<Record<string, number>>({})
 
-async function openFolderPicker() {
-  await OfflineFavoriteService.ensureInit()
-  pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
-
-  if (isLoggedIn.value) {
-    try {
-      const result: FavoriteResult = await JmcomicService.favorites({ folderId: '0', page: 1 })
-      if (result.folderList) {
-        const entries: FolderEntry[] = []
-        const counts: Record<string, number> = {}
-        const countPromises: Promise<void>[] = []
-        for (const [id, name] of Object.entries(result.folderList)) {
-          entries.push({ id, name, count: 0 })
-          countPromises.push(
-            JmcomicService.favorites({ folderId: id, page: 1 })
-              .then((r) => {
-                counts[id] = r.totalItems
-              })
-              .catch(() => {
-                counts[id] = 0
-              }),
-          )
-        }
-        pickerOnlineFolders.value = entries
-        await Promise.all(countPromises)
-        onlineFolderCounts.value = counts
-      }
-    } catch {
-      pickerOnlineFolders.value = []
-    }
-  } else {
-    pickerOnlineFolders.value = []
+async function refreshOnlineFolderData() {
+  if (!isLoggedIn.value) {
+    clearFavoriteFolders()
+    return
   }
+  await refreshFavoriteFolders(accountId.value)
+}
 
+function openFolderPicker() {
+  pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
   showFolderPicker.value = true
+
+  void (async () => {
+    try {
+      await OfflineFavoriteService.ensureInit()
+      pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
+    } catch {
+      // 离线收藏夹读取失败时保留当前缓存。
+    }
+  })()
+  void refreshOnlineFolderData()
 }
 
 async function onPickerSelect(payload: { folderId: string; source: 'online' | 'offline' }) {
@@ -359,8 +367,11 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
   try {
     if (payload.source === 'online') {
       await JmcomicService.toggleAlbumFavorite(albumId.value, payload.folderId)
+      invalidateFavoritePageCache()
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
     } else {
-      OfflineFavoriteService.addItem(payload.folderId, {
+      await OfflineFavoriteService.addItem(payload.folderId, {
         id: albumDetail.value.id,
         title: albumDetail.value.title,
         coverUrl: albumDetail.value.image,
@@ -394,31 +405,8 @@ async function onPickerAddFolder(source: 'online' | 'offline') {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {
                 await showToast('收藏夹已创建', 'success')
-                // 刷新在线列表 + 数量
-                const result: FavoriteResult = await JmcomicService.favorites({
-                  folderId: '0',
-                  page: 1,
-                })
-                if (result.folderList) {
-                  const entries: FolderEntry[] = []
-                  const counts: Record<string, number> = {}
-                  const countPromises: Promise<void>[] = []
-                  for (const [id, fName] of Object.entries(result.folderList)) {
-                    entries.push({ id, name: fName, count: 0 })
-                    countPromises.push(
-                      JmcomicService.favorites({ folderId: id, page: 1 })
-                        .then((r) => {
-                          counts[id] = r.totalItems
-                        })
-                        .catch(() => {
-                          counts[id] = 0
-                        }),
-                    )
-                  }
-                  pickerOnlineFolders.value = entries
-                  await Promise.all(countPromises)
-                  onlineFolderCounts.value = counts
-                }
+                invalidateFavoriteFolders()
+                await refreshOnlineFolderData()
               }
             } catch {
               /* ignore */

--- a/src/views/BatchParsePage.vue
+++ b/src/views/BatchParsePage.vue
@@ -1032,6 +1032,7 @@ async function executeSingleFavorite(
         return
       }
       await OfflineFavoriteService.addItem(payload.folderId, item)
+      invalidateFavoritePageCache()
       offlineFavIds.value = new Set([...offlineFavIds.value, item.id])
       showToast('已收藏到离线收藏夹', 'success')
     }
@@ -1087,6 +1088,7 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
       progressTitle.value = '正在保存到离线收藏夹'
       progressTotal.value = 1
       await OfflineFavoriteService.addItems(payload.folderId, toAdd)
+      invalidateFavoritePageCache()
       progressCurrent.value = 1
       await showToast(`已保存 ${toAdd.length} 个本子到离线`, 'success')
     } else {
@@ -1112,9 +1114,11 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
       } else {
         await showToast(`已保存 ${ok} 个本子到在线`, 'success')
       }
-      invalidateFavoriteFolders()
-      invalidateFavoritePageCache()
-      void refreshOnlineFolderData()
+      if (ok > 0) {
+        invalidateFavoriteFolders()
+        invalidateFavoritePageCache()
+        void refreshOnlineFolderData()
+      }
     }
   } catch (e: any) {
     await showToast(sanitizeError(e, '保存失败'), 'danger')

--- a/src/views/BatchParsePage.vue
+++ b/src/views/BatchParsePage.vue
@@ -204,9 +204,14 @@
       :online-folders="pickerOnlineFolders"
       :offline-folders="pickerOfflineFolders"
       :online-folder-counts="pickerOnlineFolderCounts"
+      :online-has-successful-data="onlineFolderHasSuccessfulData"
+      :online-loading="onlineFolderLoading"
+      :online-refreshing="onlineFolderRefreshing"
+      :online-error-message="onlineFolderErrorMessage"
       :hide-online="!isLoggedIn"
       @select="onPickerSelect"
       @add-folder="onPickerAddFolder"
+      @retry-online="refreshOnlineFolderData"
     />
 
     <!-- 操作进度遮罩 -->
@@ -260,6 +265,8 @@ import { JmcomicService, sanitizeError, showToast } from '@/services/JmcomicServ
 import { OfflineDownloadService } from '@/services/OfflineDownloadService'
 import { OfflineFavoriteService } from '@/services/OfflineFavoriteService'
 import { useAuth } from '@/composables/useAuth'
+import { useFavoriteFolderStore } from '@/composables/favoriteFolderStore'
+import { invalidateFavoritePageCache } from '@/composables/favoritePageCache'
 import type {
   AlbumDetail,
   FavoriteResult,
@@ -289,7 +296,25 @@ interface SourceLine {
 const router = useRouter()
 const route = useRoute()
 const routeKey = computed(() => route.query.key as string)
-const { isLoggedIn } = useAuth()
+const auth = useAuth()
+const isLoggedIn = auth.isLoggedIn
+const userInfo = auth.userInfo
+const accountId = computed(
+  () => userInfo?.value?.uid ?? (isLoggedIn.value ? 'authenticated' : null),
+)
+const {
+  folders: pickerOnlineFolders,
+  counts: pickerOnlineFolderCounts,
+  hasSuccessfulData: onlineFolderHasSuccessfulData,
+  isFetching: onlineFolderRefreshing,
+  errorMessage: onlineFolderErrorMessage,
+  refresh: refreshFavoriteFolders,
+  invalidate: invalidateFavoriteFolders,
+  clear: clearFavoriteFolders,
+} = useFavoriteFolderStore()
+const onlineFolderLoading = computed(
+  () => onlineFolderRefreshing.value && !onlineFolderHasSuccessfulData.value,
+)
 const contentRef = ref<InstanceType<typeof IonContent> | null>(null)
 const resultContainerRef = ref<InstanceType<typeof SearchResultContainer> | null>(null)
 const sourceScrollRef = ref<HTMLElement | null>(null)
@@ -558,8 +583,7 @@ async function doParse() {
 async function resolveScrollElement() {
   if (scrollElementRef.value) return scrollElementRef.value
   const contentEl = contentRef.value?.$el as
-    | { getScrollElement?: () => Promise<HTMLElement> }
-    | undefined
+    { getScrollElement?: () => Promise<HTMLElement> } | undefined
   if (!contentEl?.getScrollElement) return null
   scrollElementRef.value = await contentEl.getScrollElement()
   return scrollElementRef.value
@@ -954,47 +978,28 @@ type PickerMode = 'batch' | 'single'
 const showFolderPicker = ref(false)
 const pickerMode = ref<PickerMode>('batch')
 const pickerTargetItem = ref<SearchResultItem | null>(null)
-const pickerOnlineFolders = ref<FolderEntry[]>([])
 const pickerOfflineFolders = ref<FolderEntry[]>([])
-const pickerOnlineFolderCounts = ref<Record<string, number>>({})
 
-async function loadOnlineFolderData() {
+async function refreshOnlineFolderData() {
   if (!isLoggedIn.value) {
-    pickerOnlineFolders.value = []
+    clearFavoriteFolders()
     return
   }
-  try {
-    const result: FavoriteResult = await JmcomicService.favorites({ folderId: '0', page: 1 })
-    if (result.folderList) {
-      const entries: FolderEntry[] = []
-      const countPromises: Promise<void>[] = []
-      const counts: Record<string, number> = {}
-      for (const [id, name] of Object.entries(result.folderList)) {
-        entries.push({ id, name, count: 0 })
-        countPromises.push(
-          JmcomicService.favorites({ folderId: id, page: 1 })
-            .then((r) => {
-              counts[id] = r.totalItems
-            })
-            .catch(() => {
-              counts[id] = 0
-            }),
-        )
-      }
-      pickerOnlineFolders.value = entries
-      await Promise.all(countPromises)
-      pickerOnlineFolderCounts.value = counts
-    }
-  } catch {
-    pickerOnlineFolders.value = []
-  }
+  await refreshFavoriteFolders(accountId.value)
 }
 
-async function openFolderPickerForMode() {
-  await OfflineFavoriteService.ensureInit()
+function openFolderPickerForMode() {
   pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
-  void loadOnlineFolderData()
   showFolderPicker.value = true
+  void (async () => {
+    try {
+      await OfflineFavoriteService.ensureInit()
+      pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
+    } catch {
+      // 离线收藏夹读取失败时保留当前缓存。
+    }
+  })()
+  void refreshOnlineFolderData()
 }
 
 function openBatchSave() {
@@ -1017,6 +1022,9 @@ async function executeSingleFavorite(
         return
       }
       await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+      invalidateFavoritePageCache()
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
       showToast('已收藏到在线收藏夹', 'success')
     } else {
       if (offlineFavIds.value.has(item.id) || bothFavIds.value.has(item.id)) {
@@ -1104,6 +1112,9 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
       } else {
         await showToast(`已保存 ${ok} 个本子到在线`, 'success')
       }
+      invalidateFavoriteFolders()
+      invalidateFavoritePageCache()
+      void refreshOnlineFolderData()
     }
   } catch (e: any) {
     await showToast(sanitizeError(e, '保存失败'), 'danger')
@@ -1129,7 +1140,8 @@ async function onPickerAddFolder(source: 'online' | 'offline') {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {
                 await showToast('收藏夹已创建', 'success')
-                await loadOnlineFolderData()
+                invalidateFavoriteFolders()
+                await refreshOnlineFolderData()
               } else {
                 await showToast(r.msg || '创建失败', 'danger')
               }

--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -69,9 +69,14 @@
         :online-folders="pickerOnlineFolders"
         :offline-folders="pickerOfflineFolders"
         :online-folder-counts="pickerOnlineFolderCounts"
+        :online-has-successful-data="onlineFolderHasSuccessfulData"
+        :online-loading="onlineFolderLoading"
+        :online-refreshing="onlineFolderRefreshing"
+        :online-error-message="onlineFolderErrorMessage"
         :hide-online="!isLoggedIn"
         @select="onPickerSelect"
         @add-folder="onPickerAddFolder"
+        @retry-online="refreshOnlineFolderData"
       />
 
       <QuickActionFab
@@ -113,8 +118,9 @@ import { JmcomicService, sanitizeError, showToast } from '@/services/JmcomicServ
 import { OfflineDownloadService } from '@/services/OfflineDownloadService'
 import { OfflineFavoriteService } from '@/services/OfflineFavoriteService'
 import { useAuth } from '@/composables/useAuth'
+import { useFavoriteFolderStore } from '@/composables/favoriteFolderStore'
+import { invalidateFavoritePageCache } from '@/composables/favoritePageCache'
 import type {
-  FavoriteResult,
   FolderEntry,
   SearchQuery,
   SearchResult,
@@ -372,7 +378,25 @@ const handleItemClick = (item: SearchResultItem) => {
 
 // ========== 卡片操作菜单 ==========
 
-const { isLoggedIn } = useAuth()
+const auth = useAuth()
+const isLoggedIn = auth.isLoggedIn
+const userInfo = auth.userInfo
+const accountId = computed(
+  () => userInfo?.value?.uid ?? (isLoggedIn.value ? 'authenticated' : null),
+)
+const {
+  folders: pickerOnlineFolders,
+  counts: pickerOnlineFolderCounts,
+  hasSuccessfulData: onlineFolderHasSuccessfulData,
+  isFetching: onlineFolderRefreshing,
+  errorMessage: onlineFolderErrorMessage,
+  refresh: refreshFavoriteFolders,
+  invalidate: invalidateFavoriteFolders,
+  clear: clearFavoriteFolders,
+} = useFavoriteFolderStore()
+const onlineFolderLoading = computed(
+  () => onlineFolderRefreshing.value && !onlineFolderHasSuccessfulData.value,
+)
 
 interface CardMenuState {
   item: SearchResultItem
@@ -472,47 +496,28 @@ function handleCardFavorite(item: SearchResultItem) {
 
 const showFolderPicker = ref(false)
 const pickerTargetItem = ref<SearchResultItem | null>(null)
-const pickerOnlineFolders = ref<FolderEntry[]>([])
 const pickerOfflineFolders = ref<FolderEntry[]>([])
-const pickerOnlineFolderCounts = ref<Record<string, number>>({})
 
-async function loadOnlineFolderData() {
+async function refreshOnlineFolderData() {
   if (!isLoggedIn.value) {
-    pickerOnlineFolders.value = []
+    clearFavoriteFolders()
     return
   }
-  try {
-    const result: FavoriteResult = await JmcomicService.favorites({ folderId: '0', page: 1 })
-    if (result.folderList) {
-      const entries: FolderEntry[] = []
-      const countPromises: Promise<void>[] = []
-      const counts: Record<string, number> = {}
-      for (const [id, name] of Object.entries(result.folderList)) {
-        entries.push({ id, name, count: 0 })
-        countPromises.push(
-          JmcomicService.favorites({ folderId: id, page: 1 })
-            .then((r) => {
-              counts[id] = r.totalItems
-            })
-            .catch(() => {
-              counts[id] = 0
-            }),
-        )
-      }
-      pickerOnlineFolders.value = entries
-      await Promise.all(countPromises)
-      pickerOnlineFolderCounts.value = counts
-    }
-  } catch {
-    pickerOnlineFolders.value = []
-  }
+  await refreshFavoriteFolders(accountId.value)
 }
 
-async function openFolderPicker() {
-  await OfflineFavoriteService.ensureInit()
+function openFolderPicker() {
   pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
-  void loadOnlineFolderData()
   showFolderPicker.value = true
+  void (async () => {
+    try {
+      await OfflineFavoriteService.ensureInit()
+      pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
+    } catch {
+      // 离线收藏夹读取失败时保留当前缓存。
+    }
+  })()
+  void refreshOnlineFolderData()
 }
 
 async function onPickerSelect(payload: { folderId: string; source: 'online' | 'offline' }) {
@@ -535,6 +540,9 @@ async function executeFavorite(
         return
       }
       await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+      invalidateFavoritePageCache()
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
       showToast('已收藏到在线收藏夹', 'success')
     } else {
       await OfflineFavoriteService.addItem(payload.folderId, item)
@@ -562,7 +570,8 @@ async function onPickerAddFolder(source: 'online' | 'offline') {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {
                 await showToast('收藏夹已创建', 'success')
-                await loadOnlineFolderData()
+                invalidateFavoriteFolders()
+                await refreshOnlineFolderData()
               } else {
                 await showToast(r.msg || '创建失败', 'danger')
               }

--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -546,6 +546,7 @@ async function executeFavorite(
       showToast('已收藏到在线收藏夹', 'success')
     } else {
       await OfflineFavoriteService.addItem(payload.folderId, item)
+      invalidateFavoritePageCache()
       showToast('已收藏到离线收藏夹', 'success')
     }
   } catch (e: any) {

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -196,7 +196,7 @@ import type {
 } from '@/services/JmcomicTypes'
 import { OFFLINE_ALL_FOLDER_ID } from '@/services/JmcomicTypes'
 import { closeLeftMenu, useSideMenuState } from '@/composables/useSideMenuState'
-import { cachedState } from '@/composables/favoritePageCache'
+import { cachedState, clearFavoritePageCache } from '@/composables/favoritePageCache'
 
 defineOptions({ name: 'FavoritePage' })
 
@@ -1149,10 +1149,14 @@ async function handleCardRemove(item: SearchResultItem) {
               await showToast('操作失败', 'danger')
             }
           } else {
-            await OfflineFavoriteService.removeItem(context.folderId, item.id)
-            const removal = removeItemFromCurrentView(item.id, context)
-            if (removal) void replenishAfterRemoval(removal, item.id, context)
-            await showToast('已取消收藏', 'success')
+            try {
+              await OfflineFavoriteService.removeItem(context.folderId, item.id)
+              const removal = removeItemFromCurrentView(item.id, context)
+              if (removal) void replenishAfterRemoval(removal, item.id, context)
+              await showToast('已取消收藏', 'success')
+            } catch {
+              await showToast('操作失败', 'danger')
+            }
           }
         },
       },
@@ -1853,6 +1857,31 @@ watch(widePaneOpen, (open) => {
   if (open) void refreshOnlineFolderData()
 })
 
+const handleLogout = () => {
+  clearFavoriteFolders()
+  clearFavoritePageCache()
+  queryGeneration += 1
+  onlineSearchCache.value = null
+  folderSource.value = 'offline'
+  currentKeyword.value = ''
+
+  const folders = OfflineFavoriteService.getFolders()
+  if (folders.length > 0) {
+    currentFolderId.value = folders[0].id
+    void resetWithPage(1)
+    return
+  }
+
+  currentFolderId.value = OFFLINE_ALL_FOLDER_ID
+  resultMeta.value = null
+  pageCache.value = {}
+  initialLoading.value = false
+  loadingPrevious.value = false
+  loadingNext.value = false
+  errorMessage.value = ''
+  pageAtTop.value = true
+}
+
 // 登录态从未登录变为已登录时自动切换到在线收藏夹
 watch([isLoggedIn, accountId], ([loggedIn, currentAccount], [wasLoggedIn, previousAccount]) => {
   if (loggedIn && (!wasLoggedIn || currentAccount !== previousAccount)) {
@@ -1863,7 +1892,7 @@ watch([isLoggedIn, accountId], ([loggedIn, currentAccount], [wasLoggedIn, previo
     invalidateFavoriteFolders()
     void refreshOnlineFolderData()
   } else if (!loggedIn && wasLoggedIn) {
-    clearFavoriteFolders()
+    handleLogout()
   }
 })
 

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -89,6 +89,10 @@
         :selected-online-id="folderSource === 'online' ? currentFolderId : ''"
         :selected-offline-id="folderSource === 'offline' ? currentFolderId : ''"
         :online-folder-counts="onlineFolderCounts"
+        :online-has-successful-data="onlineFolderHasSuccessfulData"
+        :online-loading="onlineFolderLoading"
+        :online-refreshing="onlineFolderRefreshing"
+        :online-error-message="onlineFolderErrorMessage"
         @select-online-folder="onSelectOnlineFolder"
         @select-offline-folder="onSelectOfflineFolder"
         @add-folder="onAddFolder"
@@ -97,6 +101,7 @@
         @move-folder="onMoveFolder"
         @copy-folder="onCopyFolder"
         @export-folder="onExportFolder"
+        @retry-online="refreshOnlineFolderData"
       />
     </div>
 
@@ -181,6 +186,7 @@ import {
 } from '@/services/OfflineFavoriteService'
 import { ExportFormatService } from '@/services/ExportFormatService'
 import { useAuth } from '@/composables/useAuth'
+import { useFavoriteFolderStore } from '@/composables/favoriteFolderStore'
 import type {
   FavoriteQuery,
   FavoriteResult,
@@ -206,29 +212,28 @@ const router = useRouter()
 type FolderSource = 'online' | 'offline'
 const folderSource = ref<FolderSource>('offline')
 const currentFolderId = ref('default')
-const onlineFolderMap = ref<Record<string, string>>({})
-const onlineFolderCounts = ref<Record<string, number>>({})
 const currentKeyword = ref('')
-
-const loadOnlineFolderCounts = async () => {
-  const ids = Object.keys(onlineFolderMap.value)
-  if (ids.length === 0) return
-  const counts: Record<string, number> = {}
-  const promises = ids.map((id) =>
-    JmcomicService.favorites({ folderId: id, page: 1 })
-      .then((r) => {
-        counts[id] = r.totalItems
-      })
-      .catch(() => {
-        counts[id] = 0
-      }),
-  )
-  await Promise.all(promises)
-  onlineFolderCounts.value = counts
-}
-
-const onlineFolderEntries = computed<FolderEntry[]>(() =>
-  Object.entries(onlineFolderMap.value).map(([id, name]) => ({ id, name, count: 0 })),
+const auth = useAuth()
+const isLoggedIn = auth.isLoggedIn
+const userInfo = auth.userInfo
+const accountId = computed(
+  () => userInfo?.value?.uid ?? (isLoggedIn.value ? 'authenticated' : null),
+)
+const {
+  folders: onlineFolderEntries,
+  counts: onlineFolderCounts,
+  hasSuccessfulData: onlineFolderHasSuccessfulData,
+  isFetching: onlineFolderRefreshing,
+  errorMessage: onlineFolderErrorMessage,
+  refresh: refreshFavoriteFolders,
+  invalidate: invalidateFavoriteFolders,
+  clear: clearFavoriteFolders,
+} = useFavoriteFolderStore()
+const onlineFolderLoading = computed(
+  () => onlineFolderRefreshing.value && !onlineFolderHasSuccessfulData.value,
+)
+const onlineFolderMap = computed<Record<string, string>>(() =>
+  Object.fromEntries(onlineFolderEntries.value.map((folder) => [folder.id, folder.name])),
 )
 
 const offlineFolderEntries = computed<FolderEntry[]>(() => {
@@ -269,7 +274,37 @@ let pageResizeObserver: ResizeObserver | undefined
 const pageCache = ref<Record<number, SearchResultItem[]>>({})
 
 /** 在线关键字搜索时缓存全部过滤结果，翻页直接切片不重复拉取 */
-const onlineSearchCache = ref<SearchResultItem[] | null>(null)
+const onlineSearchCache = ref<{ generation: number; items: SearchResultItem[] } | null>(null)
+
+interface FavoriteViewContext {
+  generation: number
+  accountId: string | null
+  source: FolderSource
+  folderId: string
+  keyword: string
+}
+
+let queryGeneration = 0
+
+const captureViewContext = (generation = queryGeneration): FavoriteViewContext => ({
+  generation,
+  accountId: accountId.value,
+  source: folderSource.value,
+  folderId: currentFolderId.value,
+  keyword: currentKeyword.value.trim(),
+})
+
+const isCurrentViewContext = (context: FavoriteViewContext) =>
+  context.generation === queryGeneration &&
+  context.accountId === accountId.value &&
+  context.source === folderSource.value &&
+  context.folderId === currentFolderId.value &&
+  context.keyword === currentKeyword.value.trim()
+
+const beginViewContext = () => {
+  queryGeneration += 1
+  return captureViewContext()
+}
 
 const matchesKeyword = (item: SearchResultItem, kw: string): boolean => {
   const kwLower = kw.toLowerCase()
@@ -314,6 +349,9 @@ const refreshDownloadStatuses = async () => {
 const saveToCache = () => {
   if (!resultMeta.value) return
   cachedState.value = {
+    accountId: accountId.value ?? '',
+    keyword: currentKeyword.value,
+    stale: false,
     folderSource: folderSource.value,
     currentFolderId: currentFolderId.value,
     onlineFolderMap: { ...onlineFolderMap.value },
@@ -326,11 +364,12 @@ const saveToCache = () => {
 
 const restoreFromCache = (): boolean => {
   const c = cachedState.value
-  if (!c) return false
+  if (!c || c.accountId !== (accountId.value ?? '')) {
+    return false
+  }
   folderSource.value = c.folderSource
   currentFolderId.value = c.currentFolderId
-  onlineFolderMap.value = c.onlineFolderMap
-  onlineFolderCounts.value = c.onlineFolderCounts
+  currentKeyword.value = c.keyword ?? ''
   resultMeta.value = c.resultMeta
   pageCache.value = c.pageCache
   displayMode.value = c.displayMode
@@ -338,8 +377,10 @@ const restoreFromCache = (): boolean => {
 }
 
 const silentRefresh = async () => {
+  const context = captureViewContext()
   try {
-    const pageResult = await fetchPage(1)
+    const pageResult = await fetchPage(1, context)
+    if (!isCurrentViewContext(context)) return
     const cached = pageCache.value[1] ?? []
     const sameContent =
       cached.length === pageResult.content.length &&
@@ -446,34 +487,43 @@ const stopPageResizeObserver = () => {
 }
 
 // --- 数据获取 ---
-const fetchOnlineFavorites = async (page: number): Promise<SearchResult> => {
-  const kw = currentKeyword.value?.trim()
+const fetchOnlineFavorites = async (
+  page: number,
+  context: FavoriteViewContext,
+): Promise<SearchResult> => {
+  const kw = context.keyword
   const pageSize = 20
 
   if (kw) {
-    if (onlineSearchCache.value === null) {
+    const cachedSearch =
+      onlineSearchCache.value?.generation === context.generation
+        ? onlineSearchCache.value.items
+        : null
+    let filtered: SearchResultItem[]
+    if (cachedSearch) {
+      filtered = cachedSearch
+    } else {
       const allItems: SearchResultItem[] = []
       let p = 1
       let tp = 1
       while (p <= tp) {
         const result: FavoriteResult = await JmcomicService.favorites({
-          folderId: currentFolderId.value,
+          folderId: context.folderId,
           page: p,
         })
         allItems.push(...result.content)
-        if (result.folderList) {
-          onlineFolderMap.value = result.folderList
-        }
         tp = result.totalPages
         p++
         if (p <= tp) {
           await new Promise((r) => setTimeout(r, 100))
         }
       }
-      onlineSearchCache.value = allItems.filter((item) => matchesKeyword(item, kw))
+      filtered = allItems.filter((item) => matchesKeyword(item, kw))
+      if (isCurrentViewContext(context)) {
+        onlineSearchCache.value = { generation: context.generation, items: filtered }
+      }
     }
 
-    const filtered = onlineSearchCache.value
     const totalItems = filtered.length
     const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
     const currentPage = Math.min(Math.max(1, page), totalPages)
@@ -487,14 +537,11 @@ const fetchOnlineFavorites = async (page: number): Promise<SearchResult> => {
   }
 
   // 无关键字：清缓存，走服务端分页
-  onlineSearchCache.value = null
+  if (isCurrentViewContext(context)) onlineSearchCache.value = null
   const result: FavoriteResult = await JmcomicService.favorites({
-    folderId: currentFolderId.value,
+    folderId: context.folderId,
     page,
   })
-  if (result.folderList) {
-    onlineFolderMap.value = result.folderList
-  }
   return {
     currentPage: result.currentPage,
     totalItems: result.totalItems,
@@ -503,11 +550,14 @@ const fetchOnlineFavorites = async (page: number): Promise<SearchResult> => {
   }
 }
 
-const fetchOfflineFavorites = async (page: number): Promise<SearchResult> => {
+const fetchOfflineFavorites = async (
+  page: number,
+  context: FavoriteViewContext,
+): Promise<SearchResult> => {
   const pageSize = 20
-  if (currentFolderId.value === OFFLINE_ALL_FOLDER_ID) {
+  if (context.folderId === OFFLINE_ALL_FOLDER_ID) {
     const items = await OfflineFavoriteService.getAllItemsMerged()
-    const kw = currentKeyword.value || undefined
+    const kw = context.keyword || undefined
     const filtered = kw ? items.filter((i) => matchesKeyword(i, kw)) : items
     const totalItems = filtered.length
     const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
@@ -521,8 +571,8 @@ const fetchOfflineFavorites = async (page: number): Promise<SearchResult> => {
     }
   }
   const result = await OfflineFavoriteService.getItems(
-    currentFolderId.value,
-    currentKeyword.value || undefined,
+    context.folderId,
+    context.keyword || undefined,
     page,
     pageSize,
   )
@@ -534,21 +584,25 @@ const fetchOfflineFavorites = async (page: number): Promise<SearchResult> => {
   }
 }
 
-const fetchPage = async (page: number): Promise<SearchResult> => {
-  if (folderSource.value === 'online') {
-    return await fetchOnlineFavorites(page)
+const fetchPage = async (page: number, context = captureViewContext()): Promise<SearchResult> => {
+  if (context.source === 'online') {
+    return await fetchOnlineFavorites(page, context)
   }
-  return fetchOfflineFavorites(page)
+  return fetchOfflineFavorites(page, context)
 }
 
 const resetWithPage = async (page: number = 1) => {
+  const context = beginViewContext()
   onlineSearchCache.value = null
   initialLoading.value = true
+  loadingPrevious.value = false
+  loadingNext.value = false
   errorMessage.value = ''
   resultMeta.value = null
   pageCache.value = {}
   try {
-    const pageResult = await fetchPage(page)
+    const pageResult = await fetchPage(page, context)
+    if (!isCurrentViewContext(context)) return
     resultMeta.value = pageResult
     pageCache.value = { [page]: pageResult.content }
     saveToCache()
@@ -556,11 +610,126 @@ const resetWithPage = async (page: number = 1) => {
     void contentRef.value?.$el?.scrollToTop?.(0)
     pageAtTop.value = true
   } catch (error) {
+    if (!isCurrentViewContext(context)) return
     resultMeta.value = null
     pageCache.value = {}
     errorMessage.value = sanitizeError(error, '加载失败')
   } finally {
-    initialLoading.value = false
+    if (isCurrentViewContext(context)) initialLoading.value = false
+  }
+}
+
+interface RemovalAnchor {
+  itemId: string
+  top: number | null
+}
+
+interface RemovalResult {
+  page: number
+  anchor: RemovalAnchor | null
+}
+
+const getEntryKey = (entry: SearchResultDisplayItem) =>
+  `${entry.page}-${entry.indexInPage}-${entry.item.id}`
+
+const removeItemFromCurrentView = (
+  itemId: string,
+  context: FavoriteViewContext,
+): RemovalResult | null => {
+  if (!isCurrentViewContext(context)) return null
+
+  const anchorEntry = displayItems.value.find((entry) => entry.item.id !== itemId)
+  const anchor = anchorEntry
+    ? {
+        itemId: anchorEntry.item.id,
+        top:
+          resultContainerRef.value
+            ?.getEntryElement(getEntryKey(anchorEntry))
+            ?.getBoundingClientRect().top ?? null,
+      }
+    : null
+
+  let removedPage: number | null = null
+  const nextPageCache: Record<number, SearchResultItem[]> = {}
+  for (const [pageString, items] of Object.entries(pageCache.value)) {
+    const page = Number(pageString)
+    const nextItems = [...items]
+    const itemIndex = nextItems.findIndex((candidate) => candidate.id === itemId)
+    if (itemIndex >= 0 && removedPage === null) {
+      nextItems.splice(itemIndex, 1)
+      removedPage = page
+    }
+    nextPageCache[page] = nextItems
+  }
+
+  if (removedPage === null) return null
+
+  const previousTotal = resultMeta.value?.totalItems ?? 0
+  const nextTotal = Math.max(0, previousTotal - 1)
+  resultMeta.value = resultMeta.value
+    ? {
+        ...resultMeta.value,
+        totalItems: nextTotal,
+        totalPages: Math.max(1, Math.ceil(nextTotal / 20)),
+      }
+    : null
+  pageCache.value = nextPageCache
+  onlineSearchCache.value = null
+  saveToCache()
+  return { page: removedPage, anchor }
+}
+
+const replenishAfterRemoval = async (
+  removal: RemovalResult,
+  itemId: string,
+  context: FavoriteViewContext,
+) => {
+  const lastLoadedPage = loadedPageEnd.value
+  if (!lastLoadedPage || !isCurrentViewContext(context)) return
+
+  try {
+    const results: Array<{ page: number; result: SearchResult }> = []
+    for (let page = removal.page; page <= lastLoadedPage; page++) {
+      const result = await fetchPage(page, context)
+      results.push({ page, result })
+    }
+    if (!isCurrentViewContext(context) || results.length === 0) return
+
+    const previousTotal = resultMeta.value?.totalItems ?? 0
+    const serverTotal = results[0].result.totalItems
+    const totalItems = Math.max(0, Math.min(serverTotal, previousTotal))
+    const totalPages = Math.max(1, Math.ceil(totalItems / 20))
+    const nextPageCache = { ...pageCache.value }
+    for (const { page, result } of results) {
+      if (page > totalPages) {
+        delete nextPageCache[page]
+        continue
+      }
+      nextPageCache[page] = result.content.filter((item) => item.id !== itemId)
+    }
+    resultMeta.value = {
+      ...results[0].result,
+      totalItems,
+      totalPages,
+    }
+    pageCache.value = nextPageCache
+    saveToCache()
+
+    if (removal.anchor) {
+      await nextTick()
+      const nextEntry = displayItems.value.find((entry) => entry.item.id === removal.anchor?.itemId)
+      if (nextEntry && removal.anchor.top !== null) {
+        const nextTop = resultContainerRef.value
+          ?.getEntryElement(getEntryKey(nextEntry))
+          ?.getBoundingClientRect().top
+        const scrollElement = await resolveScrollElement()
+        if (nextTop !== undefined && nextTop !== null && scrollElement) {
+          scrollElement.scrollTop += nextTop - removal.anchor.top
+        }
+      }
+    }
+  } catch {
+    // The confirmed local removal remains visible; the next explicit refresh retries.
   }
 }
 
@@ -575,20 +744,23 @@ const retrySearch = () => {
 
 const handleRefresh = async (event: CustomEvent) => {
   const refresher = event.target as HTMLIonRefresherElement
+  const context = captureViewContext()
   try {
-    if (folderSource.value === 'online') {
+    if (context.source === 'online') {
       onlineSearchCache.value = null
       errorMessage.value = ''
-      const result = await fetchOnlineFavorites(1)
+      const result = await fetchOnlineFavorites(1, context)
+      if (!isCurrentViewContext(context)) return
       resultMeta.value = result
       pageCache.value = { 1: result.content }
     } else {
-      const result = await fetchOfflineFavorites(1)
+      const result = await fetchOfflineFavorites(1, context)
+      if (!isCurrentViewContext(context)) return
       resultMeta.value = result
       pageCache.value = { 1: result.content }
     }
   } catch {
-    if (folderSource.value === 'online') {
+    if (isCurrentViewContext(context) && context.source === 'online') {
       errorMessage.value = '刷新失败'
     }
   } finally {
@@ -599,23 +771,28 @@ const handleRefresh = async (event: CustomEvent) => {
 // --- 分页 ---
 const appendPage = async (page: number) => {
   if (loadingNext.value || initialLoading.value || !canLoadNext.value) return
+  const context = captureViewContext()
   loadingNext.value = true
   try {
     errorMessage.value = ''
-    const pageResult = await fetchPage(page)
+    const pageResult = await fetchPage(page, context)
+    if (!isCurrentViewContext(context)) return
     resultMeta.value = pageResult
     pageCache.value = { ...pageCache.value, [page]: pageResult.content }
     saveToCache()
     await maybeLoadNextAfterRender()
   } catch (error) {
-    errorMessage.value = sanitizeError(error, '加载下一页失败')
+    if (isCurrentViewContext(context)) {
+      errorMessage.value = sanitizeError(error, '加载下一页失败')
+    }
   } finally {
-    loadingNext.value = false
+    if (isCurrentViewContext(context)) loadingNext.value = false
   }
 }
 
 const prependPage = async (page: number) => {
   if (loadingPrevious.value || initialLoading.value || !canLoadPrevious.value) return
+  const context = captureViewContext()
 
   const contentScrollElement = await resolveScrollElement()
   const anchorEntry = displayItems.value[0]
@@ -634,7 +811,8 @@ const prependPage = async (page: number) => {
   loadingPrevious.value = true
   try {
     errorMessage.value = ''
-    const pageResult = await fetchPage(page)
+    const pageResult = await fetchPage(page, context)
+    if (!isCurrentViewContext(context)) return
     resultMeta.value = pageResult
     pageCache.value = { [page]: pageResult.content, ...pageCache.value }
     saveToCache()
@@ -653,9 +831,11 @@ const prependPage = async (page: number) => {
       contentScrollElement.scrollTop += nextRootTop - previousRootTop
     }
   } catch (error) {
-    errorMessage.value = sanitizeError(error, '加载上一页失败')
+    if (isCurrentViewContext(context)) {
+      errorMessage.value = sanitizeError(error, '加载上一页失败')
+    }
   } finally {
-    loadingPrevious.value = false
+    if (isCurrentViewContext(context)) loadingPrevious.value = false
   }
 }
 
@@ -721,6 +901,7 @@ const openRightMenu = async () => {
 
   if (isWideLayout.value) {
     widePaneOpen.value = true
+    void refreshOnlineFolderData()
     return
   }
 
@@ -728,6 +909,7 @@ const openRightMenu = async () => {
   rightDragProgress.value = 0
   isDraggingRight.value = true
   rightMenuOpen.value = true
+  void refreshOnlineFolderData()
   await nextTick()
   const panelEl = sideMenuRef.value?.panelRef
   if (panelEl) void panelEl.offsetHeight // 强制 reflow，确认初始位置已渲染
@@ -823,7 +1005,8 @@ async function handleCardRead(item: SearchResultItem) {
 // --- 卡片操作：移动 ---
 async function handleCardMove(item: SearchResultItem) {
   closeCardMenu()
-  if (currentFolderId.value === OFFLINE_ALL_FOLDER_ID) {
+  const context = captureViewContext()
+  if (context.folderId === OFFLINE_ALL_FOLDER_ID) {
     await showToast('全部视图不支持移动，请进入具体文件夹操作', 'medium')
     return
   }
@@ -832,10 +1015,10 @@ async function handleCardMove(item: SearchResultItem) {
 
   if (isOnline) {
     folders = Object.entries(onlineFolderMap.value)
-      .filter(([id]) => id !== currentFolderId.value)
+      .filter(([id]) => id !== context.folderId)
       .map(([id, name]) => ({ id, name }))
   } else {
-    folders = OfflineFavoriteService.getFolders().filter((f) => f.id !== currentFolderId.value)
+    folders = OfflineFavoriteService.getFolders().filter((f) => f.id !== context.folderId)
   }
 
   if (folders.length === 0) {
@@ -857,23 +1040,43 @@ async function handleCardMove(item: SearchResultItem) {
         handler: async (data: string) => {
           if (!data) return
           if (isOnline) {
+            let sourceRemoved = false
             try {
               if (data === '0') {
-                await JmcomicService.toggleAlbumFavorite(item.id, currentFolderId.value)
+                await JmcomicService.toggleAlbumFavorite(item.id, context.folderId)
+                sourceRemoved = true
                 await JmcomicService.toggleAlbumFavorite(item.id, '0')
               } else {
                 await JmcomicService.manageFavoriteFolder('move', data, '', item.id)
               }
+              invalidateFavoriteFolders()
+              void refreshOnlineFolderData()
+              if (context.folderId !== '0') {
+                const removal = removeItemFromCurrentView(item.id, context)
+                if (removal) void replenishAfterRemoval(removal, item.id, context)
+              }
               await showToast('已移动', 'success')
-              void resetWithPage(1)
             } catch {
+              if (sourceRemoved) {
+                invalidateFavoriteFolders()
+                void refreshOnlineFolderData()
+                if (isCurrentViewContext(context)) void resetWithPage(1)
+              }
               await showToast('移动失败', 'danger')
             }
           } else {
-            await OfflineFavoriteService.removeItem(currentFolderId.value, item.id)
-            await OfflineFavoriteService.addItem(data, item)
-            await showToast('已移动', 'success')
-            void resetWithPage(1)
+            let sourceRemoved = false
+            try {
+              await OfflineFavoriteService.removeItem(context.folderId, item.id)
+              sourceRemoved = true
+              await OfflineFavoriteService.addItem(data, item)
+              const removal = removeItemFromCurrentView(item.id, context)
+              if (removal) void replenishAfterRemoval(removal, item.id, context)
+              await showToast('已移动', 'success')
+            } catch {
+              if (sourceRemoved && isCurrentViewContext(context)) void resetWithPage(1)
+              await showToast('移动失败', 'danger')
+            }
           }
         },
       },
@@ -918,7 +1121,8 @@ async function handleCardDownload(item: SearchResultItem) {
 // --- 卡片操作：取消收藏 ---
 async function handleCardRemove(item: SearchResultItem) {
   closeCardMenu()
-  if (currentFolderId.value === OFFLINE_ALL_FOLDER_ID) {
+  const context = captureViewContext()
+  if (context.folderId === OFFLINE_ALL_FOLDER_ID) {
     await showToast('全部视图不支持移除，请进入具体文件夹操作', 'medium')
     return
   }
@@ -935,16 +1139,20 @@ async function handleCardRemove(item: SearchResultItem) {
         handler: async () => {
           if (isOnline) {
             try {
-              await JmcomicService.toggleAlbumFavorite(item.id, currentFolderId.value)
+              await JmcomicService.toggleAlbumFavorite(item.id, context.folderId)
+              invalidateFavoriteFolders()
+              void refreshOnlineFolderData()
+              const removal = removeItemFromCurrentView(item.id, context)
+              if (removal) void replenishAfterRemoval(removal, item.id, context)
               await showToast('已取消收藏', 'success')
-              void resetWithPage(1)
             } catch {
               await showToast('操作失败', 'danger')
             }
           } else {
-            await OfflineFavoriteService.removeItem(currentFolderId.value, item.id)
+            await OfflineFavoriteService.removeItem(context.folderId, item.id)
+            const removal = removeItemFromCurrentView(item.id, context)
+            if (removal) void replenishAfterRemoval(removal, item.id, context)
             await showToast('已取消收藏', 'success')
-            void resetWithPage(1)
           }
         },
       },
@@ -1510,23 +1718,23 @@ const onExportFolder = async (payload: {
 }
 
 async function refreshOnlineFolderList() {
-  try {
-    const result: FavoriteResult = await JmcomicService.favorites({ folderId: '0', page: 1 })
-    if (result.folderList) {
-      onlineFolderMap.value = result.folderList
-    }
-    await loadOnlineFolderCounts()
-  } catch {
-    /* ignore */
-  }
+  invalidateFavoriteFolders()
+  await refreshOnlineFolderData()
 }
 
 // --- 初始化 ---
-const { isLoggedIn } = useAuth()
+async function refreshOnlineFolderData() {
+  if (!isLoggedIn.value) {
+    clearFavoriteFolders()
+    return
+  }
+  await refreshFavoriteFolders(accountId.value)
+}
 
 const initOnlineFolders = async () => {
   await OfflineFavoriteService.ensureInit()
   if (!isLoggedIn.value) {
+    clearFavoriteFolders()
     folderSource.value = 'offline'
     const offlineFolders = OfflineFavoriteService.getFolders()
     if (offlineFolders.length > 0) {
@@ -1539,34 +1747,26 @@ const initOnlineFolders = async () => {
   }
 
   const hasCached = restoreFromCache()
-  if (!hasCached) {
-    initialLoading.value = true
-  }
+  if (!hasCached) initialLoading.value = true
 
-  try {
-    const result: FavoriteResult = await JmcomicService.favorites({ folderId: '0', page: 1 })
-    if (result.folderList) {
-      onlineFolderMap.value = result.folderList
-    }
-    void loadOnlineFolderCounts()
+  if (!hasCached) {
     folderSource.value = 'online'
     currentFolderId.value = '0'
-    if (hasCached) {
-      void silentRefresh()
-    } else {
+    void resetWithPage(1)
+  } else {
+    void silentRefresh()
+  }
+
+  await refreshOnlineFolderData()
+  if (!hasCached && !onlineFolderHasSuccessfulData.value && !resultMeta.value) {
+    folderSource.value = 'offline'
+    const offlineFolders = OfflineFavoriteService.getFolders()
+    if (offlineFolders.length > 0) {
+      currentFolderId.value = offlineFolders[0].id
       void resetWithPage(1)
-    }
-  } catch {
-    if (!hasCached) {
-      folderSource.value = 'offline'
-      const offlineFolders = OfflineFavoriteService.getFolders()
-      if (offlineFolders.length > 0) {
-        currentFolderId.value = offlineFolders[0].id
-        void resetWithPage(1)
-      } else {
-        currentFolderId.value = OFFLINE_ALL_FOLDER_ID
-        initialLoading.value = false
-      }
+    } else {
+      currentFolderId.value = OFFLINE_ALL_FOLDER_ID
+      initialLoading.value = false
     }
   }
 }
@@ -1639,26 +1839,31 @@ watch(isWideLayout, (wide) => {
   resetOverlayMenuState()
 })
 
-// 右侧菜单打开时建立关闭手势，关闭时销毁；同时刷新在线文件夹数量
+// 右侧菜单打开时建立关闭手势，关闭时销毁；每次实际打开都后台刷新共享列表。
 watch(rightMenuOpen, (open) => {
   if (open) {
     nextTick(() => setupCloseGesture())
-    if (isLoggedIn.value) {
-      void loadOnlineFolderCounts()
-    }
   } else {
     menuCloseGesture?.destroy()
     menuCloseGesture = undefined
   }
 })
 
+watch(widePaneOpen, (open) => {
+  if (open) void refreshOnlineFolderData()
+})
+
 // 登录态从未登录变为已登录时自动切换到在线收藏夹
-watch(isLoggedIn, (loggedIn, wasLoggedIn) => {
-  if (loggedIn && !wasLoggedIn) {
+watch([isLoggedIn, accountId], ([loggedIn, currentAccount], [wasLoggedIn, previousAccount]) => {
+  if (loggedIn && (!wasLoggedIn || currentAccount !== previousAccount)) {
     initialLoading.value = true
     folderSource.value = 'online'
     currentFolderId.value = '0'
     void resetWithPage(1)
+    invalidateFavoriteFolders()
+    void refreshOnlineFolderData()
+  } else if (!loggedIn && wasLoggedIn) {
+    clearFavoriteFolders()
   }
 })
 
@@ -1698,6 +1903,8 @@ onDeactivated(() => {
 onActivated(async () => {
   await nextTick()
   startPageResizeObserver()
+  void refreshOnlineFolderData()
+  if (cachedState.value?.stale && resultMeta.value) void silentRefresh()
   if (isWideLayout.value) {
     widePaneOpen.value = true
   }

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -376,29 +376,75 @@ const restoreFromCache = (): boolean => {
   return true
 }
 
-const silentRefresh = async () => {
+let silentRefreshRequest: {
+  context: FavoriteViewContext
+  promise: Promise<void>
+} | null = null
+
+const sameViewContext = (left: FavoriteViewContext, right: FavoriteViewContext) =>
+  left.generation === right.generation &&
+  left.accountId === right.accountId &&
+  left.source === right.source &&
+  left.folderId === right.folderId &&
+  left.keyword === right.keyword
+
+const silentRefresh = () => {
   const context = captureViewContext()
-  try {
-    const pageResult = await fetchPage(1, context)
-    if (!isCurrentViewContext(context)) return
-    const cached = pageCache.value[1] ?? []
-    const sameContent =
-      cached.length === pageResult.content.length &&
-      cached.every((item, i) => item.id === pageResult.content[i]?.id)
-    const sameTotal = resultMeta.value?.totalItems === pageResult.totalItems
-    if (!sameContent) {
-      resultMeta.value = pageResult
-      pageCache.value = { 1: pageResult.content }
-    } else if (!sameTotal) {
-      resultMeta.value = pageResult
-    }
-    saveToCache()
-    if (!sameContent) {
-      pageAtTop.value = true
-    }
-  } catch {
-    // 静默失败，缓存数据保持显示
+  if (silentRefreshRequest && sameViewContext(silentRefreshRequest.context, context)) {
+    return silentRefreshRequest.promise
   }
+
+  const cachedPages = loadedPages.value.length > 0 ? [...loadedPages.value] : [1]
+  const originalSearchCache = onlineSearchCache.value
+  const request: { context: FavoriteViewContext; promise: Promise<void> } = {
+    context,
+    promise: Promise.resolve(),
+  }
+  const promise = (async () => {
+    try {
+      // A keyword cache represents the whole query. Clear it so this refresh
+      // cannot reuse an older result while rebuilding every cached page.
+      if (context.source === 'online' && context.keyword) onlineSearchCache.value = null
+
+      const refreshedPages: Record<number, SearchResultItem[]> = {}
+      let refreshedMeta: SearchResult | null = null
+      for (const page of cachedPages) {
+        const pageResult = await fetchPage(page, context)
+        refreshedPages[page] = pageResult.content
+        if (!refreshedMeta) refreshedMeta = pageResult
+      }
+
+      if (!isCurrentViewContext(context) || !refreshedMeta) return
+
+      const nextPageCache: Record<number, SearchResultItem[]> = {}
+      for (const page of cachedPages) {
+        if (page <= refreshedMeta.totalPages) {
+          nextPageCache[page] = refreshedPages[page] ?? []
+        }
+      }
+      const pageOneChanged =
+        (pageCache.value[1] ?? []).length !== (nextPageCache[1] ?? []).length ||
+        (pageCache.value[1] ?? []).some((item, index) => item.id !== nextPageCache[1]?.[index]?.id)
+
+      // Commit only after every cached page has completed successfully and
+      // the original query context is still current.
+      resultMeta.value = refreshedMeta
+      pageCache.value = nextPageCache
+      saveToCache()
+      if (pageOneChanged) pageAtTop.value = true
+    } catch {
+      if (isCurrentViewContext(context)) {
+        onlineSearchCache.value = originalSearchCache
+        if (cachedState.value) cachedState.value = { ...cachedState.value, stale: true }
+      }
+      // Keep the original page/result snapshot untouched for the next retry.
+    } finally {
+      if (silentRefreshRequest === request) silentRefreshRequest = null
+    }
+  })()
+  request.promise = promise
+  silentRefreshRequest = request
+  return promise
 }
 
 const currentFavoriteQuery = computed<FavoriteQuery>(() => ({

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -50,6 +50,7 @@
           :loaded-page-start="loadedPageStart"
           :loaded-page-end="loadedPageEnd"
           :downloaded-album-ids="downloadedAlbumIds"
+          :removing-ids="removingIds"
           idle-text="请在右侧收藏夹菜单中选择文件夹"
           @mode-change="displayMode = $event"
           @item-click="handleItemClick"
@@ -779,6 +780,39 @@ const replenishAfterRemoval = async (
   }
 }
 
+// --- 卡片移除退场动画 ---
+const CARD_REMOVE_ANIMATION_MS = 260
+
+const removingIds = ref<Set<string>>(new Set())
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+const waitForRemovalAnimation = () =>
+  new Promise<void>((resolve) => {
+    if (prefersReducedMotion()) {
+      resolve()
+      return
+    }
+    window.setTimeout(resolve, CARD_REMOVE_ANIMATION_MS)
+  })
+
+const animateRemoveFromView = async (itemId: string, context: FavoriteViewContext) => {
+  if (!isCurrentViewContext(context)) return
+  const withId = new Set(removingIds.value)
+  withId.add(itemId)
+  removingIds.value = withId
+  await nextTick()
+  await waitForRemovalAnimation()
+  const removal = removeItemFromCurrentView(itemId, context)
+  const cleared = new Set(removingIds.value)
+  cleared.delete(itemId)
+  removingIds.value = cleared
+  if (removal) void replenishAfterRemoval(removal, itemId, context)
+}
+
 const submitSearch = (query: FavoriteQuery) => {
   currentKeyword.value = query.keyword ?? ''
   void resetWithPage(1)
@@ -1085,50 +1119,58 @@ async function handleCardMove(item: SearchResultItem) {
         text: '确定',
         handler: async (data: string) => {
           if (!data) return
-          if (isOnline) {
-            let sourceRemoved = false
-            try {
-              if (data === '0') {
-                await JmcomicService.toggleAlbumFavorite(item.id, context.folderId)
-                sourceRemoved = true
-                await JmcomicService.toggleAlbumFavorite(item.id, '0')
-              } else {
-                await JmcomicService.manageFavoriteFolder('move', data, '', item.id)
-              }
-              invalidateFavoriteFolders()
-              void refreshOnlineFolderData()
-              if (context.folderId !== '0') {
-                const removal = removeItemFromCurrentView(item.id, context)
-                if (removal) void replenishAfterRemoval(removal, item.id, context)
-              }
-              await showToast('已移动', 'success')
-            } catch {
-              if (sourceRemoved) {
-                invalidateFavoriteFolders()
-                void refreshOnlineFolderData()
-                if (isCurrentViewContext(context)) void resetWithPage(1)
-              }
-              await showToast('移动失败', 'danger')
-            }
-          } else {
-            let sourceRemoved = false
-            try {
-              await OfflineFavoriteService.removeItem(context.folderId, item.id)
-              sourceRemoved = true
-              await OfflineFavoriteService.addItem(data, item)
-              const removal = removeItemFromCurrentView(item.id, context)
-              if (removal) void replenishAfterRemoval(removal, item.id, context)
-              await showToast('已移动', 'success')
-            } catch {
-              if (sourceRemoved && isCurrentViewContext(context)) void resetWithPage(1)
-              await showToast('移动失败', 'danger')
-            }
-          }
+          await alert.dismiss()
+          void performCardMove(item, context, isOnline, data)
         },
       },
     ],
   })
   await alert.present()
+}
+
+async function performCardMove(
+  item: SearchResultItem,
+  context: FavoriteViewContext,
+  isOnline: boolean,
+  targetFolderId: string,
+) {
+  if (isOnline) {
+    let sourceRemoved = false
+    try {
+      if (targetFolderId === '0') {
+        await JmcomicService.toggleAlbumFavorite(item.id, context.folderId)
+        sourceRemoved = true
+        await JmcomicService.toggleAlbumFavorite(item.id, '0')
+      } else {
+        await JmcomicService.manageFavoriteFolder('move', targetFolderId, '', item.id)
+      }
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
+      if (context.folderId !== '0') {
+        await animateRemoveFromView(item.id, context)
+      }
+      await showToast('已移动', 'success')
+    } catch {
+      if (sourceRemoved) {
+        invalidateFavoriteFolders()
+        void refreshOnlineFolderData()
+        if (isCurrentViewContext(context)) void resetWithPage(1)
+      }
+      await showToast('移动失败', 'danger')
+    }
+  } else {
+    let sourceRemoved = false
+    try {
+      await OfflineFavoriteService.removeItem(context.folderId, item.id)
+      sourceRemoved = true
+      await OfflineFavoriteService.addItem(targetFolderId, item)
+      await animateRemoveFromView(item.id, context)
+      await showToast('已移动', 'success')
+    } catch {
+      if (sourceRemoved && isCurrentViewContext(context)) void resetWithPage(1)
+      await showToast('移动失败', 'danger')
+    }
+  }
 }
 
 // --- 卡片操作：下载 ---
@@ -1183,32 +1225,39 @@ async function handleCardRemove(item: SearchResultItem) {
         role: 'destructive' as const,
         cssClass: 'danger-alert',
         handler: async () => {
-          if (isOnline) {
-            try {
-              await JmcomicService.toggleAlbumFavorite(item.id, context.folderId)
-              invalidateFavoriteFolders()
-              void refreshOnlineFolderData()
-              const removal = removeItemFromCurrentView(item.id, context)
-              if (removal) void replenishAfterRemoval(removal, item.id, context)
-              await showToast('已取消收藏', 'success')
-            } catch {
-              await showToast('操作失败', 'danger')
-            }
-          } else {
-            try {
-              await OfflineFavoriteService.removeItem(context.folderId, item.id)
-              const removal = removeItemFromCurrentView(item.id, context)
-              if (removal) void replenishAfterRemoval(removal, item.id, context)
-              await showToast('已取消收藏', 'success')
-            } catch {
-              await showToast('操作失败', 'danger')
-            }
-          }
+          await alert.dismiss()
+          void performCardRemove(item, context, isOnline)
         },
       },
     ],
   })
   await alert.present()
+}
+
+async function performCardRemove(
+  item: SearchResultItem,
+  context: FavoriteViewContext,
+  isOnline: boolean,
+) {
+  if (isOnline) {
+    try {
+      await JmcomicService.toggleAlbumFavorite(item.id, context.folderId)
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
+      await animateRemoveFromView(item.id, context)
+      await showToast('已取消收藏', 'success')
+    } catch {
+      await showToast('操作失败', 'danger')
+    }
+  } else {
+    try {
+      await OfflineFavoriteService.removeItem(context.folderId, item.id)
+      await animateRemoveFromView(item.id, context)
+      await showToast('已取消收藏', 'success')
+    } catch {
+      await showToast('操作失败', 'danger')
+    }
+  }
 }
 
 const onAddFolder = async (source: 'online' | 'offline') => {

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -423,16 +423,11 @@ const silentRefresh = () => {
           nextPageCache[page] = refreshedPages[page] ?? []
         }
       }
-      const pageOneChanged =
-        (pageCache.value[1] ?? []).length !== (nextPageCache[1] ?? []).length ||
-        (pageCache.value[1] ?? []).some((item, index) => item.id !== nextPageCache[1]?.[index]?.id)
-
       // Commit only after every cached page has completed successfully and
       // the original query context is still current.
       resultMeta.value = refreshedMeta
       pageCache.value = nextPageCache
       saveToCache()
-      if (pageOneChanged) pageAtTop.value = true
     } catch {
       if (isCurrentViewContext(context)) {
         onlineSearchCache.value = originalSearchCache

--- a/src/views/PdfImportPage.vue
+++ b/src/views/PdfImportPage.vue
@@ -265,6 +265,7 @@ import {
 import { PdfImportService } from '@/services/PdfImportService'
 import { JmcomicService, sanitizeError, showToast } from '@/services/JmcomicService'
 import { OfflineFavoriteService } from '@/services/OfflineFavoriteService'
+import { invalidateFavoritePageCache } from '@/composables/favoritePageCache'
 import FavoriteFolderPicker from '@/components/favorite/FavoriteFolderPicker.vue'
 import SearchHeaderBar from '@/components/search/SearchHeaderBar.vue'
 import type { SearchResultDisplayItem } from '@/components/search/SearchResultContainer.vue'
@@ -942,6 +943,7 @@ async function doImport(resolvedFiles: PdfFileParseItem[], folderId?: string) {
           tags: [],
         }))
       await OfflineFavoriteService.addItems(folderId, favItems)
+      if (favItems.length > 0) invalidateFavoritePageCache()
     }
     const parts = [`已导入 ${result.imported} 个 PDF`]
     if (result.duplicateCount > 0) parts.push(`${result.duplicateCount} 个已存在`)

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -647,6 +647,7 @@ async function executeFavorite(
       showToast('已收藏到在线收藏夹', 'success')
     } else {
       await OfflineFavoriteService.addItem(payload.folderId, item)
+      invalidateFavoritePageCache()
       showToast('已收藏到离线收藏夹', 'success')
     }
   } catch (e: any) {

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -75,9 +75,14 @@
         :online-folders="pickerOnlineFolders"
         :offline-folders="pickerOfflineFolders"
         :online-folder-counts="pickerOnlineFolderCounts"
+        :online-has-successful-data="onlineFolderHasSuccessfulData"
+        :online-loading="onlineFolderLoading"
+        :online-refreshing="onlineFolderRefreshing"
+        :online-error-message="onlineFolderErrorMessage"
         :hide-online="!isLoggedIn"
         @select="onPickerSelect"
         @add-folder="onPickerAddFolder"
+        @retry-online="refreshOnlineFolderData"
       />
 
       <QuickActionFab
@@ -118,9 +123,10 @@ import { JmcomicService, sanitizeError, showToast } from '@/services/JmcomicServ
 import { OfflineDownloadService } from '@/services/OfflineDownloadService'
 import { OfflineFavoriteService } from '@/services/OfflineFavoriteService'
 import { useAuth } from '@/composables/useAuth'
+import { useFavoriteFolderStore } from '@/composables/favoriteFolderStore'
+import { invalidateFavoritePageCache } from '@/composables/favoritePageCache'
 import type {
   AlbumDetail,
-  FavoriteResult,
   FolderEntry,
   SearchQuery,
   SearchResult,
@@ -473,7 +479,25 @@ const handleItemClick = (item: SearchResultItem) => {
 
 // ========== 卡片操作菜单 ==========
 
-const { isLoggedIn } = useAuth()
+const auth = useAuth()
+const isLoggedIn = auth.isLoggedIn
+const userInfo = auth.userInfo
+const accountId = computed(
+  () => userInfo?.value?.uid ?? (isLoggedIn.value ? 'authenticated' : null),
+)
+const {
+  folders: pickerOnlineFolders,
+  counts: pickerOnlineFolderCounts,
+  hasSuccessfulData: onlineFolderHasSuccessfulData,
+  isFetching: onlineFolderRefreshing,
+  errorMessage: onlineFolderErrorMessage,
+  refresh: refreshFavoriteFolders,
+  invalidate: invalidateFavoriteFolders,
+  clear: clearFavoriteFolders,
+} = useFavoriteFolderStore()
+const onlineFolderLoading = computed(
+  () => onlineFolderRefreshing.value && !onlineFolderHasSuccessfulData.value,
+)
 
 interface CardMenuState {
   item: SearchResultItem
@@ -573,47 +597,28 @@ function handleCardFavorite(item: SearchResultItem) {
 
 const showFolderPicker = ref(false)
 const pickerTargetItem = ref<SearchResultItem | null>(null)
-const pickerOnlineFolders = ref<FolderEntry[]>([])
 const pickerOfflineFolders = ref<FolderEntry[]>([])
-const pickerOnlineFolderCounts = ref<Record<string, number>>({})
 
-async function loadOnlineFolderData() {
+async function refreshOnlineFolderData() {
   if (!isLoggedIn.value) {
-    pickerOnlineFolders.value = []
+    clearFavoriteFolders()
     return
   }
-  try {
-    const result: FavoriteResult = await JmcomicService.favorites({ folderId: '0', page: 1 })
-    if (result.folderList) {
-      const entries: FolderEntry[] = []
-      const countPromises: Promise<void>[] = []
-      const counts: Record<string, number> = {}
-      for (const [id, name] of Object.entries(result.folderList)) {
-        entries.push({ id, name, count: 0 })
-        countPromises.push(
-          JmcomicService.favorites({ folderId: id, page: 1 })
-            .then((r) => {
-              counts[id] = r.totalItems
-            })
-            .catch(() => {
-              counts[id] = 0
-            }),
-        )
-      }
-      pickerOnlineFolders.value = entries
-      await Promise.all(countPromises)
-      pickerOnlineFolderCounts.value = counts
-    }
-  } catch {
-    pickerOnlineFolders.value = []
-  }
+  await refreshFavoriteFolders(accountId.value)
 }
 
-async function openFolderPicker() {
-  await OfflineFavoriteService.ensureInit()
+function openFolderPicker() {
   pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
-  void loadOnlineFolderData()
   showFolderPicker.value = true
+  void (async () => {
+    try {
+      await OfflineFavoriteService.ensureInit()
+      pickerOfflineFolders.value = OfflineFavoriteService.getFolders()
+    } catch {
+      // 离线收藏夹读取失败时保留当前缓存。
+    }
+  })()
+  void refreshOnlineFolderData()
 }
 
 async function onPickerSelect(payload: { folderId: string; source: 'online' | 'offline' }) {
@@ -636,6 +641,9 @@ async function executeFavorite(
         return
       }
       await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+      invalidateFavoritePageCache()
+      invalidateFavoriteFolders()
+      void refreshOnlineFolderData()
       showToast('已收藏到在线收藏夹', 'success')
     } else {
       await OfflineFavoriteService.addItem(payload.folderId, item)
@@ -663,7 +671,8 @@ async function onPickerAddFolder(source: 'online' | 'offline') {
               const r = await JmcomicService.manageFavoriteFolder('add', '0', name, '')
               if (r.status === 'ok') {
                 await showToast('收藏夹已创建', 'success')
-                await loadOnlineFolderData()
+                invalidateFavoriteFolders()
+                await refreshOnlineFolderData()
               } else {
                 await showToast(r.msg || '创建失败', 'danger')
               }

--- a/tests/unit/FavoriteFolderPicker.test.ts
+++ b/tests/unit/FavoriteFolderPicker.test.ts
@@ -8,6 +8,10 @@ vi.mock('@ionic/vue', () => ({
     name: 'IonIcon',
     setup: () => () => h('span'),
   }),
+  IonSpinner: defineComponent({
+    name: 'IonSpinner',
+    setup: () => () => h('span'),
+  }),
 }))
 
 vi.mock('ionicons/icons', () => ({
@@ -64,5 +68,38 @@ describe('FavoriteFolderPicker 新建入口', () => {
     expect(wrapper.find('[aria-label="新建在线收藏夹"]').exists()).toBe(true)
     expect(wrapper.find('[aria-label="新建离线收藏夹"]').exists()).toBe(true)
     expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+
+  test('首次加载立即显示加载状态而不是伪空态', () => {
+    const wrapper = mount(FavoriteFolderPicker, {
+      props: {
+        ...baseProps,
+        onlineFolders: [],
+        onlineHasSuccessfulData: false,
+        onlineLoading: true,
+        onlineRefreshing: true,
+      },
+    })
+
+    expect(wrapper.find('.picker-panel').exists()).toBe(true)
+    expect(wrapper.find('.loading-state').exists()).toBe(true)
+    expect(wrapper.find('.empty-state').exists()).toBe(false)
+  })
+
+  test('缓存刷新失败时保留旧列表并提供重试', async () => {
+    const wrapper = mount(FavoriteFolderPicker, {
+      props: {
+        ...baseProps,
+        onlineHasSuccessfulData: true,
+        onlineErrorMessage: '网络不可用',
+      },
+    })
+
+    expect(wrapper.text()).toContain('在线收藏夹')
+    expect(wrapper.text()).toContain('网络不可用')
+    expect(wrapper.find('.refresh-error').exists()).toBe(true)
+
+    await wrapper.get('.retry-btn').trigger('click')
+    expect(wrapper.emitted('retry-online')).toEqual([[]])
   })
 })

--- a/tests/unit/FavoritePage.test.ts
+++ b/tests/unit/FavoritePage.test.ts
@@ -1,0 +1,216 @@
+/* eslint-disable vue/one-component-per-file -- test-only Ionic and child-component fixtures */
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { defineComponent, h, onMounted, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  auth: null as null | { isLoggedIn: ReturnType<typeof ref>; userInfo: ReturnType<typeof ref> },
+  favorites: vi.fn(),
+  getDownloadTasks: vi.fn(),
+  getImportedPdfs: vi.fn(),
+  addDownloadProgressListener: vi.fn(),
+  showToast: vi.fn(() => Promise.resolve()),
+  router: {
+    push: vi.fn(() => Promise.resolve()),
+    back: vi.fn(),
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => mocks.router,
+}))
+
+vi.mock('@ionic/vue', () => ({
+  IonContent: defineComponent({
+    name: 'IonContent',
+    setup(_, { slots }) {
+      const elementRef = ref<HTMLElement | null>(null)
+      onMounted(() => {
+        const element = elementRef.value as HTMLElement & {
+          getScrollElement: () => Promise<HTMLElement>
+          scrollToTop: ReturnType<typeof vi.fn>
+        }
+        element.getScrollElement = async () => element
+        element.scrollToTop = vi.fn()
+      })
+      return () => h('main', { ref: elementRef }, slots.default?.())
+    },
+  }),
+  IonIcon: defineComponent({ name: 'IonIcon', setup: () => () => h('span') }),
+  IonPage: defineComponent({
+    name: 'IonPage',
+    setup(_, { slots }) {
+      return () => h('div', slots.default?.())
+    },
+  }),
+  IonRefresher: defineComponent({
+    name: 'IonRefresher',
+    setup(_, { slots }) {
+      return () => h('div', slots.default?.())
+    },
+  }),
+  IonRefresherContent: defineComponent({
+    name: 'IonRefresherContent',
+    setup: () => () => h('div'),
+  }),
+  createGesture: vi.fn(() => ({ destroy: vi.fn(), enable: vi.fn() })),
+}))
+
+vi.mock('ionicons/icons', () => ({
+  bookOutline: 'book',
+  downloadOutline: 'download',
+  ellipsisVertical: 'ellipsis',
+  folderOpenOutline: 'folder',
+  swapHorizontalOutline: 'swap',
+  trashOutline: 'trash',
+}))
+
+vi.mock('@/components/common/MenuToggleButton.vue', () => ({
+  default: defineComponent({ name: 'MenuToggleButton', setup: () => () => h('div') }),
+}))
+
+vi.mock('@/components/common/QuickActionFab.vue', () => ({
+  default: defineComponent({ name: 'QuickActionFab', setup: () => () => h('div') }),
+}))
+
+vi.mock('@/components/favorite/FavoriteSearchBar.vue', () => ({
+  default: defineComponent({
+    name: 'FavoriteSearchBar',
+    props: { query: { type: Object, required: true }, loading: Boolean },
+    setup: () => () => h('div'),
+  }),
+}))
+
+vi.mock('@/components/favorite/FavoriteSideMenu.vue', () => ({
+  default: defineComponent({
+    name: 'FavoriteSideMenu',
+    setup(_, { expose }) {
+      expose({ panelRef: null })
+      return () => h('aside')
+    },
+  }),
+}))
+
+vi.mock('@/components/common/CardContextMenu.vue', () => ({
+  default: defineComponent({ name: 'CardContextMenu', setup: () => () => h('div') }),
+}))
+
+vi.mock('@/components/search/SearchResultContainer.vue', () => ({
+  default: defineComponent({
+    name: 'SearchResultContainer',
+    props: {
+      result: { type: Object, default: null },
+      items: { type: Array, default: () => [] },
+      loading: Boolean,
+    },
+    setup(_, { expose }) {
+      expose({
+        getEntryElement: () => null,
+        getRootElement: () => null,
+      })
+      return () => h('section')
+    },
+  }),
+}))
+
+vi.mock('@/services/AppAlertService', () => ({
+  createAppAlert: vi.fn(),
+}))
+
+vi.mock('@/services/JmcomicService', () => ({
+  JmcomicService: {
+    favorites: mocks.favorites,
+    getDownloadTasks: mocks.getDownloadTasks,
+    getImportedPdfs: mocks.getImportedPdfs,
+    addDownloadProgressListener: mocks.addDownloadProgressListener,
+  },
+  sanitizeError: (_error: unknown, fallback: string) => fallback,
+  showToast: mocks.showToast,
+}))
+
+vi.mock('@/services/OfflineFavoriteService', () => ({
+  OfflineFavoriteService: {
+    ensureInit: vi.fn(() => Promise.resolve()),
+    getFolders: vi.fn(() => []),
+  },
+  offlineFolderCache: ref([]),
+  offlineTotalCount: ref(0),
+}))
+
+vi.mock('@/services/OfflineDownloadService', () => ({
+  OfflineDownloadService: { getAll: vi.fn(() => []) },
+}))
+
+vi.mock('@/services/ExportFormatService', () => ({
+  ExportFormatService: {},
+}))
+
+vi.mock('@/composables/useAuth', async () => {
+  const { ref } = await import('vue')
+  const isLoggedIn = ref(true)
+  const userInfo = ref({ uid: 'account-a' })
+  mocks.auth = { isLoggedIn, userInfo }
+  return { useAuth: () => mocks.auth }
+})
+
+import FavoritePage from '@/views/FavoritePage.vue'
+import { clearFavoriteFolderStore } from '@/composables/favoriteFolderStore'
+import { clearFavoritePageCache } from '@/composables/favoritePageCache'
+
+const item = {
+  id: 'album-1',
+  title: '在线收藏',
+  coverUrl: 'cover.jpg',
+  authors: [],
+  tags: [],
+}
+
+const onlineResult = {
+  folderName: '全部',
+  folderId: '0',
+  currentPage: 1,
+  totalItems: 1,
+  totalPages: 1,
+  content: [item],
+  folderList: { '0': '全部' },
+}
+
+let wrapper: VueWrapper | null = null
+
+beforeEach(() => {
+  clearFavoriteFolderStore()
+  clearFavoritePageCache()
+  mocks.auth!.isLoggedIn.value = true
+  mocks.auth!.userInfo.value = { uid: 'account-a' }
+  mocks.favorites.mockReset()
+  mocks.favorites.mockResolvedValue(onlineResult)
+  mocks.getDownloadTasks.mockReset()
+  mocks.getDownloadTasks.mockResolvedValue({ tasks: [] })
+  mocks.getImportedPdfs.mockReset()
+  mocks.getImportedPdfs.mockResolvedValue({ pdfs: [] })
+  mocks.addDownloadProgressListener.mockReset()
+  mocks.addDownloadProgressListener.mockResolvedValue({ remove: vi.fn(() => Promise.resolve()) })
+})
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+})
+
+describe('FavoritePage 账号切换', () => {
+  test('登出后立即清空在线结果并切换到无离线内容状态', async () => {
+    wrapper = mount(FavoritePage)
+    await flushPromises()
+
+    const results = wrapper.findComponent({ name: 'SearchResultContainer' })
+    expect(results.props('items')).toHaveLength(1)
+    expect(results.props('result')).not.toBeNull()
+
+    mocks.auth!.isLoggedIn.value = false
+    mocks.auth!.userInfo.value = null
+    await flushPromises()
+
+    expect(results.props('items')).toHaveLength(0)
+    expect(results.props('result')).toBeNull()
+  })
+})

--- a/tests/unit/FavoritePage.test.ts
+++ b/tests/unit/FavoritePage.test.ts
@@ -155,7 +155,7 @@ vi.mock('@/composables/useAuth', async () => {
 
 import FavoritePage from '@/views/FavoritePage.vue'
 import { clearFavoriteFolderStore } from '@/composables/favoriteFolderStore'
-import { clearFavoritePageCache } from '@/composables/favoritePageCache'
+import { cachedState, clearFavoritePageCache } from '@/composables/favoritePageCache'
 
 const item = {
   id: 'album-1',
@@ -163,6 +163,19 @@ const item = {
   coverUrl: 'cover.jpg',
   authors: [],
   tags: [],
+}
+
+const secondItem = {
+  id: 'album-2',
+  title: '第二页旧内容',
+  coverUrl: 'cover-2.jpg',
+  authors: [],
+  tags: [],
+}
+
+const refreshedSecondItem = {
+  ...secondItem,
+  title: '第二页新内容',
 }
 
 const onlineResult = {
@@ -212,5 +225,85 @@ describe('FavoritePage 账号切换', () => {
 
     expect(results.props('items')).toHaveLength(0)
     expect(results.props('result')).toBeNull()
+  })
+
+  test('静默刷新会请求并原子替换全部已缓存页后清除 stale', async () => {
+    const pageOneResult = {
+      ...onlineResult,
+      totalItems: 40,
+      totalPages: 2,
+    }
+    const pageTwoResult = {
+      ...pageOneResult,
+      currentPage: 2,
+      content: [refreshedSecondItem],
+    }
+    cachedState.value = {
+      accountId: 'account-a',
+      keyword: '',
+      stale: true,
+      folderSource: 'online',
+      currentFolderId: '0',
+      onlineFolderMap: { '0': '全部' },
+      onlineFolderCounts: { '0': 40 },
+      resultMeta: pageOneResult,
+      pageCache: { 1: [item], 2: [secondItem] },
+      displayMode: 'list',
+    }
+
+    const requestedPages: number[] = []
+    mocks.favorites.mockImplementation(({ folderId, page }: { folderId: string; page: number }) => {
+      if (folderId === '0') {
+        requestedPages.push(page)
+        return Promise.resolve(page === 2 ? pageTwoResult : pageOneResult)
+      }
+      return Promise.resolve({ totalItems: 40 })
+    })
+
+    wrapper = mount(FavoritePage)
+    await flushPromises()
+
+    const results = wrapper.findComponent({ name: 'SearchResultContainer' })
+    expect(requestedPages).toContain(2)
+    expect(results.props('items').map((entry: { item: { id: string } }) => entry.item.id)).toEqual([
+      'album-1',
+      'album-2',
+    ])
+    expect(
+      results.props('items').map((entry: { item: { title: string } }) => entry.item.title),
+    ).toEqual(['在线收藏', '第二页新内容'])
+    expect(cachedState.value?.stale).toBe(false)
+  })
+
+  test('静默刷新任一缓存页失败时保留原快照并继续标记 stale', async () => {
+    const pageOneResult = { ...onlineResult, totalItems: 40, totalPages: 2 }
+    cachedState.value = {
+      accountId: 'account-a',
+      keyword: '',
+      stale: true,
+      folderSource: 'online',
+      currentFolderId: '0',
+      onlineFolderMap: { '0': '全部' },
+      onlineFolderCounts: { '0': 40 },
+      resultMeta: pageOneResult,
+      pageCache: { 1: [item], 2: [secondItem] },
+      displayMode: 'list',
+    }
+
+    mocks.favorites.mockImplementation(({ folderId, page }: { folderId: string; page: number }) => {
+      if (folderId !== '0') return Promise.resolve({ totalItems: 40 })
+      if (page === 2) return Promise.reject(new Error('page 2 failed'))
+      return Promise.resolve(pageOneResult)
+    })
+
+    wrapper = mount(FavoritePage)
+    await flushPromises()
+
+    const results = wrapper.findComponent({ name: 'SearchResultContainer' })
+    expect(results.props('items').map((entry: { item: { id: string } }) => entry.item.id)).toEqual([
+      'album-1',
+      'album-2',
+    ])
+    expect(cachedState.value?.stale).toBe(true)
   })
 })

--- a/tests/unit/FavoriteSideMenu.test.ts
+++ b/tests/unit/FavoriteSideMenu.test.ts
@@ -8,6 +8,10 @@ vi.mock('@ionic/vue', () => ({
     name: 'IonIcon',
     setup: () => () => h('span'),
   }),
+  IonSpinner: defineComponent({
+    name: 'IonSpinner',
+    setup: () => () => h('span'),
+  }),
 }))
 
 vi.mock('@/components/common/CardContextMenu.vue', () => ({
@@ -102,6 +106,23 @@ describe('FavoriteSideMenu 展示模式', () => {
 
     expect(wrapper.emitted('update:paneOpen')).toEqual([[false]])
     expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  test('首次在线列表加载显示 loading 而不是空态', () => {
+    const wrapper = mount(FavoriteSideMenu, {
+      props: {
+        ...baseProps,
+        modelValue: true,
+        onlineFolders: [],
+        onlineHasSuccessfulData: false,
+        onlineLoading: true,
+        onlineRefreshing: true,
+      },
+    })
+
+    expect(wrapper.find('.loading-state').exists()).toBe(true)
+    expect(wrapper.find('.empty-state').exists()).toBe(false)
     wrapper.unmount()
   })
 })

--- a/tests/unit/favoriteFolderStore.test.ts
+++ b/tests/unit/favoriteFolderStore.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  favorites: vi.fn(),
+}))
+
+vi.mock('@/services/JmcomicService', () => ({
+  JmcomicService: { favorites: mocks.favorites },
+  sanitizeError: (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback,
+}))
+
+import {
+  clearFavoriteFolderStore,
+  favoriteFolderState,
+  invalidateFavoriteFolders,
+  refreshFavoriteFolders,
+} from '@/composables/favoriteFolderStore'
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const folderResult = (folderList: Record<string, string>) => ({
+  folderName: '全部',
+  folderId: '0',
+  currentPage: 1,
+  totalItems: 0,
+  totalPages: 1,
+  content: [],
+  folderList,
+})
+
+beforeEach(() => {
+  clearFavoriteFolderStore()
+  mocks.favorites.mockReset()
+})
+
+describe('favoriteFolderStore', () => {
+  test('先展示 loading，主列表成功后独立更新计数', async () => {
+    const main = deferred<ReturnType<typeof folderResult>>()
+    mocks.favorites.mockImplementation(({ folderId }: { folderId: string }) => {
+      if (folderId === '0') return main.promise
+      if (folderId === 'a') return Promise.resolve({ totalItems: 3 })
+      return Promise.reject(new Error('count failed'))
+    })
+
+    const request = refreshFavoriteFolders('account-a')
+    expect(favoriteFolderState.isFetching).toBe(true)
+    expect(favoriteFolderState.folders).toEqual([])
+    expect(favoriteFolderState.hasSuccessfulData).toBe(false)
+
+    main.resolve(folderResult({ a: '收藏夹 A', b: '收藏夹 B' }))
+    await request
+
+    expect(favoriteFolderState.isFetching).toBe(false)
+    expect(favoriteFolderState.hasSuccessfulData).toBe(true)
+    expect(favoriteFolderState.folders.map((folder) => folder.name)).toEqual([
+      '收藏夹 A',
+      '收藏夹 B',
+    ])
+    expect(favoriteFolderState.counts).toEqual({ a: 3 })
+  })
+
+  test('同一账号的并发刷新复用请求，账号变化会丢弃旧响应', async () => {
+    const accountA = deferred<ReturnType<typeof folderResult>>()
+    const accountB = deferred<ReturnType<typeof folderResult>>()
+    mocks.favorites.mockImplementation(({ folderId }: { folderId: string }) => {
+      if (folderId !== '0') return Promise.resolve({ totalItems: 1 })
+      if (favoriteFolderState.accountId === 'account-a') return accountA.promise
+      return accountB.promise
+    })
+
+    const first = refreshFavoriteFolders('account-a')
+    expect(refreshFavoriteFolders('account-a')).toBe(first)
+    const oldRequest = first
+    const newRequest = refreshFavoriteFolders('account-b')
+
+    accountB.resolve(folderResult({ b: '账号 B' }))
+    await newRequest
+    expect(favoriteFolderState.accountId).toBe('account-b')
+    expect(favoriteFolderState.folders.map((folder) => folder.name)).toEqual(['账号 B'])
+
+    accountA.resolve(folderResult({ a: '账号 A' }))
+    await oldRequest
+    expect(favoriteFolderState.accountId).toBe('account-b')
+    expect(favoriteFolderState.folders.map((folder) => folder.name)).toEqual(['账号 B'])
+  })
+
+  test('刷新失败时保留旧列表并提供错误，登出清空缓存', async () => {
+    mocks.favorites.mockResolvedValueOnce(folderResult({ a: '旧列表' }))
+    mocks.favorites.mockResolvedValueOnce({ totalItems: 2 })
+    await refreshFavoriteFolders('account-a')
+
+    invalidateFavoriteFolders()
+    mocks.favorites.mockRejectedValueOnce(new Error('网络不可用'))
+    await refreshFavoriteFolders('account-a')
+
+    expect(favoriteFolderState.folders.map((folder) => folder.name)).toEqual(['旧列表'])
+    expect(favoriteFolderState.hasSuccessfulData).toBe(true)
+    expect(favoriteFolderState.errorMessage).toBe('网络不可用')
+
+    clearFavoriteFolderStore()
+    expect(favoriteFolderState.accountId).toBeNull()
+    expect(favoriteFolderState.folders).toEqual([])
+    expect(favoriteFolderState.hasSuccessfulData).toBe(false)
+  })
+})

--- a/tests/unit/favoriteFolderStore.test.ts
+++ b/tests/unit/favoriteFolderStore.test.ts
@@ -111,4 +111,20 @@ describe('favoriteFolderStore', () => {
     expect(favoriteFolderState.folders).toEqual([])
     expect(favoriteFolderState.hasSuccessfulData).toBe(false)
   })
+
+  test('已有计数在后续计数请求失败时被隐藏', async () => {
+    mocks.favorites.mockResolvedValueOnce(folderResult({ a: '收藏夹 A' }))
+    mocks.favorites.mockResolvedValueOnce({ totalItems: 4 })
+    await refreshFavoriteFolders('account-a')
+    expect(favoriteFolderState.counts).toEqual({ a: 4 })
+
+    invalidateFavoriteFolders()
+    mocks.favorites.mockResolvedValueOnce(folderResult({ a: '收藏夹 A' }))
+    mocks.favorites.mockRejectedValueOnce(new Error('count failed'))
+    await refreshFavoriteFolders('account-a')
+
+    expect(favoriteFolderState.counts).toEqual({})
+    expect(favoriteFolderState.folders[0]?.count).toBe(0)
+    expect(favoriteFolderState.errorMessage).toBe('')
+  })
 })


### PR DESCRIPTION
## 变更

- 新增按账号隔离的模块级收藏夹列表 store，复用文件夹名称缓存，主请求成功后立即展示列表，并在后台并发刷新各文件夹计数；单项计数失败时删除该计数，不显示过期值或伪造 `0`。
- 详情、搜索、分类和批量解析页的收藏夹选择器共享同一份缓存；首次无缓存时立即显示选择器和 loading，已有结果时保留旧列表并在标题行显示与关于页一致的 circular spinner。
- 收藏页窄屏 overlay 与宽屏 pane 均在实际打开和激活时后台刷新，增加首次加载、刷新失败保留旧列表和重试状态；登录账号变化、登出和晚到响应均受到隔离保护。
- 收藏页取消/移动成功后只局部移除卡片、更新总数并后台补齐受影响分页；“全部收藏”中的在线移动保留卡片，查询切换和分页请求增加代次保护。
- 所有在线/离线收藏关系变更入口都会标记收藏页快照失效；静默刷新会按同一查询上下文刷新全部已缓存页，仅完整成功后原子替换并清除 `stale`。
- 补充收藏页登出、多页静默刷新成功/失败、共享 store、选择器和侧栏回归测试。

## 验证

- `NODE_OPTIONS=--localstorage-file=/tmp/jq-viewer-astra-71-vitest-localstorage npm run test:unit`（55 个测试文件、317 个测试通过）
- `npm run lint`
- `npm run check:version`
- 改动文件 `prettier --check`
- `git diff --check`

## 限制

- 本地 `npm run typecheck` 与 `npm run build` 仍被基线 `src/services/PdfReaderService.ts:67` 的 `isEvalSupported` 类型错误阻断；本 PR 未修改该范围外问题。
- 仓库完整 `npm run format:check` 仍报告基线 `src/services/JmcomicTypes.ts` 与 `src/services/PdfReaderService.ts` 的格式问题；本次改动文件格式检查通过。
- 当前环境的 `npm ci` 受锁文件远程 tarball 策略阻断，验证依赖使用同一 `package.json` 通过公开 npm registry 安装，未修改 `package-lock.json`。

Closes #134
Refs ASTRA-71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 收藏夹加载、刷新和错误状态更加清晰，支持加载占位、错误提示及一键重试。
  - 刷新失败时保留已有收藏夹列表，并提示当前显示的是上次结果。
  - 收藏夹数据与页面缓存自动同步，登录、登出及账号切换时状态更可靠。
  - 收藏条目移除支持淡出动画，并可自动补充后续内容。
- **问题修复**
  - 改善异步刷新和账号切换时的数据一致性，避免旧数据覆盖当前内容。
  - 离线收藏操作失败时保留当前列表并显示错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->