### PR TITLE
feat: 添加 PicaComic 实验性入口

### DIFF
--- a/android/app/src/androidTest/java/io/github/jukomu/bridge/SettingsPluginContractInstrumentedTest.java
+++ b/android/app/src/androidTest/java/io/github/jukomu/bridge/SettingsPluginContractInstrumentedTest.java
@@ -87,6 +87,36 @@ public class SettingsPluginContractInstrumentedTest {
     }
 
     @Test
+    public void picacomicSettingsValidateAndClearDependentSetting() throws Exception {
+        RecordingPluginCall blockedConversion = call("setPicacomicConversionEnabled", "enabled", true);
+        plugin.setPicacomicConversionEnabled(blockedConversion);
+
+        assertRejected(blockedConversion, "picacomicEnabled must be enabled");
+        assertFalse(settingsService.picacomicConversionEnabled);
+
+        RecordingPluginCall enable = call("setPicacomicEnabled", "enabled", true);
+        RecordingPluginCall conversion = call("setPicacomicConversionEnabled", "enabled", true);
+        plugin.setPicacomicEnabled(enable);
+        plugin.setPicacomicConversionEnabled(conversion);
+
+        assertTrue(settingsService.picacomicEnabled);
+        assertTrue(settingsService.picacomicConversionEnabled);
+        assertTrue(enable.resolvedData.getBool("success"));
+        assertTrue(conversion.resolvedData.getBool("success"));
+
+        RecordingPluginCall disable = call("setPicacomicEnabled", "enabled", false);
+        RecordingPluginCall getAll = call("getAllSettings");
+        plugin.setPicacomicEnabled(disable);
+        plugin.getAllSettings(getAll);
+
+        assertFalse(settingsService.picacomicEnabled);
+        assertFalse(settingsService.picacomicConversionEnabled);
+        assertFalse(getAll.resolvedData.getBool("picacomicEnabled"));
+        assertFalse(getAll.resolvedData.getBool("picacomicConversionEnabled"));
+        assertSynchronous(blockedConversion, enable, conversion, disable, getAll);
+    }
+
+    @Test
     public void downloadPublicValidationRejectsBeforeKeepAliveAndRelocation() {
         settingsService.validationError = "switch blocked";
         RecordingPluginCall call = call("setDownloadPublic", "open", true);
@@ -191,6 +221,8 @@ public class SettingsPluginContractInstrumentedTest {
         private int preloadConcurrency;
         private int readerPreloadPages;
         private boolean ocrEnabled = true;
+        private boolean picacomicEnabled;
+        private boolean picacomicConversionEnabled;
         private boolean validatedOpen;
         private boolean relocatedOpen;
         private String validationError;
@@ -236,7 +268,9 @@ public class SettingsPluginContractInstrumentedTest {
             return jsonObject(
                 "readerPreloadPages", 15,
                 "downloadConcurrency", 6,
-                "preloadConcurrency", 6);
+                "preloadConcurrency", 6,
+                "picacomicEnabled", picacomicEnabled,
+                "picacomicConversionEnabled", picacomicConversionEnabled);
         }
 
         @Override
@@ -247,6 +281,22 @@ public class SettingsPluginContractInstrumentedTest {
         @Override
         public void setOcrEnabled(boolean enabled) {
             ocrEnabled = enabled;
+        }
+
+        @Override
+        public void setPicacomicEnabled(boolean enabled) {
+            picacomicEnabled = enabled;
+            if (!enabled) {
+                picacomicConversionEnabled = false;
+            }
+        }
+
+        @Override
+        public void setPicacomicConversionEnabled(boolean enabled) {
+            if (enabled && !picacomicEnabled) {
+                throw new IllegalStateException("picacomicEnabled must be enabled");
+            }
+            picacomicConversionEnabled = enabled;
         }
 
         private void completeRelocationSuccess() {

--- a/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/JmcomicPlugin.java
@@ -650,6 +650,16 @@ public class JmcomicPlugin extends Plugin {
         settingsHandler.setOcrEnabled(call);
     }
 
+    @PluginMethod
+    public void setPicacomicEnabled(PluginCall call) {
+        settingsHandler.setPicacomicEnabled(call);
+    }
+
+    @PluginMethod
+    public void setPicacomicConversionEnabled(PluginCall call) {
+        settingsHandler.setPicacomicConversionEnabled(call);
+    }
+
     // ========== 阅读器设置 ==========
 
     @PluginMethod

--- a/android/app/src/main/java/io/github/jukomu/bridge/handler/SettingsPluginHandler.java
+++ b/android/app/src/main/java/io/github/jukomu/bridge/handler/SettingsPluginHandler.java
@@ -136,6 +136,40 @@ public final class SettingsPluginHandler {
         }
     }
 
+    /**
+     * 保存 PicaComic 接入开关；enabled 为必填布尔值。
+     */
+    public void setPicacomicEnabled(PluginCall call) {
+        try {
+            Boolean enabled = call.getBoolean("enabled");
+            if (enabled == null) {
+                call.reject("enabled is required");
+                return;
+            }
+            settingsService.setPicacomicEnabled(enabled);
+            call.resolve(successResult());
+        } catch (Exception error) {
+            call.reject(error.getMessage(), error);
+        }
+    }
+
+    /**
+     * 保存 PicaComic 转换开关；enabled 为必填布尔值。
+     */
+    public void setPicacomicConversionEnabled(PluginCall call) {
+        try {
+            Boolean enabled = call.getBoolean("enabled");
+            if (enabled == null) {
+                call.reject("enabled is required");
+                return;
+            }
+            settingsService.setPicacomicConversionEnabled(enabled);
+            call.resolve(successResult());
+        } catch (Exception error) {
+            call.reject(error.getMessage(), error);
+        }
+    }
+
     private static JSObject successResult() {
         JSObject result = new JSObject();
         result.put("success", true);

--- a/android/app/src/main/java/io/github/jukomu/feature/settings/SettingsService.java
+++ b/android/app/src/main/java/io/github/jukomu/feature/settings/SettingsService.java
@@ -95,6 +95,8 @@ public class SettingsService {
             ret.put("readerKeepScreenOn", getReaderKeepScreenOn());
             ret.put("readerVolumeNavigation", getReaderVolumeNavigation());
             ret.put("readerAutoShowToolbarAtEnd", getReaderAutoShowToolbarAtEnd());
+            ret.put("picacomicEnabled", getPicacomicEnabled());
+            ret.put("picacomicConversionEnabled", getPicacomicConversionEnabled());
         } catch (Exception e) {
             Log.w(TAG, "构建全部设置信息失败", e);
         }
@@ -119,6 +121,33 @@ public class SettingsService {
 
     public void setOcrEnabled(boolean enabled) {
         settingsDb.putString("ocr_enabled", String.valueOf(enabled));
+    }
+
+    public boolean getPicacomicEnabled() {
+        return settingsDb.getBoolean("picacomic_enabled", false);
+    }
+
+    public void setPicacomicEnabled(boolean enabled) {
+        if (!enabled && !settingsDb.putString("picacomic_conversion_enabled", "false")) {
+            throw new IllegalStateException("保存 PicaComic 转换设置失败");
+        }
+        if (!settingsDb.putString("picacomic_enabled", String.valueOf(enabled))) {
+            throw new IllegalStateException("保存 PicaComic 接入设置失败");
+        }
+    }
+
+    public boolean getPicacomicConversionEnabled() {
+        return getPicacomicEnabled()
+            && settingsDb.getBoolean("picacomic_conversion_enabled", false);
+    }
+
+    public void setPicacomicConversionEnabled(boolean enabled) {
+        if (enabled && !getPicacomicEnabled()) {
+            throw new IllegalStateException("picacomicEnabled must be enabled");
+        }
+        if (!settingsDb.putString("picacomic_conversion_enabled", String.valueOf(enabled))) {
+            throw new IllegalStateException("保存 PicaComic 转换设置失败");
+        }
     }
 
     // ---- 阅读器设置 ----

--- a/src/services/JmcomicTypes.ts
+++ b/src/services/JmcomicTypes.ts
@@ -201,6 +201,8 @@ export interface AllSettings {
   readerKeepScreenOn: boolean
   readerVolumeNavigation: boolean
   readerAutoShowToolbarAtEnd?: boolean
+  picacomicEnabled?: boolean
+  picacomicConversionEnabled?: boolean
 }
 
 // --- 设置页：文件搬迁 ---

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -20,6 +20,8 @@ let cachedReaderBrightness = -1
 let cachedReaderKeepScreenOn = true
 let cachedReaderVolumeNavigation = false
 let cachedReaderAutoShowToolbarAtEnd = true
+let cachedPicacomicEnabled = false
+let cachedPicacomicConversionEnabled = false
 let confirmedPreloadConcurrency = 6
 let confirmedDownloadConcurrency = 6
 let preloadConcurrencySaveVersion = 0
@@ -46,6 +48,9 @@ export async function initSettings(): Promise<void> {
     cachedReaderKeepScreenOn = all.readerKeepScreenOn ?? true
     cachedReaderVolumeNavigation = all.readerVolumeNavigation ?? false
     cachedReaderAutoShowToolbarAtEnd = all.readerAutoShowToolbarAtEnd ?? true
+    cachedPicacomicEnabled = all.picacomicEnabled ?? false
+    cachedPicacomicConversionEnabled =
+      cachedPicacomicEnabled && (all.picacomicConversionEnabled ?? false)
     settingsLoaded = true
   } catch (e) {
     // 使用默认值（已在缓存变量中预设）
@@ -148,6 +153,21 @@ export const SettingsStore = {
   },
   setReaderAutoShowToolbarAtEnd(enabled: boolean) {
     cachedReaderAutoShowToolbarAtEnd = enabled
+  },
+
+  // ---- PicaComic 实验性功能 ----
+  getPicacomicEnabled(): boolean {
+    return cachedPicacomicEnabled
+  },
+  setPicacomicEnabled(enabled: boolean) {
+    cachedPicacomicEnabled = enabled
+    if (!enabled) cachedPicacomicConversionEnabled = false
+  },
+  getPicacomicConversionEnabled(): boolean {
+    return cachedPicacomicConversionEnabled
+  },
+  setPicacomicConversionEnabled(enabled: boolean) {
+    cachedPicacomicConversionEnabled = enabled && cachedPicacomicEnabled
   },
 }
 

--- a/src/services/jmcomic/JmcomicClient.ts
+++ b/src/services/jmcomic/JmcomicClient.ts
@@ -103,6 +103,10 @@ export interface JmcomicClient {
 
   setOcrEnabled(options: { enabled: boolean }): Promise<{ success: boolean }>
 
+  setPicacomicEnabled(options: { enabled: boolean }): Promise<{ success: boolean }>
+
+  setPicacomicConversionEnabled(options: { enabled: boolean }): Promise<{ success: boolean }>
+
   setDownloadPublic(options: {
     open: boolean
   }): Promise<{ success: boolean; downloadPublic: boolean; moved: number }>

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -231,6 +231,16 @@ export const JmcomicService = {
     return native.setOcrEnabled({ enabled })
   },
 
+  /** 持久化 PicaComic 接入开关 */
+  setPicacomicEnabled(enabled: boolean) {
+    return native.setPicacomicEnabled({ enabled })
+  },
+
+  /** 持久化 PicaComic 转换开关 */
+  setPicacomicConversionEnabled(enabled: boolean) {
+    return native.setPicacomicConversionEnabled({ enabled })
+  },
+
   /** 持久化预加载并发数（下次启动生效） */
   setPreloadConcurrency(n: number) {
     return native.setPreloadConcurrency({ n })

--- a/src/views/SettingPage.vue
+++ b/src/views/SettingPage.vue
@@ -408,6 +408,39 @@
           </button>
         </div>
 
+        <!-- 分组：实验性功能 -->
+        <div class="section-label">实验性功能</div>
+        <div class="card">
+          <div class="row">
+            <div class="row-left">
+              <span class="row-title">接入 PicaComic</span>
+            </div>
+            <div class="row-right">
+              <IonToggle
+                :checked="picacomicEnabled"
+                :disabled="isSwitchingPicacomic"
+                aria-label="接入 PicaComic"
+                color="warning"
+                @ion-change="onPicacomicEnabledChange"
+              />
+            </div>
+          </div>
+          <div class="row divider">
+            <div class="row-left">
+              <span class="row-title">转换到 PicaComic</span>
+            </div>
+            <div class="row-right">
+              <IonToggle
+                :checked="picacomicConversionEnabled"
+                :disabled="isSwitchingPicacomic || !picacomicEnabled"
+                aria-label="转换到 PicaComic"
+                color="warning"
+                @ion-change="onPicacomicConversionEnabledChange"
+              />
+            </div>
+          </div>
+        </div>
+
         <!-- 分组：网络状态 -->
         <div class="section-label">网络状态</div>
         <div class="card">
@@ -571,6 +604,8 @@ const brightnessValue = ref(
 const keepScreenOn = ref(SettingsStore.getReaderKeepScreenOn())
 const volumeNavigation = ref(SettingsStore.getReaderVolumeNavigation())
 const autoShowToolbarAtEnd = ref(SettingsStore.getReaderAutoShowToolbarAtEnd())
+const picacomicEnabled = ref(SettingsStore.getPicacomicEnabled())
+const picacomicConversionEnabled = ref(SettingsStore.getPicacomicConversionEnabled())
 
 const exportPreview = computed(() => ExportFormatService.previewExportFormat(exportFormat.value))
 
@@ -674,6 +709,8 @@ onMounted(async () => {
   keepScreenOn.value = SettingsStore.getReaderKeepScreenOn()
   volumeNavigation.value = SettingsStore.getReaderVolumeNavigation()
   autoShowToolbarAtEnd.value = SettingsStore.getReaderAutoShowToolbarAtEnd()
+  picacomicEnabled.value = SettingsStore.getPicacomicEnabled()
+  picacomicConversionEnabled.value = SettingsStore.getPicacomicConversionEnabled()
 
   // 将 PDF 导出默认相对路径解析为绝对路径（与文件夹选择器返回的绝对路径保持一致）
   try {
@@ -789,6 +826,54 @@ async function onOcrEnabledChange(e: CustomEvent) {
     ocrEnabled.value = !enabled
     SettingsStore.setOcrEnabled(!enabled)
     await showToast('保存失败', 'danger')
+  }
+}
+
+// ---- PicaComic 实验性功能 ----
+const isSwitchingPicacomic = ref(false)
+
+async function onPicacomicEnabledChange(e: CustomEvent) {
+  if (isSwitchingPicacomic.value) return
+  const enabled = Boolean(e.detail.checked)
+  const previousEnabled = picacomicEnabled.value
+  const previousConversionEnabled = picacomicConversionEnabled.value
+  isSwitchingPicacomic.value = true
+  picacomicEnabled.value = enabled
+  if (!enabled) picacomicConversionEnabled.value = false
+  SettingsStore.setPicacomicEnabled(enabled)
+
+  try {
+    const result = await JmcomicService.setPicacomicEnabled(enabled)
+    if (!result.success) throw new Error('保存失败')
+  } catch {
+    picacomicEnabled.value = previousEnabled
+    picacomicConversionEnabled.value = previousConversionEnabled
+    SettingsStore.setPicacomicEnabled(previousEnabled)
+    SettingsStore.setPicacomicConversionEnabled(previousConversionEnabled)
+    await showToast('保存失败', 'danger')
+  } finally {
+    isSwitchingPicacomic.value = false
+  }
+}
+
+async function onPicacomicConversionEnabledChange(e: CustomEvent) {
+  if (isSwitchingPicacomic.value) return
+  const enabled = Boolean(e.detail.checked)
+  if (enabled && !picacomicEnabled.value) return
+  const previous = picacomicConversionEnabled.value
+  isSwitchingPicacomic.value = true
+  picacomicConversionEnabled.value = enabled
+  SettingsStore.setPicacomicConversionEnabled(enabled)
+
+  try {
+    const result = await JmcomicService.setPicacomicConversionEnabled(enabled)
+    if (!result.success) throw new Error('保存失败')
+  } catch {
+    picacomicConversionEnabled.value = previous
+    SettingsStore.setPicacomicConversionEnabled(previous)
+    await showToast('保存失败', 'danger')
+  } finally {
+    isSwitchingPicacomic.value = false
   }
 }
 

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   getAlbum: vi.fn(),
   toggleAlbumFavorite: vi.fn(),
   manageFavoriteFolder: vi.fn(),
+  setPicacomicEnabled: vi.fn(),
+  setPicacomicConversionEnabled: vi.fn(),
 }))
 
 vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
@@ -19,6 +21,8 @@ vi.mock('@/services/jmcomic/JmcomicNativeClient', () => ({
     getAlbum: mocks.getAlbum,
     toggleAlbumFavorite: mocks.toggleAlbumFavorite,
     manageFavoriteFolder: mocks.manageFavoriteFolder,
+    setPicacomicEnabled: mocks.setPicacomicEnabled,
+    setPicacomicConversionEnabled: mocks.setPicacomicConversionEnabled,
   },
 }))
 
@@ -100,6 +104,19 @@ describe('JmcomicService.retryImage', () => {
 
     await expect(JmcomicService.retryImage('chapter-1', image)).resolves.toEqual({ success: true })
     expect(mocks.retryImage).toHaveBeenCalledWith({ photoId: 'chapter-1', image })
+  })
+})
+
+describe('JmcomicService PicaComic 设置', () => {
+  test('透传两个开关的布尔参数', async () => {
+    mocks.setPicacomicEnabled.mockResolvedValue({ success: true })
+    mocks.setPicacomicConversionEnabled.mockResolvedValue({ success: true })
+
+    await JmcomicService.setPicacomicEnabled(true)
+    await JmcomicService.setPicacomicConversionEnabled(false)
+
+    expect(mocks.setPicacomicEnabled).toHaveBeenCalledWith({ enabled: true })
+    expect(mocks.setPicacomicConversionEnabled).toHaveBeenCalledWith({ enabled: false })
   })
 })
 

--- a/tests/unit/SettingPage.test.ts
+++ b/tests/unit/SettingPage.test.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   resetExportFormat: vi.fn(),
   showToast: vi.fn(),
   routerPush: vi.fn(),
+  setPicacomicEnabled: vi.fn(),
+  setPicacomicConversionEnabled: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
@@ -26,6 +28,25 @@ vi.mock('@ionic/vue', () => {
       },
     })
 
+  const IonToggle = defineComponent({
+    name: 'IonToggle',
+    props: {
+      checked: { type: Boolean, default: false },
+      disabled: { type: Boolean, default: false },
+    },
+    emits: ['ion-change'],
+    setup(props, { attrs, emit }) {
+      return () =>
+        h('button', {
+          ...attrs,
+          type: 'button',
+          disabled: props.disabled,
+          'aria-checked': String(props.checked),
+          onClick: () => emit('ion-change', { detail: { checked: !props.checked } }),
+        })
+    },
+  })
+
   return {
     alertController: { create: vi.fn() },
     IonContent: withSlot('IonContent', 'main'),
@@ -33,7 +54,7 @@ vi.mock('@ionic/vue', () => {
     IonIcon: withSlot('IonIcon', 'span'),
     IonPage: withSlot('IonPage'),
     IonRange: withSlot('IonRange'),
-    IonToggle: withSlot('IonToggle'),
+    IonToggle,
     IonToolbar: withSlot('IonToolbar'),
   }
 })
@@ -48,6 +69,8 @@ vi.mock('@/services/JmcomicService', () => ({
   JmcomicService: {
     getCacheCapacityInfo: vi.fn().mockResolvedValue({ capacityMb: 512, usedMb: 0 }),
     getExternalStoragePath: vi.fn().mockResolvedValue({ path: '/storage/emulated/0/' }),
+    setPicacomicEnabled: mocks.setPicacomicEnabled,
+    setPicacomicConversionEnabled: mocks.setPicacomicConversionEnabled,
   },
   sanitizeError: vi.fn((_: unknown, fallback: string) => fallback),
   showToast: mocks.showToast,
@@ -62,6 +85,8 @@ vi.mock('@/services/SettingsService', () => ({
     getDownloadConcurrency: vi.fn(() => 4),
     getDownloadPublic: vi.fn(() => false),
     getOcrEnabled: vi.fn(() => false),
+    getPicacomicEnabled: vi.fn(() => false),
+    getPicacomicConversionEnabled: vi.fn(() => false),
     getPreloadConcurrency: vi.fn(() => 4),
     getReaderAutoShowToolbarAtEnd: vi.fn(() => true),
     getReaderBrightness: vi.fn(() => -1),
@@ -73,6 +98,8 @@ vi.mock('@/services/SettingsService', () => ({
     setCacheCapacityMb: vi.fn(),
     setDownloadPublic: vi.fn(),
     setOcrEnabled: vi.fn(),
+    setPicacomicEnabled: vi.fn(),
+    setPicacomicConversionEnabled: vi.fn(),
     setReaderAutoShowToolbarAtEnd: vi.fn(),
     setReaderBrightness: vi.fn(),
     setReaderDisplayMode: vi.fn(),
@@ -112,6 +139,8 @@ import SettingPage from '@/views/SettingPage.vue'
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.showToast.mockResolvedValue(undefined)
+  mocks.setPicacomicEnabled.mockResolvedValue({ success: true })
+  mocks.setPicacomicConversionEnabled.mockResolvedValue({ success: true })
 })
 
 afterEach(() => {
@@ -132,6 +161,55 @@ describe('SettingPage 导出格式重置', () => {
     await resetButton?.trigger('click')
 
     expect(mocks.resetExportFormat).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+})
+
+describe('SettingPage PicaComic 实验性功能', () => {
+  test('展示两个开关并按接入开关控制转换开关', async () => {
+    const wrapper = mount(SettingPage)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('实验性功能')
+    expect(wrapper.text()).toContain('接入 PicaComic')
+    expect(wrapper.text()).toContain('转换到 PicaComic')
+
+    const enabledToggle = wrapper.get('[aria-label="接入 PicaComic"]')
+    const conversionToggle = wrapper.get('[aria-label="转换到 PicaComic"]')
+    expect(conversionToggle.attributes('disabled')).toBeDefined()
+
+    await enabledToggle.trigger('click')
+    await flushPromises()
+
+    expect(mocks.setPicacomicEnabled).toHaveBeenCalledWith(true)
+    expect(conversionToggle.attributes('disabled')).toBeUndefined()
+
+    await conversionToggle.trigger('click')
+    await flushPromises()
+
+    expect(mocks.setPicacomicConversionEnabled).toHaveBeenCalledWith(true)
+
+    await enabledToggle.trigger('click')
+    await flushPromises()
+
+    expect(mocks.setPicacomicEnabled).toHaveBeenLastCalledWith(false)
+    expect(conversionToggle.attributes('aria-checked')).toBe('false')
+    expect(conversionToggle.attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+
+  test('接入开关保存失败时回滚状态', async () => {
+    mocks.setPicacomicEnabled.mockRejectedValueOnce(new Error('native failure'))
+    const wrapper = mount(SettingPage)
+    await flushPromises()
+
+    const enabledToggle = wrapper.get('[aria-label="接入 PicaComic"]')
+    await enabledToggle.trigger('click')
+    await flushPromises()
+
+    expect(enabledToggle.attributes('aria-checked')).toBe('false')
+    expect(wrapper.get('[aria-label="转换到 PicaComic"]').attributes('disabled')).toBeDefined()
+    expect(mocks.showToast).toHaveBeenCalledWith('保存失败', 'danger')
     wrapper.unmount()
   })
 })

--- a/tests/unit/SettingsService.test.ts
+++ b/tests/unit/SettingsService.test.ts
@@ -57,6 +57,37 @@ describe('SettingsService', () => {
     expect(SettingsStore.getReaderAutoShowToolbarAtEnd()).toBe(false)
   })
 
+  test('缺少 PicaComic 设置时默认关闭并保持依赖约束', async () => {
+    getAllSettings.mockResolvedValue(legacySettings)
+
+    const { initSettings, SettingsStore } = await import('@/services/SettingsService')
+    await initSettings()
+
+    expect(SettingsStore.getPicacomicEnabled()).toBe(false)
+    expect(SettingsStore.getPicacomicConversionEnabled()).toBe(false)
+
+    SettingsStore.setPicacomicEnabled(true)
+    SettingsStore.setPicacomicConversionEnabled(true)
+    expect(SettingsStore.getPicacomicConversionEnabled()).toBe(true)
+
+    SettingsStore.setPicacomicEnabled(false)
+    expect(SettingsStore.getPicacomicConversionEnabled()).toBe(false)
+  })
+
+  test('加载已保存的 PicaComic 设置', async () => {
+    getAllSettings.mockResolvedValue({
+      ...legacySettings,
+      picacomicEnabled: true,
+      picacomicConversionEnabled: true,
+    })
+
+    const { initSettings, SettingsStore } = await import('@/services/SettingsService')
+    await initSettings()
+
+    expect(SettingsStore.getPicacomicEnabled()).toBe(true)
+    expect(SettingsStore.getPicacomicConversionEnabled()).toBe(true)
+  })
+
   test('新原生返回 requested 和 effective 时缓存用户设置值', async () => {
     getAllSettings.mockResolvedValue({
       ...legacySettings,


### PR DESCRIPTION
## 变更

- 在设置页新增“实验性功能”分组，提供“接入 PicaComic”和“转换到 PicaComic”两个开关。
- 转换开关仅在接入开关开启时可操作；关闭接入开关会同步关闭转换开关。
- 通过前端 SettingsStore、Capacitor Bridge 和 Android SettingsStore 持久化两个布尔设置，旧数据库缺失时默认关闭。
- Android 设置服务和 Bridge 同时校验依赖关系；本次不接入 PicaComic 业务、路由或转换逻辑。

## 验证

- `npm run lint` 通过。
- `npm run test:unit -- tests/unit/SettingPage.test.ts tests/unit/SettingsService.test.ts tests/unit/JmcomicServiceFacade.test.ts` 通过，24/24 tests passed。
- `npx vite build` 通过。
- `npm run typecheck` 和 `npm run build` 受现有 `src/services/PdfReaderService.ts:67` 类型错误阻塞：当前 `pdf.js` 类型不包含 `isEvalSupported`。
- `npm run test:unit` 为 317/340 通过；其余既有失败来自当前 Node 26 环境未提供 `localStorage`，涉及 PDF 导出、阅读进度和搜索结果测试。
- Android JVM/lint 未能执行；Gradle 配置阶段提示当前环境缺少 Android SDK（未设置 `ANDROID_HOME` 或 `android/local.properties` 中的 `sdk.dir`）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 设置页新增实验性 PicaComic 接入开关。
  - 新增“转换到 PicaComic”开关，需先启用 PicaComic 接入。
  - 关闭接入后，转换功能会自动关闭。
  - 设置会持久化保存，保存失败时会恢复原状态并提示错误。

- **测试**
  - 新增相关设置、状态联动及错误回滚场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->