### PR TITLE
fix(ui): 修复宽屏页面工具栏布局

### DIFF
--- a/src/views/CategoryPage.vue
+++ b/src/views/CategoryPage.vue
@@ -688,12 +688,15 @@ onMounted(() => {
 }
 
 .category-page-toolbar {
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
+  display: flex;
   align-items: start;
   gap: 5px;
   max-width: 1000px;
   margin-inline: auto;
+}
+
+.category-page-toolbar > :deep(.menu-toggle-btn) {
+  flex: 0 0 auto;
 }
 
 .category-page-toolbar.pinned {
@@ -705,6 +708,7 @@ onMounted(() => {
 }
 
 .toolbar-category {
+  flex: 1 1 auto;
   min-width: 0;
 }
 

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -2059,10 +2059,13 @@ onActivated(async () => {
 }
 
 .favorite-page-toolbar {
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
+  display: flex;
   align-items: start;
   gap: 10px;
+}
+
+.favorite-page-toolbar > :deep(.menu-toggle-btn) {
+  flex: 0 0 auto;
 }
 
 .favorite-page-toolbar.pinned {
@@ -2074,6 +2077,7 @@ onActivated(async () => {
 }
 
 .toolbar-favorite {
+  flex: 1 1 auto;
   min-width: 0;
 }
 

--- a/src/views/SearchPage.vue
+++ b/src/views/SearchPage.vue
@@ -980,10 +980,13 @@ onMounted(async () => {
 .search-page-toolbar {
   max-width: 1000px;
   margin-inline: auto;
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
+  display: flex;
   align-items: start;
   gap: 10px;
+}
+
+.search-page-toolbar > :deep(.menu-toggle-btn) {
+  flex: 0 0 auto;
 }
 
 .search-page-toolbar.pinned {
@@ -995,6 +998,7 @@ onMounted(async () => {
 }
 
 .toolbar-search {
+  flex: 1 1 auto;
   min-width: 0;
 }
 


### PR DESCRIPTION
## 变更

- 修复分类页、搜索页、收藏页在宽屏隐藏菜单按钮后仍保留固定 44px 首列的问题。
- 将三个页面的顶部工具栏改为 `flex` 布局。
- 保留窄屏菜单按钮固定尺寸，并让宽屏内容区域自动占满可用宽度。
- 保留收藏页收藏夹列表按钮及原有交互。

## 验证

- `git diff --check` 已通过。
- 未启动浏览器或截图，宽屏视觉验收由用户执行。
- 本地依赖安装受运行环境限制，未能执行类型检查、格式检查和构建。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化分类、收藏和搜索页面的工具栏布局。
  - 菜单按钮保持固定宽度，搜索区域可根据可用空间自适应伸缩。
  - 提升不同屏幕尺寸下工具栏的布局稳定性与使用体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->