### PR TITLE
fix(preload): 缩略图预载补发原图就绪事件

### DIFF
--- a/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
@@ -18,7 +18,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -235,6 +238,63 @@ public class PreloadServiceTest {
 
         assertEquals(1, result.getJSONArray("pending").length());
         assertTrue(fetched.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void networkThumbnailNotifiesOriginalAndThumbReadyAfterCachingBoth() throws Exception {
+        List<String> readyTypes = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch ready = new CountDownLatch(2);
+        PreloadService service = createService(image -> createPng(), new PreloadEventSink() {
+            @Override
+            public void onImageReady(String photoId, int sortOrder, String type) {
+                assertEquals("network-thumb", photoId);
+                assertEquals(1, sortOrder);
+                readyTypes.add(type);
+                ready.countDown();
+            }
+
+            @Override
+            public void onImageFailed(String photoId, int sortOrder, String type) {
+                fail("有效缩略图不应发送 imageFailed");
+            }
+        });
+
+        JSONObject result = service.preloadImages("network-thumb", "thumb", imageArray());
+
+        assertEquals(1, result.getJSONArray("pending").length());
+        assertTrue(ready.await(1, TimeUnit.SECONDS));
+        assertEquals(java.util.Arrays.asList("image", "thumb"), readyTypes);
+        assertTrue(imageCache.has("network-thumb/1"));
+        assertTrue(imageCache.has("network-thumb/1/thumb"));
+    }
+
+    @Test
+    public void localThumbnailNotifiesOriginalAndThumbReadyAfterCachingBoth() throws Exception {
+        prepareLocalImage("local-thumb", createPng());
+        List<String> readyTypes = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch ready = new CountDownLatch(2);
+        PreloadService service = createService(image -> createPng(), new PreloadEventSink() {
+            @Override
+            public void onImageReady(String photoId, int sortOrder, String type) {
+                assertEquals("local-thumb", photoId);
+                assertEquals(1, sortOrder);
+                readyTypes.add(type);
+                ready.countDown();
+            }
+
+            @Override
+            public void onImageFailed(String photoId, int sortOrder, String type) {
+                fail("有效本地缩略图不应发送 imageFailed");
+            }
+        });
+
+        JSONObject result = service.preloadImages("local-thumb", "thumb", imageArray());
+
+        assertEquals(1, result.getJSONArray("pending").length());
+        assertTrue(ready.await(1, TimeUnit.SECONDS));
+        assertEquals(java.util.Arrays.asList("image", "thumb"), readyTypes);
+        assertTrue(imageCache.has("local-thumb/1"));
+        assertTrue(imageCache.has("local-thumb/1/thumb"));
     }
 
     @Test

--- a/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/feature/preload/PreloadServiceTest.java
@@ -249,6 +249,10 @@ public class PreloadServiceTest {
             public void onImageReady(String photoId, int sortOrder, String type) {
                 assertEquals("network-thumb", photoId);
                 assertEquals(1, sortOrder);
+                if ("image".equals(type)) {
+                    assertTrue(imageCache.has("network-thumb/1"));
+                    assertTrue(imageCache.has("network-thumb/1/thumb"));
+                }
                 readyTypes.add(type);
                 ready.countDown();
             }
@@ -278,6 +282,10 @@ public class PreloadServiceTest {
             public void onImageReady(String photoId, int sortOrder, String type) {
                 assertEquals("local-thumb", photoId);
                 assertEquals(1, sortOrder);
+                if ("image".equals(type)) {
+                    assertTrue(imageCache.has("local-thumb/1"));
+                    assertTrue(imageCache.has("local-thumb/1/thumb"));
+                }
                 readyTypes.add(type);
                 ready.countDown();
             }

--- a/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/preload/PreloadService.java
@@ -178,8 +178,12 @@ public class PreloadService {
                             byte[] thumbBytes = ImageCache.createThumbnail(localBytes);
                             if (isStale(scopeKey, generation)) return;
                             String mime = "image/" + ImageCache.guessFormatName(localBytes);
-                            imageCache.put(imageKey, localBytes, mime, reservation);
+                            boolean originalCached = imageCache.put(
+                                imageKey, localBytes, mime, reservation);
                             if (imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
+                                if (originalCached && imageCache.has(imageKey)) {
+                                    notifyImageReady(photoId, sortOrder, "image");
+                                }
                                 notifyImageReady(photoId, sortOrder, type);
                             } else {
                                 throw new IOException("本地缩略图无法写入内存缓存");
@@ -259,9 +263,13 @@ public class PreloadService {
                         }
                         if (isThumb) {
                             byte[] thumbBytes = ImageCache.createThumbnail(decrypted);
-                            imageCache.put(imageKey, decrypted, mimeType, reservation);
+                            boolean originalCached = imageCache.put(
+                                imageKey, decrypted, mimeType, reservation);
                             if (!imageCache.put(cacheKey, thumbBytes, "image/jpeg")) {
                                 throw new IOException("缩略图无法写入内存缓存");
+                            }
+                            if (originalCached && imageCache.has(imageKey)) {
+                                notifyImageReady(photoId, sortOrder, "image");
                             }
                         } else {
                             if (!imageCache.put(cacheKey, decrypted, mimeType, reservation)) {


### PR DESCRIPTION
## 变更

- 缩略图预载在原图和缩略图都写入缓存后，额外发送一次 `imageReady(type=image)`。
- 仅当原图写入成功且缩略图写入后仍在缓存中才发送原图就绪事件；保留原有 `thumb` 就绪和失败事件语义。
- 增加网络、本地缩略图预载的回归测试，覆盖两个缓存键与两类就绪事件。

## 验证

- `npm run lint` 通过。
- `npm run test:unit -- tests/unit/ReaderPage.test.ts tests/unit/JmcomicServiceFacade.test.ts`：21/21 通过。
- 完整前端单元测试：312/335 通过；23 个失败均发生在既有测试的 `localStorage` 环境访问/清理处。
- `npm run typecheck` 与 `npm run build` 仍受既有 `src/services/PdfReaderService.ts:67` 的 `isEvalSupported` 类型错误阻塞。
- Android 测试未能执行：当前环境没有 Android SDK；未启动本地模拟器。

Fixes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 图片预加载完成后，现在会分别通知原图和缩略图均已就绪，通知顺序为“原图”后“缩略图”。
  - 本地图片与网络图片的预加载行为保持一致。

- **测试**
  - 增加了对原图、缩略图缓存及就绪通知顺序的验证。
  - 确认成功场景不会触发图片加载失败通知。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->