### PR TITLE
ci: 让 desktop-dev PR 自动触发检查

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, desktop-dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-android-instrumentation.yml
+++ b/.github/workflows/ci-android-instrumentation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, desktop-dev]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/ci-android-jvm.yml
+++ b/.github/workflows/ci-android-jvm.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, desktop-dev]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, desktop-dev]
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
## 变更

- 将 `ci-frontend.yml`、`ci-android-jvm.yml`、`ci-android-instrumentation.yml` 和 `build.yml` 的 `pull_request.branches` 扩展为 `[master, main, desktop-dev]`。
- 保持 `push.branches` 不变，未修改 instrumentation retry workflow。

## 验证

- `git diff --check` 通过。
- `npm ci` 受当前环境 `EALLOWREMOTE` 限制，无法下载远程依赖；因此 `npm run lint`、`npm run typecheck` 和 `npm run build` 因缺少本地依赖未能启动。
- `actionlint` 未安装，未执行该检查。

关联 Multica Issue：ASTRA-94