### PR TITLE
fix(search): limit paginated result cache window

### DIFF
--- a/src/composables/searchPageContextCache.ts
+++ b/src/composables/searchPageContextCache.ts
@@ -52,25 +52,19 @@ const cloneSnapshot = (snapshot: SearchPageContextSnapshot): SearchPageContextSn
   resultMeta: { ...snapshot.resultMeta, content: snapshot.resultMeta.content.map(cloneItem) },
 })
 
-export const toSearchPageContextQuery = (query: SearchQuery): SearchPageContextQuery => ({
-  keyword: query.keyword ?? '',
+export const toSearchPageContextQuery = (
+  query: Pick<SearchQuery, 'keyword' | 'orderBy' | 'time' | 'searchMainTag'>,
+): SearchPageContextQuery => ({
+  keyword: query.keyword?.trim() ?? '',
   orderBy: query.orderBy,
   time: query.time,
   searchMainTag: query.searchMainTag,
 })
 
 export const createSearchPageContextKey = (query: SearchQuery | SearchPageContextQuery) => {
-  const contextQuery: SearchPageContextQuery =
-    'page' in query
-      ? toSearchPageContextQuery(query)
-      : {
-          keyword: query.keyword ?? '',
-          orderBy: query.orderBy,
-          time: query.time,
-          searchMainTag: query.searchMainTag,
-        }
+  const contextQuery = toSearchPageContextQuery(query)
   return JSON.stringify([
-    contextQuery.keyword.trim(),
+    contextQuery.keyword,
     contextQuery.orderBy,
     contextQuery.time,
     contextQuery.searchMainTag,

--- a/src/composables/searchPageContextCache.ts
+++ b/src/composables/searchPageContextCache.ts
@@ -1,0 +1,149 @@
+import type { SearchQuery, SearchResult, SearchResultItem } from '@/services/JmcomicTypes'
+
+export const SEARCH_PAGE_WINDOW_SIZE = 5
+export const SEARCH_PAGE_CONTEXT_CACHE_LIMIT = 3
+
+export type SearchPageContextQuery = {
+  keyword: string
+  orderBy: string
+  time: string
+  searchMainTag: number
+}
+
+export interface SearchPageContextSnapshot {
+  query: SearchPageContextQuery
+  pageCache: Record<number, SearchResultItem[]>
+  resultMeta: SearchResult
+  routePage: number
+  anchorEntryKey: string | null
+  anchorOffset: number | null
+  scrollTop: number
+  displayMode: 'list' | 'grid'
+  generation: number
+  savedAt: number
+}
+
+const contextCache = new Map<string, SearchPageContextSnapshot>()
+let nextContextGeneration = 0
+
+export const allocateSearchPageContextGeneration = () => {
+  nextContextGeneration += 1
+  return nextContextGeneration
+}
+
+const cloneItem = (item: SearchResultItem): SearchResultItem => ({
+  ...item,
+  authors: item.authors.slice(),
+  tags: item.tags.slice(),
+})
+
+const clonePageCache = (pageCache: Record<number, SearchResultItem[]>) => {
+  const cloned: Record<number, SearchResultItem[]> = {}
+  for (const [page, items] of Object.entries(pageCache)) {
+    cloned[Number(page)] = items.map(cloneItem)
+  }
+  return cloned
+}
+
+const cloneSnapshot = (snapshot: SearchPageContextSnapshot): SearchPageContextSnapshot => ({
+  ...snapshot,
+  query: { ...snapshot.query },
+  pageCache: clonePageCache(snapshot.pageCache),
+  resultMeta: { ...snapshot.resultMeta, content: snapshot.resultMeta.content.map(cloneItem) },
+})
+
+export const toSearchPageContextQuery = (query: SearchQuery): SearchPageContextQuery => ({
+  keyword: query.keyword ?? '',
+  orderBy: query.orderBy,
+  time: query.time,
+  searchMainTag: query.searchMainTag,
+})
+
+export const createSearchPageContextKey = (query: SearchQuery | SearchPageContextQuery) => {
+  const contextQuery: SearchPageContextQuery =
+    'page' in query
+      ? toSearchPageContextQuery(query)
+      : {
+          keyword: query.keyword ?? '',
+          orderBy: query.orderBy,
+          time: query.time,
+          searchMainTag: query.searchMainTag,
+        }
+  return JSON.stringify([
+    contextQuery.keyword.trim(),
+    contextQuery.orderBy,
+    contextQuery.time,
+    contextQuery.searchMainTag,
+  ])
+}
+
+export type SearchPageWindowDirection = 'reset' | 'append' | 'prepend'
+
+export interface SearchPageWindowCommit {
+  pageCache: Record<number, SearchResultItem[]>
+  pages: number[]
+  evictedPages: number[]
+}
+
+export const commitSearchPageWindow = (
+  pageCache: Record<number, SearchResultItem[]>,
+  page: number,
+  content: SearchResultItem[],
+  direction: SearchPageWindowDirection,
+): SearchPageWindowCommit => {
+  const nextCache: Record<number, SearchResultItem[]> =
+    direction === 'reset' ? {} : { ...pageCache }
+  if (direction !== 'reset' && nextCache[page]) {
+    return {
+      pageCache: nextCache,
+      pages: Object.keys(nextCache)
+        .map(Number)
+        .sort((a, b) => a - b),
+      evictedPages: [],
+    }
+  }
+  nextCache[page] = content
+  const pages = Object.keys(nextCache)
+    .map(Number)
+    .sort((a, b) => a - b)
+  const evictedPages: number[] = []
+  while (pages.length > SEARCH_PAGE_WINDOW_SIZE) {
+    const evicted = direction === 'prepend' ? pages.pop() : pages.shift()
+    if (evicted === undefined) break
+    evictedPages.push(evicted)
+    delete nextCache[evicted]
+  }
+  return { pageCache: nextCache, pages, evictedPages }
+}
+
+export const saveSearchPageContext = (snapshot: SearchPageContextSnapshot) => {
+  const key = createSearchPageContextKey(snapshot.query)
+  const existing = contextCache.get(key)
+  if (existing && snapshot.generation < existing.generation) return
+  contextCache.delete(key)
+  contextCache.set(key, cloneSnapshot(snapshot))
+  while (contextCache.size > SEARCH_PAGE_CONTEXT_CACHE_LIMIT) {
+    const oldestKey = contextCache.keys().next().value as string | undefined
+    if (!oldestKey) break
+    contextCache.delete(oldestKey)
+  }
+}
+
+export const getSearchPageContext = (query: SearchQuery | SearchPageContextQuery) => {
+  const key = createSearchPageContextKey(query)
+  const snapshot = contextCache.get(key)
+  if (!snapshot) return null
+  contextCache.delete(key)
+  contextCache.set(key, snapshot)
+  return cloneSnapshot(snapshot)
+}
+
+export const clearSearchPageContext = (query: SearchQuery | SearchPageContextQuery) => {
+  contextCache.delete(createSearchPageContextKey(query))
+}
+
+export const clearSearchPageContextCache = () => {
+  contextCache.clear()
+}
+
+export const getSearchPageContextCacheSize = () => contextCache.size

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -198,6 +198,7 @@ const routeAnchorPage = ref(currentQuery.value.page ?? 1)
 
 const pageCache = ref<Record<number, SearchResultItem[]>>({})
 const savedScrollTop = ref(0)
+let snapshotSavedOnDeactivated = false
 let queryGeneration = allocateSearchPageContextGeneration()
 let activeContextQuery = toSearchPageContextQuery({
   keyword: '',
@@ -354,7 +355,9 @@ const captureSnapshot = (): SearchPageContextSnapshot | null => {
 
 const saveContextSnapshot = () => {
   const snapshot = captureSnapshot()
-  if (snapshot) saveSearchPageContext(snapshot)
+  if (!snapshot) return false
+  saveSearchPageContext(snapshot)
+  return true
 }
 
 const restoreContextSnapshot = async (snapshot: SearchPageContextSnapshot, generation: number) => {
@@ -392,6 +395,7 @@ const resetWithPage = async (
   const targetPage = query.page ?? 1
   const trimmedKeyword = (query.keyword ?? '').trim()
   const context = toSearchPageContextQuery(query)
+  if (!contextQueryEqual(context, activeContextQuery)) saveContextSnapshot()
   const generation = allocateSearchPageContextGeneration()
   queryGeneration = generation
   activeContextQuery = context
@@ -929,12 +933,15 @@ watch(
 
 onDeactivated(() => {
   savedScrollTop.value = scrollElementRef.value?.scrollTop ?? 0
-  saveContextSnapshot()
+  snapshotSavedOnDeactivated = saveContextSnapshot()
 })
 
-onBeforeUnmount(() => saveContextSnapshot())
+onBeforeUnmount(() => {
+  if (!snapshotSavedOnDeactivated) saveContextSnapshot()
+})
 
 onActivated(async () => {
+  snapshotSavedOnDeactivated = false
   await nextTick()
   const scrollEl = scrollElementRef.value ?? (await resolveScrollElement())
   if (scrollEl && savedScrollTop.value > 0) {

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -97,7 +97,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onActivated, onDeactivated, onMounted, ref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  ref,
+  watch,
+} from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { IonContent, IonIcon, IonPage } from '@ionic/vue'
 import { createAppAlert } from '@/services/AppAlertService'
@@ -125,6 +134,16 @@ import { OfflineFavoriteService } from '@/services/OfflineFavoriteService'
 import { useAuth } from '@/composables/useAuth'
 import { useFavoriteFolderStore } from '@/composables/favoriteFolderStore'
 import { invalidateFavoritePageCache } from '@/composables/favoritePageCache'
+import {
+  allocateSearchPageContextGeneration,
+  clearSearchPageContext,
+  commitSearchPageWindow,
+  getSearchPageContext,
+  saveSearchPageContext,
+  SEARCH_PAGE_WINDOW_SIZE,
+  toSearchPageContextQuery,
+  type SearchPageContextSnapshot,
+} from '@/composables/searchPageContextCache'
 import type {
   AlbumDetail,
   FolderEntry,
@@ -175,7 +194,17 @@ const currentQuery = computed<SearchQuery>(() => ({
   page: readNumber(route.query.page, 1),
 }))
 
+const routeAnchorPage = ref(currentQuery.value.page ?? 1)
+
 const pageCache = ref<Record<number, SearchResultItem[]>>({})
+const savedScrollTop = ref(0)
+let queryGeneration = allocateSearchPageContextGeneration()
+let activeContextQuery = toSearchPageContextQuery({
+  keyword: '',
+  orderBy: 'mr',
+  time: 'a',
+  searchMainTag: 0,
+})
 
 const loadedPages = computed(() =>
   Object.keys(pageCache.value)
@@ -228,6 +257,51 @@ const resolveScrollElement = async () => {
   return scrollElementRef.value
 }
 
+const contextQueryEqual = (left: typeof activeContextQuery, right: typeof activeContextQuery) =>
+  left.keyword === right.keyword &&
+  left.orderBy === right.orderBy &&
+  left.time === right.time &&
+  left.searchMainTag === right.searchMainTag
+
+const isCurrentGeneration = (generation: number, query = activeContextQuery) =>
+  generation === queryGeneration && contextQueryEqual(query, activeContextQuery)
+
+const updateRoutePage = (page: number) => {
+  routeAnchorPage.value = page
+  const nextQuery = { ...currentQuery.value, page }
+  lastSearchedQuery.value = nextQuery
+  if (readNumber(route.query.page, 1) === page) return
+  void router.replace({
+    path: '/search',
+    query: {
+      keyword: nextQuery.keyword ?? '',
+      orderBy: nextQuery.orderBy,
+      time: nextQuery.time,
+      searchMainTag: String(nextQuery.searchMainTag),
+      page: String(page),
+    },
+  })
+}
+
+const commitPage = (
+  page: number,
+  content: SearchResultItem[],
+  direction: 'reset' | 'append' | 'prepend',
+) => {
+  const { pageCache: nextCache, pages } = commitSearchPageWindow(
+    pageCache.value,
+    page,
+    content,
+    direction,
+  )
+  pageCache.value = nextCache
+  const routePage = routeAnchorPage.value
+  if (!pages.includes(routePage)) {
+    const replacement = direction === 'prepend' ? (pages[0] ?? page) : (pages.at(-1) ?? page)
+    updateRoutePage(replacement)
+  }
+}
+
 const maybeLoadNextAfterRender = async () => {
   if (!canLoadNext.value || loadingNext.value || initialLoading.value) {
     return
@@ -253,26 +327,108 @@ const fetchPage = async (query: SearchQuery, page: number) => {
     : await JmcomicService.categories(nextQuery)
 }
 
-const resetWithPage = async (query: SearchQuery) => {
+const captureSnapshot = (): SearchPageContextSnapshot | null => {
+  if (!resultMeta.value || !Object.keys(pageCache.value).length) return null
+  const firstItem = displayItems.value[0]
+  const anchorEntryKey = firstItem
+    ? `${firstItem.page}-${firstItem.indexInPage}-${firstItem.item.id}`
+    : null
+  const scrollTop = scrollElementRef.value?.scrollTop ?? 0
+  const anchorOffset = anchorEntryKey
+    ? (resultContainerRef.value?.getEntryElement?.(anchorEntryKey)?.getBoundingClientRect().top ??
+      null)
+    : null
+  return {
+    query: { ...activeContextQuery },
+    pageCache: { ...pageCache.value },
+    resultMeta: resultMeta.value,
+    routePage: routeAnchorPage.value,
+    anchorEntryKey,
+    anchorOffset,
+    scrollTop,
+    displayMode: displayMode.value,
+    generation: queryGeneration,
+    savedAt: Date.now(),
+  }
+}
+
+const saveContextSnapshot = () => {
+  const snapshot = captureSnapshot()
+  if (snapshot) saveSearchPageContext(snapshot)
+}
+
+const restoreContextSnapshot = async (snapshot: SearchPageContextSnapshot, generation: number) => {
+  if (!isCurrentGeneration(generation, snapshot.query)) return false
+  activeContextQuery = { ...snapshot.query }
+  routeAnchorPage.value = snapshot.routePage
+  savedScrollTop.value = snapshot.scrollTop
+  resultMeta.value = snapshot.resultMeta
+  pageCache.value = snapshot.pageCache
+  displayMode.value = snapshot.displayMode
+  errorMessage.value = ''
+  await nextTick()
+  if (!isCurrentGeneration(generation, snapshot.query)) return false
+  const scrollEl = await resolveScrollElement()
+  if (!isCurrentGeneration(generation, snapshot.query)) return false
+  pageAtTop.value = snapshot.scrollTop <= 2
+  if (!scrollEl) return true
+  scrollEl.scrollTop = snapshot.scrollTop
+  if (snapshot.anchorEntryKey && snapshot.anchorOffset !== null) {
+    const restoredTop = resultContainerRef.value
+      ?.getEntryElement?.(snapshot.anchorEntryKey)
+      ?.getBoundingClientRect().top
+    if (restoredTop !== undefined && restoredTop !== null) {
+      scrollEl.scrollTop += restoredTop - snapshot.anchorOffset
+    }
+  }
+  pageAtTop.value = snapshot.scrollTop <= 2
+  return true
+}
+
+const resetWithPage = async (
+  query: SearchQuery,
+  { preferSnapshot = true }: { preferSnapshot?: boolean } = {},
+) => {
   const targetPage = query.page ?? 1
   const trimmedKeyword = (query.keyword ?? '').trim()
+  const context = toSearchPageContextQuery(query)
+  const generation = allocateSearchPageContextGeneration()
+  queryGeneration = generation
+  activeContextQuery = context
+  routeAnchorPage.value = targetPage
+  initialLoading.value = true
+  errorMessage.value = ''
+  resultMeta.value = null
+  pageCache.value = {}
+  loadingPrevious.value = false
+  loadingNext.value = false
+
+  const cachedSnapshot = getSearchPageContext(query)
+  const canRestoreSnapshot =
+    !/^\d+$/.test(trimmedKeyword) && preferSnapshot && cachedSnapshot?.routePage === targetPage
+  if (canRestoreSnapshot && (await restoreContextSnapshot(cachedSnapshot, generation))) {
+    initialLoading.value = false
+    return
+  }
+  if (!isCurrentGeneration(generation, context)) return
+  clearSearchPageContext(query)
+
   if (/^\d+$/.test(trimmedKeyword)) {
-    initialLoading.value = true
-    errorMessage.value = ''
-    resultMeta.value = null
-    pageCache.value = {}
     let album: AlbumDetail
     try {
       album = await JmcomicService.getAlbum(trimmedKeyword)
+      if (!isCurrentGeneration(generation, context)) return
       if (!album || String(album.id ?? '').trim() !== trimmedKeyword || !album.title?.trim()) {
         throw new Error('invalid album detail')
       }
     } catch {
+      if (!isCurrentGeneration(generation, context)) return
       await showToast('本子不存在', 'danger')
-      return
-    } finally {
       initialLoading.value = false
+      return
     }
+    if (!isCurrentGeneration(generation, context)) return
+    initialLoading.value = false
     try {
       await router.replace({
         path: `/album/${trimmedKeyword}`,
@@ -288,26 +444,26 @@ const resetWithPage = async (query: SearchQuery) => {
     return
   }
 
-  initialLoading.value = true
-  errorMessage.value = ''
-  resultMeta.value = null
-  pageCache.value = {}
-
   try {
-    const pageResult = await fetchPage(query, targetPage)
+    const pageResult = await fetchPage({ ...context, page: targetPage }, targetPage)
+    if (!isCurrentGeneration(generation, context)) return
     resultMeta.value = pageResult
-    pageCache.value = {
-      [targetPage]: pageResult.content,
-    }
+    commitPage(targetPage, pageResult.content, 'reset')
     await nextTick()
-    void contentRef.value?.$el?.scrollToTop?.(0)
+    const scrollEl = await resolveScrollElement()
+    if (scrollEl) scrollEl.scrollTop = 0
+    await contentRef.value?.$el?.scrollToTop?.(0)
+    savedScrollTop.value = 0
     pageAtTop.value = true
+    saveContextSnapshot()
   } catch (error) {
-    resultMeta.value = null
-    pageCache.value = {}
-    errorMessage.value = sanitizeError(error, '搜索失败')
+    if (isCurrentGeneration(generation, context)) {
+      resultMeta.value = null
+      pageCache.value = {}
+      errorMessage.value = sanitizeError(error, '搜索失败')
+    }
   } finally {
-    initialLoading.value = false
+    if (isCurrentGeneration(generation, context)) initialLoading.value = false
   }
 }
 
@@ -326,31 +482,18 @@ const updateRouteQuery = (query: SearchQuery) => {
 
 const submitSearch = (query: SearchQuery) => {
   const newQuery = { ...query, page: 1 }
-  if (/^\d+$/.test((newQuery.keyword ?? '').trim())) {
-    lastSearchedQuery.value = { ...newQuery }
-    void resetWithPage(newQuery)
-    return
-  }
   lastSearchedQuery.value = { ...newQuery }
-  void resetWithPage(newQuery)
-  updateRouteQuery(newQuery)
+  void resetWithPage(newQuery, { preferSnapshot: false })
+  if (!/^\d+$/.test((newQuery.keyword ?? '').trim())) updateRouteQuery(newQuery)
 }
 
 const submitOverlaySearch = (query: SearchQuery) => {
   closeSearchOverlay()
-  const newQuery = { ...query, page: 1 }
-  if (/^\d+$/.test((newQuery.keyword ?? '').trim())) {
-    lastSearchedQuery.value = { ...newQuery }
-    void resetWithPage(newQuery)
-    return
-  }
-  lastSearchedQuery.value = { ...newQuery }
-  void resetWithPage(newQuery)
-  updateRouteQuery(newQuery)
+  submitSearch(query)
 }
 
 const retrySearch = () => {
-  void resetWithPage(currentQuery.value)
+  void resetWithPage(currentQuery.value, { preferSnapshot: false })
 }
 
 const openSearch = () => {
@@ -369,76 +512,100 @@ const scrollToTop = () => {
 }
 
 const appendPage = async (page: number) => {
-  if (loadingNext.value || initialLoading.value || !canLoadNext.value) {
+  if (loadingNext.value || initialLoading.value || !canLoadNext.value) return
+  if (pageCache.value[page] || loadedPageEnd.value === null || page !== loadedPageEnd.value + 1)
     return
-  }
+
+  const context = { ...activeContextQuery }
+  const generation = queryGeneration
+  const anchorPage =
+    loadedPages.value.length >= SEARCH_PAGE_WINDOW_SIZE ? loadedPageStart.value : null
+  const anchorEntry =
+    displayItems.value.find((entry) => entry.page !== anchorPage) ?? displayItems.value[0]
+  const anchorKey = anchorEntry
+    ? `${anchorEntry.page}-${anchorEntry.indexInPage}-${anchorEntry.item.id}`
+    : null
+  const previousAnchorTop = anchorKey
+    ? (resultContainerRef.value?.getEntryElement?.(anchorKey)?.getBoundingClientRect().top ?? null)
+    : null
 
   loadingNext.value = true
   try {
     errorMessage.value = ''
-    const pageResult = await fetchPage(currentQuery.value, page)
+    const pageResult = await fetchPage({ ...context, page: currentQuery.value.page }, page)
+    if (!isCurrentGeneration(generation, context)) return
     resultMeta.value = pageResult
-    pageCache.value = {
-      ...pageCache.value,
-      [page]: pageResult.content,
+    commitPage(page, pageResult.content, 'append')
+    await nextTick()
+    if (anchorKey && previousAnchorTop !== null) {
+      const nextTop = resultContainerRef.value
+        ?.getEntryElement?.(anchorKey)
+        ?.getBoundingClientRect().top
+      const scrollEl = await resolveScrollElement()
+      if (scrollEl && nextTop !== undefined && nextTop !== null) {
+        scrollEl.scrollTop += nextTop - previousAnchorTop
+      }
     }
+    saveContextSnapshot()
     await maybeLoadNextAfterRender()
   } catch (error) {
-    errorMessage.value = sanitizeError(error, '加载下一页失败')
+    if (isCurrentGeneration(generation, context)) {
+      errorMessage.value = sanitizeError(error, '加载下一页失败')
+    }
   } finally {
-    loadingNext.value = false
+    if (isCurrentGeneration(generation, context)) loadingNext.value = false
   }
 }
 
 const prependPage = async (page: number) => {
-  if (loadingPrevious.value || initialLoading.value || !canLoadPrevious.value) {
+  if (loadingPrevious.value || initialLoading.value || !canLoadPrevious.value) return
+  if (pageCache.value[page] || loadedPageStart.value === null || page !== loadedPageStart.value - 1)
     return
-  }
 
+  const context = { ...activeContextQuery }
+  const generation = queryGeneration
   const contentScrollElement = await resolveScrollElement()
-  const anchorEntry = displayItems.value[0]
+  if (!isCurrentGeneration(generation, context)) return
+  const anchorPage =
+    loadedPages.value.length >= SEARCH_PAGE_WINDOW_SIZE ? loadedPageEnd.value : null
+  const anchorEntry =
+    displayItems.value.find((entry) => entry.page !== anchorPage) ?? displayItems.value[0]
   const anchorEntryKey = anchorEntry
     ? `${anchorEntry.page}-${anchorEntry.indexInPage}-${anchorEntry.item.id}`
     : null
   const previousAnchorTop = anchorEntryKey
-    ? (resultContainerRef.value?.getEntryElement(anchorEntryKey)?.getBoundingClientRect().top ??
+    ? (resultContainerRef.value?.getEntryElement?.(anchorEntryKey)?.getBoundingClientRect().top ??
       null)
     : null
-  const resultRoot = resultContainerRef.value?.getRootElement()
+  const resultRoot = resultContainerRef.value?.getRootElement?.()
   const previousRootTop = resultRoot?.getBoundingClientRect().top ?? null
 
-  if (!contentScrollElement || !resultRoot) {
-    return
-  }
+  if (!contentScrollElement || !resultRoot) return
 
   loadingPrevious.value = true
   try {
     errorMessage.value = ''
-    const pageResult = await fetchPage(currentQuery.value, page)
+    const pageResult = await fetchPage({ ...context, page: currentQuery.value.page }, page)
+    if (!isCurrentGeneration(generation, context)) return
     resultMeta.value = pageResult
-    pageCache.value = {
-      [page]: pageResult.content,
-      ...pageCache.value,
-    }
+    commitPage(page, pageResult.content, 'prepend')
     await nextTick()
-    if (anchorEntryKey && previousAnchorTop !== null) {
-      const nextAnchorTop =
-        resultContainerRef.value?.getEntryElement(anchorEntryKey)?.getBoundingClientRect().top ??
-        null
-      if (nextAnchorTop !== null) {
-        contentScrollElement.scrollTop += nextAnchorTop - previousAnchorTop
-        return
-      }
-    }
-
-    const nextRootTop = resultRoot.getBoundingClientRect().top
-    if (previousRootTop !== null) {
+    const nextTop = anchorEntryKey
+      ? resultContainerRef.value?.getEntryElement?.(anchorEntryKey)?.getBoundingClientRect().top
+      : null
+    if (nextTop !== undefined && nextTop !== null && previousAnchorTop !== null) {
+      contentScrollElement.scrollTop += nextTop - previousAnchorTop
+    } else if (previousRootTop !== null) {
+      const nextRootTop = resultRoot.getBoundingClientRect().top
       contentScrollElement.scrollTop += nextRootTop - previousRootTop
     }
+    saveContextSnapshot()
   } catch (error) {
-    errorMessage.value = sanitizeError(error, '加载上一页失败')
+    if (isCurrentGeneration(generation, context)) {
+      errorMessage.value = sanitizeError(error, '加载上一页失败')
+    }
   } finally {
-    loadingPrevious.value = false
+    if (isCurrentGeneration(generation, context)) loadingPrevious.value = false
   }
 }
 
@@ -760,11 +927,12 @@ watch(
   { immediate: true },
 )
 
-const savedScrollTop = ref(0)
-
 onDeactivated(() => {
   savedScrollTop.value = scrollElementRef.value?.scrollTop ?? 0
+  saveContextSnapshot()
 })
+
+onBeforeUnmount(() => saveContextSnapshot())
 
 onActivated(async () => {
   await nextTick()
@@ -774,8 +942,11 @@ onActivated(async () => {
   }
 })
 
-onMounted(() => {
-  void resolveScrollElement()
+onMounted(async () => {
+  const scrollEl = await resolveScrollElement()
+  if (scrollEl && savedScrollTop.value > 0) {
+    scrollEl.scrollTop = savedScrollTop.value
+  }
 })
 </script>
 

--- a/tests/unit/SearchPage.test.ts
+++ b/tests/unit/SearchPage.test.ts
@@ -1,7 +1,12 @@
 /* eslint-disable vue/one-component-per-file -- test-only Ionic and child-component fixtures */
 import { flushPromises, mount } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent, h, KeepAlive, nextTick, onMounted, reactive, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  clearSearchPageContextCache,
+  getSearchPageContext,
+} from '@/composables/searchPageContextCache'
 
 const mocks = vi.hoisted(() => ({
   route: {
@@ -17,7 +22,12 @@ const mocks = vi.hoisted(() => ({
   categories: vi.fn(),
   getAlbum: vi.fn(),
   showToast: vi.fn(() => Promise.resolve()),
+  scrollElement: { scrollTop: 0, scrollHeight: 5000, clientHeight: 800 },
+  anchorElement: { getBoundingClientRect: vi.fn(() => ({ top: 100 })) },
+  resultRoot: { getBoundingClientRect: vi.fn(() => ({ top: 0 })) },
 }))
+
+mocks.route = reactive(mocks.route)
 
 vi.mock('vue-router', () => ({
   useRoute: () => mocks.route,
@@ -29,7 +39,15 @@ vi.mock('@ionic/vue', () => ({
   IonContent: defineComponent({
     name: 'IonContent',
     setup(_, { slots }) {
-      return () => h('main', slots.default?.())
+      const rootRef = ref<HTMLElement | null>(null)
+      onMounted(() => {
+        if (!rootRef.value) return
+        Object.defineProperty(rootRef.value, 'getScrollElement', {
+          configurable: true,
+          value: () => Promise.resolve(mocks.scrollElement as unknown as HTMLElement),
+        })
+      })
+      return () => h('main', { ref: rootRef }, slots.default?.())
     },
   }),
   IonIcon: defineComponent({ name: 'IonIcon', setup: () => () => h('span') }),
@@ -69,7 +87,11 @@ vi.mock('@/components/search/SearchResultContainer.vue', () => ({
       loading: Boolean,
       errorMessage: { type: String, default: '' },
     },
-    setup() {
+    setup(_, { expose }) {
+      expose({
+        getRootElement: () => mocks.resultRoot,
+        getEntryElement: () => mocks.anchorElement,
+      })
       return () => h('div')
     },
   }),
@@ -120,6 +142,18 @@ vi.mock('@/composables/useAuth', () => ({
 
 import SearchPage from '@/views/SearchPage.vue'
 
+const mountedWrappers: Array<{ unmount: () => void }> = []
+
+const track = <T extends { unmount: () => void }>(wrapper: T) => {
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers) wrapper.unmount()
+  mountedWrappers.length = 0
+})
+
 const oldResult = {
   currentPage: 1,
   totalItems: 1,
@@ -137,6 +171,7 @@ const numericQuery = {
 
 describe('SearchPage 数字 ID 搜索', () => {
   beforeEach(() => {
+    clearSearchPageContextCache()
     mocks.route.name = 'SearchPage'
     mocks.route.query = {
       keyword: 'old',
@@ -154,10 +189,15 @@ describe('SearchPage 数字 ID 搜索', () => {
     mocks.categories.mockReset()
     mocks.getAlbum.mockReset()
     mocks.showToast.mockClear()
+    mocks.scrollElement.scrollTop = 0
+    mocks.anchorElement.getBoundingClientRect.mockReset()
+    mocks.anchorElement.getBoundingClientRect.mockReturnValue({ top: 100 })
+    mocks.resultRoot.getBoundingClientRect.mockReset()
+    mocks.resultRoot.getBoundingClientRect.mockReturnValue({ top: 0 })
   })
 
   test('无效数字 ID 会清除普通搜索的旧结果', async () => {
-    const wrapper = mount(SearchPage)
+    const wrapper = track(mount(SearchPage))
     await flushPromises()
     const results = wrapper.findComponent({ name: 'SearchResultContainer' })
     expect(results.props('items')).toHaveLength(1)
@@ -175,7 +215,7 @@ describe('SearchPage 数字 ID 搜索', () => {
     mocks.route.query = { ...mocks.route.query, keyword: '999' }
     mocks.getAlbum.mockResolvedValue({ id: '999', title: '数字本子', image: 'cover.jpg' })
 
-    mount(SearchPage)
+    track(mount(SearchPage))
     await flushPromises()
 
     expect(mocks.router.replace).toHaveBeenCalledWith({
@@ -195,10 +235,119 @@ describe('SearchPage 数字 ID 搜索', () => {
     })
     mocks.router.replace.mockRejectedValue(new Error('navigation failed'))
 
-    mount(SearchPage)
+    track(mount(SearchPage))
     await flushPromises()
 
     expect(mocks.showToast).toHaveBeenCalledWith('Error: navigation failed', 'danger')
     expect(mocks.showToast).not.toHaveBeenCalledWith('本子不存在', 'danger')
+  })
+
+  test('停用后销毁不会用失真的锚点覆盖有效快照', async () => {
+    const active = ref(true)
+    const SearchPageHost = defineComponent({
+      setup() {
+        return () =>
+          h(KeepAlive, null, {
+            default: () => (active.value ? h(SearchPage) : null),
+          })
+      },
+    })
+    const wrapper = mount(SearchPageHost)
+    await flushPromises()
+
+    mocks.scrollElement.scrollTop = 640
+    let captureCount = 0
+    mocks.anchorElement.getBoundingClientRect.mockImplementation(() => {
+      captureCount += 1
+      return { top: captureCount === 1 ? 180 : 0 }
+    })
+
+    active.value = false
+    await nextTick()
+    wrapper.unmount()
+
+    expect(captureCount).toBe(1)
+    expect(
+      getSearchPageContext({
+        keyword: 'old',
+        orderBy: 'mr',
+        time: 'a',
+        searchMainTag: 0,
+      }),
+    ).toMatchObject({ scrollTop: 640, anchorOffset: 180 })
+  })
+
+  test('切换搜索上下文前保存最新窗口并在返回时恢复滚动位置', async () => {
+    const queryA = {
+      keyword: 'A',
+      orderBy: 'mr',
+      time: 'a',
+      searchMainTag: 0,
+      page: 3,
+    }
+    const queryB = { ...queryA, keyword: 'B', page: 1 }
+    mocks.route.query = {
+      keyword: 'A',
+      orderBy: 'mr',
+      time: 'a',
+      searchMainTag: '0',
+      page: '3',
+    }
+    mocks.search.mockImplementation((query: { keyword?: string; page?: number }) =>
+      Promise.resolve({
+        currentPage: query.page ?? 1,
+        totalItems: 400,
+        totalPages: 5,
+        content: [
+          {
+            id: `${query.keyword ?? ''}-${query.page ?? 1}`,
+            title: `${query.keyword ?? ''} 结果`,
+            coverUrl: '',
+            authors: [],
+            tags: [],
+          },
+        ],
+      }),
+    )
+
+    const wrapper = track(mount(SearchPage))
+    await flushPromises()
+    mocks.scrollElement.scrollTop = 420
+
+    wrapper.findComponent({ name: 'SearchHeaderBar' }).vm.$emit('search', queryB)
+    await flushPromises()
+
+    mocks.route.query = {
+      keyword: 'B',
+      orderBy: 'mr',
+      time: 'a',
+      searchMainTag: '0',
+      page: '1',
+    }
+    await nextTick()
+    mocks.route.query = {
+      keyword: 'A',
+      orderBy: 'mr',
+      time: 'a',
+      searchMainTag: '0',
+      page: '3',
+    }
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(mocks.search).toHaveBeenCalledTimes(2)
+    expect(mocks.scrollElement.scrollTop).toBe(420)
+    expect(wrapper.findComponent({ name: 'SearchResultContainer' }).props('items')).toMatchObject([
+      { item: { id: 'A-3' } },
+    ])
+    expect(
+      getSearchPageContext({
+        keyword: 'A',
+        orderBy: 'mr',
+        time: 'a',
+        searchMainTag: 0,
+      }),
+    ).toMatchObject({ routePage: 3, scrollTop: 420 })
   })
 })

--- a/tests/unit/searchPageContextCache.test.ts
+++ b/tests/unit/searchPageContextCache.test.ts
@@ -5,6 +5,7 @@ import {
   getSearchPageContext,
   getSearchPageContextCacheSize,
   saveSearchPageContext,
+  toSearchPageContextQuery,
   type SearchPageContextSnapshot,
 } from '@/composables/searchPageContextCache'
 
@@ -76,6 +77,17 @@ describe('searchPageContextCache', () => {
       }),
     ).toMatchObject({ routePage: 1 })
     expect(getSearchPageContextCacheSize()).toBe(1)
+  })
+
+  test('搜索上下文会归一化关键词首尾空白', () => {
+    expect(
+      toSearchPageContextQuery({
+        keyword: '  A  ',
+        orderBy: 'mr',
+        time: 'a',
+        searchMainTag: 0,
+      }),
+    ).toEqual({ keyword: 'A', orderBy: 'mr', time: 'a', searchMainTag: 0 })
   })
 
   test('最多保留三个上下文并按最近访问淘汰', () => {

--- a/tests/unit/searchPageContextCache.test.ts
+++ b/tests/unit/searchPageContextCache.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import {
+  clearSearchPageContextCache,
+  commitSearchPageWindow,
+  getSearchPageContext,
+  getSearchPageContextCacheSize,
+  saveSearchPageContext,
+  type SearchPageContextSnapshot,
+} from '@/composables/searchPageContextCache'
+
+const makeSnapshot = (keyword: string, generation: number): SearchPageContextSnapshot => {
+  const item = {
+    id: `${keyword}-1`,
+    title: keyword,
+    coverUrl: `${keyword}.jpg`,
+    authors: ['作者'],
+    tags: ['标签'],
+  }
+  return {
+    query: { keyword, orderBy: 'mr', time: 'a', searchMainTag: 0 },
+    pageCache: { 1: [item] },
+    resultMeta: { currentPage: 1, totalItems: 1, totalPages: 1, content: [item] },
+    routePage: 1,
+    anchorEntryKey: `${keyword}-anchor`,
+    anchorOffset: 12,
+    scrollTop: 480,
+    displayMode: 'list',
+    generation,
+    savedAt: generation,
+  }
+}
+
+describe('searchPageContextCache', () => {
+  beforeEach(() => clearSearchPageContextCache())
+
+  test('窗口追加时只保留五页并淘汰最早页', () => {
+    let pageCache: Record<number, SearchPageContextSnapshot['pageCache'][number]> = {}
+    for (let page = 1; page <= 5; page += 1) {
+      pageCache = commitSearchPageWindow(pageCache, page, [], 'append').pageCache
+    }
+    const result = commitSearchPageWindow(pageCache, 6, [], 'append')
+
+    expect(Object.keys(result.pageCache).map(Number)).toEqual([2, 3, 4, 5, 6])
+    expect(result.evictedPages).toEqual([1])
+  })
+
+  test('窗口前插时淘汰最晚页并拒绝重复页覆盖', () => {
+    let pageCache: SearchPageContextSnapshot['pageCache'] = {}
+    for (let page = 5; page >= 1; page -= 1) {
+      pageCache = commitSearchPageWindow(pageCache, page, [], 'prepend').pageCache
+    }
+    const result = commitSearchPageWindow(pageCache, 0, [], 'prepend')
+    const duplicate = commitSearchPageWindow(
+      result.pageCache,
+      1,
+      [{ id: 'new', title: 'new', coverUrl: '', authors: [], tags: [] }],
+      'prepend',
+    )
+
+    expect(Object.keys(result.pageCache).map(Number)).toEqual([0, 1, 2, 3, 4])
+    expect(result.evictedPages).toEqual([5])
+    expect(duplicate.pageCache[1]).toEqual([])
+    expect(duplicate.evictedPages).toEqual([])
+  })
+
+  test('页码变化不会产生新的搜索上下文 key', () => {
+    saveSearchPageContext(makeSnapshot('A', 1))
+
+    expect(
+      getSearchPageContext({
+        keyword: 'A',
+        orderBy: 'mr',
+        time: 'a',
+        searchMainTag: 0,
+        page: 20,
+      }),
+    ).toMatchObject({ routePage: 1 })
+    expect(getSearchPageContextCacheSize()).toBe(1)
+  })
+
+  test('最多保留三个上下文并按最近访问淘汰', () => {
+    saveSearchPageContext(makeSnapshot('A', 1))
+    saveSearchPageContext(makeSnapshot('B', 2))
+    saveSearchPageContext(makeSnapshot('C', 3))
+    expect(
+      getSearchPageContext({ keyword: 'A', orderBy: 'mr', time: 'a', searchMainTag: 0 }),
+    ).not.toBeNull()
+
+    saveSearchPageContext(makeSnapshot('D', 4))
+
+    expect(
+      getSearchPageContext({ keyword: 'A', orderBy: 'mr', time: 'a', searchMainTag: 0 }),
+    ).not.toBeNull()
+    expect(
+      getSearchPageContext({ keyword: 'B', orderBy: 'mr', time: 'a', searchMainTag: 0 }),
+    ).toBeNull()
+    expect(getSearchPageContextCacheSize()).toBe(3)
+  })
+
+  test('读取快照返回深拷贝，不共享页数组和条目数组', () => {
+    saveSearchPageContext(makeSnapshot('A', 1))
+    const first = getSearchPageContext({
+      keyword: 'A',
+      orderBy: 'mr',
+      time: 'a',
+      searchMainTag: 0,
+    })!
+    first.pageCache[1].push({ ...first.pageCache[1][0], id: 'mutated' })
+    first.pageCache[1][0].authors.push('另一个作者')
+    first.resultMeta.content.push({ ...first.resultMeta.content[0], id: 'mutated-meta' })
+
+    const second = getSearchPageContext({
+      keyword: 'A',
+      orderBy: 'mr',
+      time: 'a',
+      searchMainTag: 0,
+    })!
+    expect(second.pageCache[1]).toHaveLength(1)
+    expect(second.pageCache[1][0].authors).toEqual(['作者'])
+    expect(second.resultMeta.content).toHaveLength(1)
+  })
+
+  test('旧 generation 不能覆盖更新的上下文快照', () => {
+    saveSearchPageContext(makeSnapshot('A', 2))
+    saveSearchPageContext(makeSnapshot('A', 1))
+
+    expect(
+      getSearchPageContext({ keyword: 'A', orderBy: 'mr', time: 'a', searchMainTag: 0 })
+        ?.generation,
+    ).toBe(2)
+  })
+})


### PR DESCRIPTION
## 变更

- 将搜索结果分页缓存限制为 5 页滑动窗口，追加或前插时淘汰远离当前方向的页，并同步维护路由页码锚点。
- 通过查询上下文快照保存有限页窗口、结果元数据、显示模式、锚点和滚动位置；最多保留 3 个上下文并按 LRU 淘汰，避免搜索历史无限增长。
- 为重置、分页加载和快照恢复增加 generation 校验，忽略过期请求；前插/追加淘汰时保留滚动锚点，详情页返回或实例重建后恢复附近内容与滚动位置。
- 增加窗口裁剪、重复页、上下文 key、LRU、深拷贝和 generation 回归测试。

## 验证

- `npm run test:unit -- --run`（56 个测试文件、332 个测试通过）
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check src/views/SearchPage.vue src/composables/searchPageContextCache.ts tests/unit/searchPageContextCache.test.ts`
- `npm run build`（通过；保留既有大 chunk warning）

Refs #140
Refs ASTRA-75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 搜索页面现在可保存并恢复查询上下文，包括分页结果、滚动位置和浏览锚点。
  * 翻页时保留有限范围的页面缓存，减少重复加载并改善滚动体验。
  * 支持多个搜索上下文的缓存与自动淘汰。
* **错误修复**
  * 统一处理关键词首尾空格，提升搜索上下文复用的准确性。
  * 防止过期搜索结果覆盖较新的搜索上下文。
  * 优化搜索重试、重置及页面切换时的状态恢复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->