### PR TITLE
fix(favorite): 修复在线收藏夹选择不生效

### DIFF
--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -94,11 +94,27 @@ export const JmcomicService = {
 
   favoriteToFolder(id: string, folderId: string = '0') {
     return (async () => {
-      await native.toggleAlbumFavorite({ id, folderId: '0' })
-      if (folderId !== '0') {
+      const moveToFolder = async () => {
         const result = await native.manageFavoriteFolder({ type: 'move', folderId, albumId: id })
         if (result.status !== 'ok') {
           throw new Error(result.msg || '移动到在线收藏夹失败')
+        }
+      }
+
+      const current = await native.getAlbum({ id })
+      if (current.isFavorite) {
+        if (folderId !== '0') await moveToFolder()
+        return { success: true }
+      }
+
+      await native.toggleAlbumFavorite({ id, folderId: '0' })
+      if (folderId !== '0') {
+        try {
+          await moveToFolder()
+        } catch (error) {
+          const reconciled = await native.getAlbum({ id })
+          if (!reconciled.isFavorite) throw error
+          await moveToFolder()
         }
       }
       return { success: true }

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -92,6 +92,19 @@ export const JmcomicService = {
     return native.toggleAlbumFavorite({ id, folderId })
   },
 
+  favoriteToFolder(id: string, folderId: string = '0') {
+    return (async () => {
+      await native.toggleAlbumFavorite({ id, folderId: '0' })
+      if (folderId !== '0') {
+        const result = await native.manageFavoriteFolder({ type: 'move', folderId, albumId: id })
+        if (result.status !== 'ok') {
+          throw new Error(result.msg || '移动到在线收藏夹失败')
+        }
+      }
+      return { success: true }
+    })()
+  },
+
   manageFavoriteFolder(
     type: string,
     folderId: string = '0',

--- a/src/views/AlbumDetailPage.vue
+++ b/src/views/AlbumDetailPage.vue
@@ -366,7 +366,7 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
   actionBusy.favorite = true
   try {
     if (payload.source === 'online') {
-      await JmcomicService.toggleAlbumFavorite(albumId.value, payload.folderId)
+      await JmcomicService.favoriteToFolder(albumId.value, payload.folderId)
       invalidateFavoritePageCache()
       invalidateFavoriteFolders()
       void refreshOnlineFolderData()

--- a/src/views/BatchParsePage.vue
+++ b/src/views/BatchParsePage.vue
@@ -1017,7 +1017,7 @@ async function executeSingleFavorite(
   try {
     if (payload.source === 'online') {
       const album = await JmcomicService.getAlbum(item.id)
-      if (album?.isFavorite) {
+      if (album?.isFavorite && payload.folderId === '0') {
         showToast('该本子已在收藏夹中', 'medium')
         return
       }

--- a/src/views/BatchParsePage.vue
+++ b/src/views/BatchParsePage.vue
@@ -1021,7 +1021,7 @@ async function executeSingleFavorite(
         showToast('该本子已在收藏夹中', 'medium')
         return
       }
-      await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+      await JmcomicService.favoriteToFolder(item.id, payload.folderId)
       invalidateFavoritePageCache()
       invalidateFavoriteFolders()
       void refreshOnlineFolderData()
@@ -1098,7 +1098,7 @@ async function onPickerSelect(payload: { folderId: string; source: 'online' | 'o
       const failed: string[] = []
       for (const item of toAdd) {
         try {
-          await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+          await JmcomicService.favoriteToFolder(item.id, payload.folderId)
           ok++
         } catch {
           failed.push(item.title || item.id)

--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -539,7 +539,7 @@ async function executeFavorite(
         showToast('该本子已在收藏夹中', 'medium')
         return
       }
-      await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+      await JmcomicService.favoriteToFolder(item.id, payload.folderId)
       invalidateFavoritePageCache()
       invalidateFavoriteFolders()
       void refreshOnlineFolderData()

--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -535,7 +535,7 @@ async function executeFavorite(
   try {
     if (payload.source === 'online') {
       const album = await JmcomicService.getAlbum(item.id)
-      if (album.isFavorite) {
+      if (album.isFavorite && payload.folderId === '0') {
         showToast('该本子已在收藏夹中', 'medium')
         return
       }

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -636,7 +636,7 @@ async function executeFavorite(
   try {
     if (payload.source === 'online') {
       const album = await JmcomicService.getAlbum(item.id)
-      if (album.isFavorite) {
+      if (album.isFavorite && payload.folderId === '0') {
         showToast('该本子已在收藏夹中', 'medium')
         return
       }

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -640,7 +640,7 @@ async function executeFavorite(
         showToast('该本子已在收藏夹中', 'medium')
         return
       }
-      await JmcomicService.toggleAlbumFavorite(item.id, payload.folderId)
+      await JmcomicService.favoriteToFolder(item.id, payload.folderId)
       invalidateFavoritePageCache()
       invalidateFavoriteFolders()
       void refreshOnlineFolderData()

--- a/tests/unit/BatchParsePage.test.ts
+++ b/tests/unit/BatchParsePage.test.ts
@@ -124,6 +124,7 @@ vi.mock('@/services/JmcomicService', () => ({
     getAlbum: mocks.getAlbum,
     favorites: vi.fn(),
     toggleAlbumFavorite: vi.fn(),
+    favoriteToFolder: vi.fn(),
     getPhoto: vi.fn(),
     downloadChapter: vi.fn(),
     manageFavoriteFolder: vi.fn(),

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   retryImage: vi.fn(),
   getBrowseHistory: vi.fn(),
   getBrowseHistoryOverview: vi.fn(),
+  toggleAlbumFavorite: vi.fn(),
+  manageFavoriteFolder: vi.fn(),
 }))
 
 vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
@@ -13,6 +15,8 @@ vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
     retryImage: mocks.retryImage,
     getBrowseHistory: mocks.getBrowseHistory,
     getBrowseHistoryOverview: mocks.getBrowseHistoryOverview,
+    toggleAlbumFavorite: mocks.toggleAlbumFavorite,
+    manageFavoriteFolder: mocks.manageFavoriteFolder,
   },
 }))
 
@@ -94,6 +98,44 @@ describe('JmcomicService.retryImage', () => {
 
     await expect(JmcomicService.retryImage('chapter-1', image)).resolves.toEqual({ success: true })
     expect(mocks.retryImage).toHaveBeenCalledWith({ photoId: 'chapter-1', image })
+  })
+})
+
+describe('JmcomicService.favoriteToFolder', () => {
+  beforeEach(() => {
+    mocks.toggleAlbumFavorite.mockReset()
+    mocks.manageFavoriteFolder.mockReset()
+    mocks.toggleAlbumFavorite.mockResolvedValue({ success: true })
+    mocks.manageFavoriteFolder.mockResolvedValue({ status: 'ok', msg: '' })
+  })
+
+  test('选择具体收藏夹时先收藏再移动', async () => {
+    await expect(JmcomicService.favoriteToFolder('album-1', 'folder-1')).resolves.toEqual({
+      success: true,
+    })
+
+    expect(mocks.toggleAlbumFavorite).toHaveBeenCalledWith({ id: 'album-1', folderId: '0' })
+    expect(mocks.manageFavoriteFolder).toHaveBeenCalledWith({
+      type: 'move',
+      folderId: 'folder-1',
+      albumId: 'album-1',
+    })
+    expect(mocks.toggleAlbumFavorite.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.manageFavoriteFolder.mock.invocationCallOrder[0],
+    )
+  })
+
+  test('选择全部时只执行收藏', async () => {
+    await JmcomicService.favoriteToFolder('album-1', '0')
+
+    expect(mocks.toggleAlbumFavorite).toHaveBeenCalledWith({ id: 'album-1', folderId: '0' })
+    expect(mocks.manageFavoriteFolder).not.toHaveBeenCalled()
+  })
+
+  test('移动接口返回失败状态时拒绝成功结果', async () => {
+    mocks.manageFavoriteFolder.mockResolvedValue({ status: 'fail', msg: '移动失败' })
+
+    await expect(JmcomicService.favoriteToFolder('album-1', 'folder-1')).rejects.toThrow('移动失败')
   })
 })
 

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   retryImage: vi.fn(),
   getBrowseHistory: vi.fn(),
   getBrowseHistoryOverview: vi.fn(),
+  getAlbum: vi.fn(),
   toggleAlbumFavorite: vi.fn(),
   manageFavoriteFolder: vi.fn(),
 }))
@@ -15,6 +16,7 @@ vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
     retryImage: mocks.retryImage,
     getBrowseHistory: mocks.getBrowseHistory,
     getBrowseHistoryOverview: mocks.getBrowseHistoryOverview,
+    getAlbum: mocks.getAlbum,
     toggleAlbumFavorite: mocks.toggleAlbumFavorite,
     manageFavoriteFolder: mocks.manageFavoriteFolder,
   },
@@ -103,8 +105,10 @@ describe('JmcomicService.retryImage', () => {
 
 describe('JmcomicService.favoriteToFolder', () => {
   beforeEach(() => {
+    mocks.getAlbum.mockReset()
     mocks.toggleAlbumFavorite.mockReset()
     mocks.manageFavoriteFolder.mockReset()
+    mocks.getAlbum.mockResolvedValue({ isFavorite: false })
     mocks.toggleAlbumFavorite.mockResolvedValue({ success: true })
     mocks.manageFavoriteFolder.mockResolvedValue({ status: 'ok', msg: '' })
   })
@@ -132,10 +136,39 @@ describe('JmcomicService.favoriteToFolder', () => {
     expect(mocks.manageFavoriteFolder).not.toHaveBeenCalled()
   })
 
+  test('已收藏时只移动而不再次切换', async () => {
+    mocks.getAlbum.mockResolvedValue({ isFavorite: true })
+
+    await JmcomicService.favoriteToFolder('album-1', 'folder-1')
+
+    expect(mocks.toggleAlbumFavorite).not.toHaveBeenCalled()
+    expect(mocks.manageFavoriteFolder).toHaveBeenCalledWith({
+      type: 'move',
+      folderId: 'folder-1',
+      albumId: 'album-1',
+    })
+  })
+
   test('移动接口返回失败状态时拒绝成功结果', async () => {
     mocks.manageFavoriteFolder.mockResolvedValue({ status: 'fail', msg: '移动失败' })
 
     await expect(JmcomicService.favoriteToFolder('album-1', 'folder-1')).rejects.toThrow('移动失败')
+  })
+
+  test('移动失败但对账确认已收藏时只重试移动', async () => {
+    mocks.manageFavoriteFolder
+      .mockResolvedValueOnce({ status: 'fail', msg: '暂时失败' })
+      .mockResolvedValueOnce({ status: 'ok', msg: '' })
+    mocks.getAlbum
+      .mockResolvedValueOnce({ isFavorite: false })
+      .mockResolvedValueOnce({ isFavorite: true })
+
+    await expect(JmcomicService.favoriteToFolder('album-1', 'folder-1')).resolves.toEqual({
+      success: true,
+    })
+
+    expect(mocks.toggleAlbumFavorite).toHaveBeenCalledTimes(1)
+    expect(mocks.manageFavoriteFolder).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/tests/unit/SearchPage.test.ts
+++ b/tests/unit/SearchPage.test.ts
@@ -95,6 +95,7 @@ vi.mock('@/services/JmcomicService', () => ({
     getPhoto: vi.fn(),
     downloadChapter: vi.fn(),
     toggleAlbumFavorite: vi.fn(),
+    favoriteToFolder: vi.fn(),
   },
   sanitizeError: vi.fn((error: unknown, fallback: string) => String(error || fallback)),
   showToast: mocks.showToast,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持将在线专辑直接收藏到指定收藏夹。
  - 选择非默认收藏夹时，收藏完成后会自动移动至目标文件夹。
  - 移动失败时提供明确的错误提示。

- **问题修复**
  - 优化详情、批量解析、分类和搜索页面的在线收藏行为，避免重复切换收藏状态。

- **测试**
  - 增加指定收藏夹、默认收藏夹及操作失败场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->