### PR TITLE
feat(desktop): 接通在线核心链路

### DIFF
--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -15,6 +15,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <javalin.version>7.2.2</javalin.version>
         <jackson.version>2.21.3</jackson.version>
+        <jmcomic.version>1.1.8</jmcomic.version>
         <sqlite.version>3.50.3.0</sqlite.version>
         <slf4j.version>2.0.17</slf4j.version>
         <junit.version>5.11.4</junit.version>
@@ -32,6 +33,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.jukomu</groupId>
+            <artifactId>jmcomic-core</artifactId>
+            <version>${jmcomic.version}</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>

--- a/desktop/src/main/java/io/github/jukomu/desktop/backend/DesktopBackend.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/backend/DesktopBackend.java
@@ -2,10 +2,27 @@ package io.github.jukomu.desktop.backend;
 
 import io.github.jukomu.desktop.bridge.DesktopPlugin;
 import io.github.jukomu.desktop.bridge.PluginMethodRoutes;
+import io.github.jukomu.desktop.bridge.handler.ApiPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.AsyncRequestHandler;
+import io.github.jukomu.desktop.bridge.handler.AuthPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.HistoryPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SettingsPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SystemPluginHandler;
 import io.github.jukomu.desktop.data.DesktopDatabase;
+import io.github.jukomu.desktop.data.DesktopHistoryStore;
 import io.github.jukomu.desktop.data.DesktopPaths;
+import io.github.jukomu.desktop.data.DesktopSettingsStore;
+import io.github.jukomu.desktop.service.DesktopHistoryService;
+import io.github.jukomu.desktop.service.DesktopCatalogService;
+import io.github.jukomu.desktop.service.DesktopSettingsService;
+import io.github.jukomu.desktop.service.JmComicAuthService;
+import io.github.jukomu.desktop.service.JmComicCatalogService;
 import io.javalin.Javalin;
+import io.javalin.http.Context;
 import io.javalin.http.staticfiles.Location;
+import io.github.jukomu.jmcomic.core.JmComic;
+import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
+import io.github.jukomu.jmcomic.core.config.JmConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +33,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /** 在同一 JVM 内承载 loopback Javalin 服务与 Desktop 资源。 */
 public final class DesktopBackend implements AutoCloseable {
@@ -44,14 +62,37 @@ public final class DesktopBackend implements AutoCloseable {
     private final DesktopPaths paths;
     private final DesktopDatabase database;
     private final ExecutorService businessExecutor;
+    private final Supplier<?> pluginFactory;
 
     private Javalin app;
     private URI homeUrl;
+    private JmApiClient client;
+    private DesktopCatalogService catalogService;
     private boolean running;
     private boolean closed;
 
     public DesktopBackend(DesktopPaths paths) {
-        this(paths, new DesktopDatabase(paths), createBusinessExecutor());
+        this(paths, new DesktopDatabase(paths), createBusinessExecutor(), null);
+    }
+
+    /** 仅供测试注入固定 bridge，生产启动始终创建真实 JmApiClient。 */
+    public DesktopBackend(DesktopPaths paths, Object plugin) {
+        this(paths, new DesktopDatabase(paths), createBusinessExecutor(), () -> plugin);
+    }
+
+    /** 供 HTTP contract test 注入固定 bridge 和图片资源服务。 */
+    public DesktopBackend(
+            DesktopPaths paths,
+            Object plugin,
+            DesktopCatalogService catalogService
+    ) {
+        this(
+                paths,
+                new DesktopDatabase(paths),
+                createBusinessExecutor(),
+                () -> plugin,
+                catalogService
+        );
     }
 
     public DesktopBackend(
@@ -59,9 +100,30 @@ public final class DesktopBackend implements AutoCloseable {
             DesktopDatabase database,
             ExecutorService businessExecutor
     ) {
+        this(paths, database, businessExecutor, null);
+    }
+
+    public DesktopBackend(
+            DesktopPaths paths,
+            DesktopDatabase database,
+            ExecutorService businessExecutor,
+            Supplier<?> pluginFactory
+    ) {
+        this(paths, database, businessExecutor, pluginFactory, null);
+    }
+
+    public DesktopBackend(
+            DesktopPaths paths,
+            DesktopDatabase database,
+            ExecutorService businessExecutor,
+            Supplier<?> pluginFactory,
+            DesktopCatalogService catalogService
+    ) {
         this.paths = Objects.requireNonNull(paths, "paths");
         this.database = Objects.requireNonNull(database, "database");
         this.businessExecutor = Objects.requireNonNull(businessExecutor, "businessExecutor");
+        this.pluginFactory = pluginFactory;
+        this.catalogService = catalogService;
     }
 
     public synchronized URI start() throws Exception {
@@ -82,7 +144,8 @@ public final class DesktopBackend implements AutoCloseable {
             }
 
             database.open();
-            DesktopPlugin plugin = new DesktopPlugin();
+            Object plugin = createPlugin();
+            DesktopCatalogService resources = catalogService;
             candidate = Javalin.create(config -> {
                 config.jetty.host = LOOPBACK_HOST;
                 config.jetty.port = 0;
@@ -93,6 +156,16 @@ public final class DesktopBackend implements AutoCloseable {
                 }
                 config.routes.get("/", context -> context.redirect("/home"));
                 PluginMethodRoutes.register(config.routes, plugin);
+                if (resources != null) {
+                    config.routes.get(
+                            "/image/{photoId}/{sortOrder}",
+                            context -> serveImage(context, resources, "image")
+                    );
+                    config.routes.get(
+                            "/thumb/{photoId}/{sortOrder}",
+                            context -> serveImage(context, resources, "thumb")
+                    );
+                }
             });
             candidate.start();
             int port = candidate.port();
@@ -115,7 +188,49 @@ public final class DesktopBackend implements AutoCloseable {
             }
             database.close();
             businessExecutor.shutdownNow();
+            closeClient();
             throw exception;
+        }
+    }
+
+    private Object createPlugin() {
+        if (pluginFactory != null) {
+            Object plugin = pluginFactory.get();
+            if (plugin == null) {
+                throw new IllegalStateException("Desktop plugin factory returned null");
+            }
+            return plugin;
+        }
+
+        client = JmComic.newApiClient(new JmConfiguration.Builder().build());
+        catalogService = new JmComicCatalogService(client);
+        DesktopSettingsService settingsService = new DesktopSettingsService(
+                new DesktopSettingsStore(database)
+        );
+        DesktopHistoryService historyService = new DesktopHistoryService(
+                new DesktopHistoryStore(database)
+        );
+        return new DesktopPlugin(
+                new SystemPluginHandler(() -> client != null),
+                new ApiPluginHandler(catalogService, businessExecutor),
+                new AuthPluginHandler(new JmComicAuthService(client), businessExecutor),
+                new HistoryPluginHandler(historyService, businessExecutor),
+                new SettingsPluginHandler(settingsService, businessExecutor)
+        );
+    }
+
+    private void serveImage(Context context, DesktopCatalogService resources, String type) {
+        try {
+            String photoId = context.pathParam("photoId");
+            int sortOrder = Integer.parseInt(context.pathParam("sortOrder"));
+            AsyncRequestHandler.submit(
+                    context,
+                    businessExecutor,
+                    () -> resources.getImage(photoId, sortOrder, type),
+                    resource -> context.contentType(resource.mediaType()).result(resource.bytes())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
         }
     }
 
@@ -186,6 +301,16 @@ public final class DesktopBackend implements AutoCloseable {
             businessExecutor.shutdownNow();
             Thread.currentThread().interrupt();
         }
+        closeClient();
         database.close();
+    }
+
+    private void closeClient() {
+        JmApiClient current = client;
+        client = null;
+        catalogService = null;
+        if (current != null) {
+            current.close();
+        }
     }
 }

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/DesktopPlugin.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/DesktopPlugin.java
@@ -1,22 +1,136 @@
 package io.github.jukomu.desktop.bridge;
 
 import io.github.jukomu.desktop.bridge.handler.SystemPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.ApiPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.AuthPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.HistoryPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SettingsPluginHandler;
 import io.javalin.http.Context;
 
 /** 向本地 HTTP backend 暴露的唯一 Desktop bridge。 */
 public final class DesktopPlugin {
+    private final ApiPluginHandler apiHandler;
+    private final AuthPluginHandler authHandler;
+    private final HistoryPluginHandler historyHandler;
+    private final SettingsPluginHandler settingsHandler;
     private final SystemPluginHandler systemHandler;
 
-    public DesktopPlugin() {
-        this(new SystemPluginHandler());
-    }
-
-    public DesktopPlugin(SystemPluginHandler systemHandler) {
+    public DesktopPlugin(
+            SystemPluginHandler systemHandler,
+            ApiPluginHandler apiHandler,
+            AuthPluginHandler authHandler,
+            HistoryPluginHandler historyHandler,
+            SettingsPluginHandler settingsHandler
+    ) {
         this.systemHandler = systemHandler;
+        this.apiHandler = apiHandler;
+        this.authHandler = authHandler;
+        this.historyHandler = historyHandler;
+        this.settingsHandler = settingsHandler;
     }
 
     @PluginMethod
     public void getInitStatus(Context context) {
         systemHandler.getInitStatus(context);
+    }
+
+    @PluginMethod
+    public void search(Context context) {
+        apiHandler.search(context);
+    }
+
+    @PluginMethod
+    public void categories(Context context) {
+        apiHandler.categories(context);
+    }
+
+    @PluginMethod
+    public void getAlbum(Context context) {
+        apiHandler.getAlbum(context);
+    }
+
+    @PluginMethod
+    public void getPhoto(Context context) {
+        apiHandler.getPhoto(context);
+    }
+
+    @PluginMethod
+    public void getComments(Context context) {
+        apiHandler.getComments(context);
+    }
+
+    @PluginMethod
+    public void login(Context context) {
+        authHandler.login(context);
+    }
+
+    @PluginMethod
+    public void logout(Context context) {
+        authHandler.logout(context);
+    }
+
+    @PluginMethod
+    public void checkLoginState(Context context) {
+        authHandler.checkLoginState(context);
+    }
+
+    @PluginMethod
+    public void getUserProfile(Context context) {
+        authHandler.getUserProfile(context);
+    }
+
+    @PluginMethod
+    public void getAllSettings(Context context) {
+        settingsHandler.getAllSettings(context);
+    }
+
+    @PluginMethod
+    public void setPreloadConcurrency(Context context) {
+        settingsHandler.setPreloadConcurrency(context);
+    }
+
+    @PluginMethod
+    public void setDownloadConcurrency(Context context) {
+        settingsHandler.setDownloadConcurrency(context);
+    }
+
+    @PluginMethod
+    public void setReaderPreloadPages(Context context) {
+        settingsHandler.setReaderPreloadPages(context);
+    }
+
+    @PluginMethod
+    public void setReaderDisplayMode(Context context) {
+        settingsHandler.setReaderDisplayMode(context);
+    }
+
+    @PluginMethod
+    public void setReaderAutoShowToolbarAtEnd(Context context) {
+        settingsHandler.setReaderAutoShowToolbarAtEnd(context);
+    }
+
+    @PluginMethod
+    public void getBrowseHistory(Context context) {
+        historyHandler.getBrowseHistory(context);
+    }
+
+    @PluginMethod
+    public void getBrowseHistoryOverview(Context context) {
+        historyHandler.getBrowseHistoryOverview(context);
+    }
+
+    @PluginMethod
+    public void recordBrowse(Context context) {
+        historyHandler.recordBrowse(context);
+    }
+
+    @PluginMethod
+    public void clearBrowseHistory(Context context) {
+        historyHandler.clearBrowseHistory(context);
+    }
+
+    @PluginMethod
+    public void deleteBrowseItem(Context context) {
+        historyHandler.deleteBrowseItem(context);
     }
 }

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/PluginMethodRoutes.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/PluginMethodRoutes.java
@@ -48,6 +48,11 @@ public final class PluginMethodRoutes {
                     continue;
                 }
                 validate(method);
+                if (!method.trySetAccessible()) {
+                    throw new IllegalArgumentException(
+                            "@PluginMethod is not accessible: " + method
+                    );
+                }
                 String path = "/api/" + method.getName();
                 if (!routes.add(path)) {
                     throw new IllegalArgumentException("Duplicate Desktop plugin route: " + path);

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/ApiPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/ApiPluginHandler.java
@@ -1,0 +1,82 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.service.DesktopCatalogService;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 负责目录、章节和评论请求的解析、调度及 JSON 响应转换。 */
+public final class ApiPluginHandler {
+    private final DesktopCatalogService catalogService;
+    private final Executor executor;
+
+    public ApiPluginHandler(DesktopCatalogService catalogService, Executor executor) {
+        this.catalogService = Objects.requireNonNull(catalogService, "catalogService");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void search(Context context) {
+        try {
+            DesktopDtos.SearchRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.SearchRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> catalogService.search(request.query())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void categories(Context context) {
+        try {
+            DesktopDtos.SearchRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.SearchRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> catalogService.categories(request.query())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void getAlbum(Context context) {
+        try {
+            DesktopDtos.IdRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.IdRequest.class);
+            AsyncRequestHandler.submitJson(context, executor, () -> catalogService.getAlbum(request.id()));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void getPhoto(Context context) {
+        try {
+            DesktopDtos.IdRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.IdRequest.class);
+            AsyncRequestHandler.submitJson(context, executor, () -> catalogService.getPhoto(request.id()));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void getComments(Context context) {
+        try {
+            DesktopDtos.CommentsRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.CommentsRequest.class);
+            int page = request.page() == null ? 1 : request.page();
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> catalogService.getComments(request.albumId(), page)
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AsyncRequestHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AsyncRequestHandler.java
@@ -1,0 +1,133 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.error.DesktopHttpException;
+import io.github.jukomu.jmcomic.api.exception.NetworkException;
+import io.github.jukomu.jmcomic.api.exception.ResourceNotFoundException;
+import io.github.jukomu.jmcomic.api.exception.ResponseException;
+import io.github.jukomu.jmcomic.api.exception.JmComicException;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/** 统一执行 Desktop 阻塞业务调用，并保证 Javalin 响应只提交一次。 */
+public final class AsyncRequestHandler {
+    private AsyncRequestHandler() {
+    }
+
+    public static <T> void submitJson(
+            Context context,
+            Executor executor,
+            Callable<T> operation
+    ) {
+        submit(context, executor, operation, context::json);
+    }
+
+    public static <T> void submit(
+            Context context,
+            Executor executor,
+            Callable<T> operation,
+            Consumer<T> writer
+    ) {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(executor, "executor");
+        Objects.requireNonNull(operation, "operation");
+        Objects.requireNonNull(writer, "writer");
+
+        AtomicBoolean responded = new AtomicBoolean();
+        CompletableFuture<Void> response;
+        try {
+            response = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return operation.call();
+                } catch (Exception exception) {
+                    throw new CompletionException(exception);
+                }
+            }, executor).thenAccept(result -> respondOnce(responded, () -> writer.accept(result)))
+                    .exceptionally(error -> {
+                        respondOnce(responded, () -> writeError(context, unwrap(error)));
+                        return null;
+                    });
+        } catch (RejectedExecutionException exception) {
+            writeError(context, exception);
+            return;
+        }
+
+        context.future(() -> response);
+    }
+
+    public static <T> T readBody(Context context, Class<T> type) {
+        T body = context.bodyAsClass(type);
+        if (body == null) {
+            throw new IllegalArgumentException("request body is required");
+        }
+        return body;
+    }
+
+    public static void writeError(Context context, Throwable error) {
+        DesktopHttpException mapped = mapError(error);
+        context.status(mapped.status()).json(
+                new DesktopDtos.ErrorResponse(mapped.code(), mapped.getMessage())
+        );
+    }
+
+    private static void respondOnce(AtomicBoolean responded, Runnable response) {
+        if (responded.compareAndSet(false, true)) {
+            response.run();
+        }
+    }
+
+    private static DesktopHttpException mapError(Throwable error) {
+        Throwable cause = unwrap(error);
+        if (cause instanceof DesktopHttpException desktopError) {
+            return desktopError;
+        }
+        if (cause instanceof ResourceNotFoundException) {
+            return new DesktopHttpException("not-found", 404, message(cause));
+        }
+        if (cause instanceof NetworkException) {
+            return new DesktopHttpException("network", 502, message(cause));
+        }
+        if (cause instanceof ResponseException) {
+            return new DesktopHttpException("internal", 502, message(cause));
+        }
+        if (cause instanceof IllegalArgumentException) {
+            return new DesktopHttpException("internal", 400, message(cause));
+        }
+        if (cause instanceof RejectedExecutionException) {
+            return new DesktopHttpException("internal", 503, "Desktop 业务线程池暂时不可用");
+        }
+        if (cause instanceof java.util.concurrent.CancellationException
+                || cause instanceof InterruptedException) {
+            return new DesktopHttpException("cancelled", 499, "Desktop 请求已取消");
+        }
+        if (cause instanceof JmComicException) {
+            return new DesktopHttpException("internal", 502, message(cause));
+        }
+        return new DesktopHttpException("internal", 500, message(cause));
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        Throwable current = error;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static String message(Throwable error) {
+        if (error != null && error.getMessage() != null && !error.getMessage().isBlank()) {
+            return error.getMessage();
+        }
+        return "Desktop 请求失败";
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AuthPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AuthPluginHandler.java
@@ -1,0 +1,55 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.service.DesktopAuthService;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 负责 Desktop 登录、登出、登录态和用户资料请求。 */
+public final class AuthPluginHandler {
+    private final DesktopAuthService authService;
+    private final Executor executor;
+
+    public AuthPluginHandler(DesktopAuthService authService, Executor executor) {
+        this.authService = Objects.requireNonNull(authService, "authService");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void login(Context context) {
+        try {
+            DesktopDtos.LoginRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.LoginRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> authService.login(request.username(), request.password())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void logout(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, authService::logout);
+    }
+
+    public void checkLoginState(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, authService::checkLoginState);
+    }
+
+    public void getUserProfile(Context context) {
+        try {
+            DesktopDtos.IdRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.IdRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> authService.getUserProfile(request.id())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/HistoryPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/HistoryPluginHandler.java
@@ -1,0 +1,88 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.service.DesktopHistoryService;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 负责浏览历史参数解析、事务调用和分页结果转换。 */
+public final class HistoryPluginHandler {
+    private final DesktopHistoryService historyService;
+    private final Executor executor;
+
+    public HistoryPluginHandler(DesktopHistoryService historyService, Executor executor) {
+        this.historyService = Objects.requireNonNull(historyService, "historyService");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void getBrowseHistory(Context context) {
+        try {
+            DesktopDtos.BrowseHistoryQuery request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.BrowseHistoryQuery.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> historyService.getBrowseHistory(
+                            valueOrZero(request.limit()),
+                            valueOrZero(request.offset()),
+                            request.startInclusive(),
+                            request.endExclusive()
+                    )
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void getBrowseHistoryOverview(Context context) {
+        try {
+            DesktopDtos.BrowseHistoryOverviewRequest request = AsyncRequestHandler.readBody(
+                    context,
+                    DesktopDtos.BrowseHistoryOverviewRequest.class
+            );
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> historyService.getBrowseHistoryOverview(request.ranges())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void recordBrowse(Context context) {
+        try {
+            DesktopDtos.RecordBrowseRequest request = AsyncRequestHandler.readBody(
+                    context,
+                    DesktopDtos.RecordBrowseRequest.class
+            );
+            AsyncRequestHandler.submitJson(context, executor, () -> historyService.recordBrowse(request));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void clearBrowseHistory(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, historyService::clearBrowseHistory);
+    }
+
+    public void deleteBrowseItem(Context context) {
+        try {
+            DesktopDtos.NumberRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.NumberRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> historyService.deleteBrowseItem(valueOrZero(request.n()))
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    private static int valueOrZero(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/SettingsPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/SettingsPluginHandler.java
@@ -1,0 +1,91 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.service.DesktopSettingsService;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 负责基础设置的请求解析、校验和 SQLite 持久化调度。 */
+public final class SettingsPluginHandler {
+    private final DesktopSettingsService settingsService;
+    private final Executor executor;
+
+    public SettingsPluginHandler(DesktopSettingsService settingsService, Executor executor) {
+        this.settingsService = Objects.requireNonNull(settingsService, "settingsService");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void getAllSettings(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, settingsService::getAllSettings);
+    }
+
+    public void setPreloadConcurrency(Context context) {
+        setNumber(context, settingsService::setPreloadConcurrency);
+    }
+
+    public void setDownloadConcurrency(Context context) {
+        setNumber(context, settingsService::setDownloadConcurrency);
+    }
+
+    public void setReaderPreloadPages(Context context) {
+        setNumber(context, settingsService::setReaderPreloadPages);
+    }
+
+    public void setReaderDisplayMode(Context context) {
+        try {
+            DesktopDtos.StringRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.StringRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> {
+                        settingsService.setReaderDisplayMode(request.mode());
+                        return new DesktopDtos.Success(true);
+                    }
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void setReaderAutoShowToolbarAtEnd(Context context) {
+        try {
+            DesktopDtos.BooleanRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.BooleanRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> {
+                        settingsService.setReaderAutoShowToolbarAtEnd(request.enabled());
+                        return new DesktopDtos.Success(true);
+                    }
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    private void setNumber(Context context, NumberSetter setter) {
+        try {
+            DesktopDtos.NumberRequest request =
+                    AsyncRequestHandler.readBody(context, DesktopDtos.NumberRequest.class);
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> {
+                        setter.set(request.n());
+                        return new DesktopDtos.Success(true);
+                    }
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    @FunctionalInterface
+    private interface NumberSetter {
+        void set(Integer value) throws Exception;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/SystemPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/SystemPluginHandler.java
@@ -2,10 +2,23 @@ package io.github.jukomu.desktop.bridge.handler;
 
 import io.javalin.http.Context;
 
-/** 提供不依赖远程服务的系统方法。 */
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+/** 提供初始化状态等不依赖请求参数的系统方法。 */
 public final class SystemPluginHandler {
+    private final BooleanSupplier clientPresent;
+
+    public SystemPluginHandler() {
+        this(() -> true);
+    }
+
+    public SystemPluginHandler(BooleanSupplier clientPresent) {
+        this.clientPresent = Objects.requireNonNull(clientPresent, "clientPresent");
+    }
+
     public void getInitStatus(Context context) {
-        context.json(new InitStatus(true));
+        context.json(new InitStatus(clientPresent.getAsBoolean()));
     }
 
     public record InitStatus(boolean complete) {

--- a/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopDatabase.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopDatabase.java
@@ -11,6 +11,8 @@ import java.sql.Statement;
 
 /** 管理 Desktop SQLite 连接，并提供 schema migration 入口。 */
 public final class DesktopDatabase implements AutoCloseable {
+    public static final int CURRENT_SCHEMA_VERSION = 2;
+
     private final Path databasePath;
     private Connection connection;
 
@@ -61,6 +63,103 @@ public final class DesktopDatabase implements AutoCloseable {
         )) {
             statement.executeUpdate();
         }
+
+        int version;
+        try (Statement statement = connection.createStatement();
+             var result = statement.executeQuery(
+                     "SELECT version FROM desktop_schema_version LIMIT 1")) {
+            if (!result.next()) {
+                throw new SQLException("Desktop schema version ledger is empty");
+            }
+            version = result.getInt(1);
+        }
+
+        if (version >= CURRENT_SCHEMA_VERSION) {
+            return;
+        }
+
+        boolean autoCommit = connection.getAutoCommit();
+        try {
+            connection.setAutoCommit(false);
+            createBusinessSchema(connection);
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE desktop_schema_version SET version = ?")) {
+                statement.setInt(1, CURRENT_SCHEMA_VERSION);
+                statement.executeUpdate();
+            }
+            connection.commit();
+        } catch (SQLException | RuntimeException exception) {
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackException) {
+                exception.addSuppressed(rollbackException);
+            }
+            throw exception;
+        } finally {
+            connection.setAutoCommit(autoCommit);
+        }
+    }
+
+    private static void createBusinessSchema(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    CREATE TABLE IF NOT EXISTS desktop_settings (
+                        key TEXT PRIMARY KEY NOT NULL,
+                        value TEXT NOT NULL,
+                        updated_at INTEGER NOT NULL
+                    )
+                    """);
+            statement.executeUpdate("""
+                    CREATE TABLE IF NOT EXISTS browse_history (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        album_id TEXT NOT NULL,
+                        album_title TEXT NOT NULL,
+                        cover_url TEXT NOT NULL DEFAULT '',
+                        authors TEXT NOT NULL DEFAULT '',
+                        chapter_id TEXT NOT NULL DEFAULT '',
+                        chapter_title TEXT NOT NULL DEFAULT '',
+                        timestamp INTEGER NOT NULL
+                    )
+                    """);
+            statement.executeUpdate(
+                    "CREATE INDEX IF NOT EXISTS idx_browse_history_timestamp_id "
+                            + "ON browse_history (timestamp DESC, id DESC)"
+            );
+        }
+
+        insertDefaultSettings(connection);
+    }
+
+    private static void insertDefaultSettings(Connection connection) throws SQLException {
+        long now = System.currentTimeMillis();
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT OR IGNORE INTO desktop_settings(key, value, updated_at) VALUES (?, ?, ?)")) {
+            insertDefaultSetting(statement, "reader_preload_pages", "15", now);
+            insertDefaultSetting(statement, "preload_concurrency", "6", now);
+            insertDefaultSetting(statement, "download_concurrency", "6", now);
+            insertDefaultSetting(statement, "download_public", "false", now);
+            insertDefaultSetting(statement, "cache_capacity_mb", "256", now);
+            insertDefaultSetting(statement, "ocr_enabled", "true", now);
+            insertDefaultSetting(statement, "reader_display_mode", "vertical", now);
+            insertDefaultSetting(statement, "reader_screen_orientation", "auto", now);
+            insertDefaultSetting(statement, "reader_brightness", "-1", now);
+            insertDefaultSetting(statement, "reader_keep_screen_on", "true", now);
+            insertDefaultSetting(statement, "reader_volume_navigation", "false", now);
+            insertDefaultSetting(statement, "reader_auto_show_toolbar_at_end", "true", now);
+            statement.executeBatch();
+        }
+    }
+
+    private static void insertDefaultSetting(
+            PreparedStatement statement,
+            String key,
+            String value,
+            long updatedAt
+    ) throws SQLException {
+        statement.setString(1, key);
+        statement.setString(2, value);
+        statement.setLong(3, updatedAt);
+        statement.addBatch();
     }
 
     public synchronized Connection connection() {

--- a/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopHistoryStore.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopHistoryStore.java
@@ -1,0 +1,287 @@
+package io.github.jukomu.desktop.data;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Desktop 浏览历史的 SQLite 读写与事务边界。 */
+public final class DesktopHistoryStore {
+    private static final String[] BROWSE_GROUP_KEYS = {
+            "today", "yesterday", "thisWeek", "thisMonth",
+            "lastThreeMonths", "lastSixMonths", "thisYear", "earlier"
+    };
+
+    private final DesktopDatabase database;
+
+    public DesktopHistoryStore(DesktopDatabase database) {
+        this.database = Objects.requireNonNull(database, "database");
+    }
+
+    /**
+     * 复用 Android 当前行为：只把最近一条相同专辑的记录更新到最前，避免连续阅读同一本子产生重复卡片。
+     */
+    public void recordBrowse(DesktopDtos.RecordBrowseRequest request) throws SQLException {
+        synchronized (database) {
+            var connection = database.connection();
+            boolean autoCommit = connection.getAutoCommit();
+            try {
+                connection.setAutoCommit(false);
+                Long latestId = null;
+                try (PreparedStatement statement = connection.prepareStatement("""
+                        SELECT id
+                        FROM browse_history
+                        ORDER BY id DESC
+                        LIMIT 1
+                        """)) {
+                    try (ResultSet result = statement.executeQuery()) {
+                        if (result.next()) {
+                            latestId = result.getLong(1);
+                        }
+                    }
+                }
+
+                boolean updated = false;
+                if (latestId != null) {
+                    try (PreparedStatement statement = connection.prepareStatement(
+                            "SELECT album_id FROM browse_history WHERE id = ?")) {
+                        statement.setLong(1, latestId);
+                        try (ResultSet result = statement.executeQuery()) {
+                            if (result.next() && request.albumId().equals(result.getString(1))) {
+                                try (PreparedStatement update = connection.prepareStatement("""
+                                        UPDATE browse_history
+                                        SET album_title = ?, cover_url = ?, authors = ?,
+                                            chapter_id = ?, chapter_title = ?, timestamp = ?
+                                        WHERE id = ?
+                                        """)) {
+                                    bindBrowseValues(update, request);
+                                    update.setLong(7, latestId);
+                                    update.executeUpdate();
+                                }
+                                updated = true;
+                            }
+                        }
+                    }
+                }
+
+                if (!updated) {
+                    try (PreparedStatement statement = connection.prepareStatement("""
+                            INSERT INTO browse_history(
+                                album_id, album_title, cover_url, authors,
+                                chapter_id, chapter_title, timestamp
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                            """)) {
+                        statement.setString(1, request.albumId());
+                        bindBrowseValues(statement, request, 2);
+                        statement.executeUpdate();
+                    }
+                }
+                connection.commit();
+            } catch (SQLException | RuntimeException exception) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackException) {
+                    exception.addSuppressed(rollbackException);
+                }
+                throw exception;
+            } finally {
+                connection.setAutoCommit(autoCommit);
+            }
+        }
+    }
+
+    public DesktopDtos.HistoryPage getBrowseHistory(
+            int limit,
+            int offset,
+            Long startInclusive,
+            Long endExclusive
+    ) throws SQLException {
+        validatePagination(limit, offset);
+        synchronized (database) {
+            String where = rangeWhere(startInclusive, endExclusive);
+            List<String> args = rangeArgs(startInclusive, endExclusive);
+            long totalCount = count("browse_history", where, args);
+            String sql = """
+                    SELECT id, album_id, album_title, cover_url, authors,
+                           chapter_id, chapter_title, timestamp
+                    FROM browse_history
+                    %s
+                    ORDER BY timestamp DESC, id DESC
+                    """.formatted(where);
+            if (limit > 0) {
+                sql += " LIMIT ? OFFSET ?";
+            }
+
+            List<DesktopDtos.BrowseHistoryItem> items = new ArrayList<>();
+            try (PreparedStatement statement = database.connection().prepareStatement(sql)) {
+                int index = bindArgs(statement, args, 1);
+                if (limit > 0) {
+                    statement.setInt(index++, limit);
+                    statement.setInt(index, offset);
+                }
+                try (ResultSet result = statement.executeQuery()) {
+                    while (result.next()) {
+                        items.add(new DesktopDtos.BrowseHistoryItem(
+                                result.getLong("id"),
+                                result.getString("album_id"),
+                                result.getString("album_title"),
+                                result.getString("cover_url"),
+                                result.getString("authors"),
+                                result.getString("chapter_id"),
+                                result.getString("chapter_title"),
+                                result.getLong("timestamp")
+                        ));
+                    }
+                }
+            }
+            return new DesktopDtos.HistoryPage(items, totalCount);
+        }
+    }
+
+    public DesktopDtos.BrowseHistoryOverview getBrowseHistoryOverview(
+            List<DesktopDtos.BrowseHistoryRange> ranges
+    ) throws SQLException {
+        Objects.requireNonNull(ranges, "ranges");
+        if (ranges.size() != BROWSE_GROUP_KEYS.length) {
+            throw new IllegalArgumentException("ranges must contain exactly eight groups");
+        }
+
+        java.util.LinkedHashMap<String, Long> groupCounts = new java.util.LinkedHashMap<>();
+        java.util.HashSet<String> seen = new java.util.HashSet<>();
+        synchronized (database) {
+            for (DesktopDtos.BrowseHistoryRange range : ranges) {
+                validateRangeKey(range.key());
+                if (!seen.add(range.key())) {
+                    throw new IllegalArgumentException(
+                            "invalid or duplicate browse group key: " + range.key());
+                }
+                groupCounts.put(
+                        range.key(),
+                        count("browse_history", rangeWhere(range.startInclusive(), range.endExclusive()),
+                                rangeArgs(range.startInclusive(), range.endExclusive()))
+                );
+            }
+            for (String key : BROWSE_GROUP_KEYS) {
+                if (!seen.contains(key)) {
+                    throw new IllegalArgumentException("missing browse group key: " + key);
+                }
+            }
+            return new DesktopDtos.BrowseHistoryOverview(
+                    count("browse_history", null, List.of()),
+                    groupCounts
+            );
+        }
+    }
+
+    public void clearBrowseHistory() throws SQLException {
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "DELETE FROM browse_history")) {
+                statement.executeUpdate();
+            }
+        }
+    }
+
+    public void deleteBrowseItem(long id) throws SQLException {
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "DELETE FROM browse_history WHERE id = ?")) {
+                statement.setLong(1, id);
+                statement.executeUpdate();
+            }
+        }
+    }
+
+    private long count(String table, String where, List<String> args) throws SQLException {
+        String sql = "SELECT COUNT(*) FROM " + table + (where == null ? "" : " " + where);
+        try (PreparedStatement statement = database.connection().prepareStatement(sql)) {
+            bindArgs(statement, args, 1);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) {
+                    throw new SQLException("count query returned no row");
+                }
+                return result.getLong(1);
+            }
+        }
+    }
+
+    private static void bindBrowseValues(
+            PreparedStatement statement,
+            DesktopDtos.RecordBrowseRequest request
+    ) throws SQLException {
+        bindBrowseValues(statement, request, 1);
+    }
+
+    private static void bindBrowseValues(
+            PreparedStatement statement,
+            DesktopDtos.RecordBrowseRequest request,
+            int offset
+    ) throws SQLException {
+        statement.setString(offset, request.albumTitle());
+        statement.setString(offset + 1, request.coverUrl());
+        statement.setString(offset + 2, request.authors());
+        statement.setString(offset + 3, request.chapterId());
+        statement.setString(offset + 4, request.chapterTitle());
+        statement.setLong(offset + 5, System.currentTimeMillis());
+    }
+
+    private static String rangeWhere(Long startInclusive, Long endExclusive) {
+        if (startInclusive != null && endExclusive != null && startInclusive >= endExclusive) {
+            return "WHERE 1 = 0";
+        }
+        if (startInclusive == null && endExclusive == null) {
+            return "";
+        }
+        if (startInclusive == null) {
+            return "WHERE timestamp < ?";
+        }
+        if (endExclusive == null) {
+            return "WHERE timestamp >= ?";
+        }
+        return "WHERE timestamp >= ? AND timestamp < ?";
+    }
+
+    private static List<String> rangeArgs(Long startInclusive, Long endExclusive) {
+        if (startInclusive != null && endExclusive != null && startInclusive >= endExclusive) {
+            return List.of();
+        }
+        if (startInclusive == null && endExclusive == null) {
+            return List.of();
+        }
+        if (startInclusive == null) {
+            return List.of(String.valueOf(endExclusive));
+        }
+        if (endExclusive == null) {
+            return List.of(String.valueOf(startInclusive));
+        }
+        return List.of(String.valueOf(startInclusive), String.valueOf(endExclusive));
+    }
+
+    private static int bindArgs(PreparedStatement statement, List<String> args, int start)
+            throws SQLException {
+        int index = start;
+        for (String arg : args) {
+            statement.setString(index++, arg);
+        }
+        return index;
+    }
+
+    private static void validatePagination(int limit, int offset) {
+        if (limit < 0 || offset < 0) {
+            throw new IllegalArgumentException("limit and offset must be non-negative");
+        }
+    }
+
+    private static void validateRangeKey(String key) {
+        for (String validKey : BROWSE_GROUP_KEYS) {
+            if (validKey.equals(key)) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException("invalid browse group key: " + key);
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopSettingsStore.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopSettingsStore.java
@@ -1,0 +1,47 @@
+package io.github.jukomu.desktop.data;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+/** 使用 Desktop 自己的 SQLite 设置表保存标量应用设置。 */
+public final class DesktopSettingsStore {
+    private final DesktopDatabase database;
+
+    public DesktopSettingsStore(DesktopDatabase database) {
+        this.database = Objects.requireNonNull(database, "database");
+    }
+
+    public String getString(String key) throws SQLException {
+        Objects.requireNonNull(key, "key");
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "SELECT value FROM desktop_settings WHERE key = ?")) {
+                statement.setString(1, key);
+                try (ResultSet result = statement.executeQuery()) {
+                    return result.next() ? result.getString(1) : null;
+                }
+            }
+        }
+    }
+
+    public void putString(String key, String value) throws SQLException {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement("""
+                    INSERT INTO desktop_settings(key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                        value = excluded.value,
+                        updated_at = excluded.updated_at
+                    """)) {
+                statement.setString(1, key);
+                statement.setString(2, value);
+                statement.setLong(3, System.currentTimeMillis());
+                statement.executeUpdate();
+            }
+        }
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/dto/DesktopDtos.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/dto/DesktopDtos.java
@@ -1,0 +1,259 @@
+package io.github.jukomu.desktop.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/** Desktop HTTP 边界使用的请求、响应和资源 DTO。 */
+public final class DesktopDtos {
+    private DesktopDtos() {
+    }
+
+    public record SearchRequest(SearchQuery query) {
+    }
+
+    public record SearchQuery(
+            String keyword,
+            String category,
+            String orderBy,
+            String time,
+            Integer searchMainTag,
+            Integer page
+    ) {
+    }
+
+    public record IdRequest(String id) {
+    }
+
+    public record CommentsRequest(String albumId, Integer page) {
+    }
+
+    public record LoginRequest(String username, String password) {
+    }
+
+    public record UserInfo(
+            String uid,
+            String username,
+            String email,
+            boolean emailVerified,
+            String avatarUrl,
+            String firstName,
+            String gender,
+            String message,
+            int level,
+            String levelName,
+            long nextLevelExp,
+            long currentExp,
+            double expPercent,
+            int coin,
+            int albumFavorites,
+            int maxAlbumFavorites
+    ) {
+    }
+
+    public record LoginState(boolean loggedIn, String username, UserInfo userInfo) {
+    }
+
+    public record UserProfile(
+            String username,
+            String email,
+            String nickname,
+            String birthday,
+            String city,
+            String country,
+            String occupation,
+            String aboutMe,
+            String website
+    ) {
+    }
+
+    public record SearchResult(
+            int currentPage,
+            int totalItems,
+            int totalPages,
+            List<SearchResultItem> content
+    ) {
+    }
+
+    public record SearchResultItem(
+            String id,
+            String title,
+            String coverUrl,
+            List<String> authors,
+            List<String> tags
+    ) {
+    }
+
+    public record CategoryMeta(String id, String title) {
+    }
+
+    public record PhotoMeta(String id, String title, int sortOrder) {
+    }
+
+    public record ImageInfo(
+            String photoId,
+            String scrambleId,
+            String filename,
+            String url,
+            String queryParams,
+            int sortOrder
+    ) {
+    }
+
+    public record PhotoDetail(
+            String id,
+            String title,
+            String albumId,
+            int sortOrder,
+            String author,
+            List<String> tags,
+            List<ImageInfo> images,
+            boolean isSingleEpisode
+    ) {
+    }
+
+    public record AlbumDetail(
+            String id,
+            String title,
+            String description,
+            String addTime,
+            int pageCount,
+            String likes,
+            String views,
+            int commentCount,
+            String image,
+            CategoryMeta category,
+            CategoryMeta subCategory,
+            List<String> authors,
+            List<String> works,
+            List<String> actors,
+            List<String> tags,
+            List<AlbumMeta> relatedAlbums,
+            List<PhotoMeta> photoMetas,
+            String seriesId,
+            boolean isSingleEpisode,
+            boolean isFavorite,
+            boolean isLiked,
+            String price,
+            String purchased
+    ) {
+    }
+
+    public record AlbumMeta(
+            String id,
+            String title,
+            String coverUrl,
+            List<String> authors,
+            List<String> tags,
+            String description,
+            String image,
+            CategoryMeta category,
+            CategoryMeta subCategory
+    ) {
+    }
+
+    public record CommentList(int total, List<CommentItem> list) {
+    }
+
+    public record CommentItem(
+            String commentId,
+            String userId,
+            String username,
+            String nickname,
+            String content,
+            String postDate,
+            String photo,
+            String expinfo,
+            String aid,
+            String name,
+            int likes,
+            int voteUp,
+            int voteDown,
+            List<CommentItem> replys
+    ) {
+    }
+
+    public record AllSettings(
+            int readerPreloadPages,
+            int preloadConcurrency,
+            int downloadConcurrency,
+            boolean downloadPublic,
+            int cacheCapacityMb,
+            int cacheRequestedMb,
+            int cacheEffectiveMb,
+            boolean cacheTemporaryClamp,
+            String cacheLimitReason,
+            boolean ocrEnabled,
+            String readerDisplayMode,
+            String readerScreenOrientation,
+            double readerBrightness,
+            boolean readerKeepScreenOn,
+            boolean readerVolumeNavigation,
+            boolean readerAutoShowToolbarAtEnd
+    ) {
+    }
+
+    public record NumberRequest(Integer n) {
+    }
+
+    public record StringRequest(String mode) {
+    }
+
+    public record BooleanRequest(Boolean enabled) {
+    }
+
+    public record RecordBrowseRequest(
+            String albumId,
+            String albumTitle,
+            String coverUrl,
+            String authors,
+            String chapterId,
+            String chapterTitle
+    ) {
+    }
+
+    public record BrowseHistoryRange(
+            String key,
+            Long startInclusive,
+            Long endExclusive
+    ) {
+    }
+
+    public record BrowseHistoryOverviewRequest(List<BrowseHistoryRange> ranges) {
+    }
+
+    public record BrowseHistoryQuery(
+            Integer limit,
+            Integer offset,
+            Long startInclusive,
+            Long endExclusive
+    ) {
+    }
+
+    public record BrowseHistoryItem(
+            long id,
+            String albumId,
+            String albumTitle,
+            String coverUrl,
+            String authors,
+            String chapterId,
+            String chapterTitle,
+            long timestamp
+    ) {
+    }
+
+    public record HistoryPage(List<BrowseHistoryItem> items, long totalCount) {
+    }
+
+    public record BrowseHistoryOverview(long totalCount, Map<String, Long> groupCounts) {
+    }
+
+    public record Success(boolean success) {
+    }
+
+    public record ErrorResponse(String code, String message) {
+    }
+
+    /** 图片资源响应不走 JSON，单独携带解密后的字节和 Content-Type。 */
+    public record ImageResource(byte[] bytes, String mediaType) {
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/error/DesktopHttpException.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/error/DesktopHttpException.java
@@ -1,0 +1,23 @@
+package io.github.jukomu.desktop.error;
+
+import java.util.Objects;
+
+/** 带稳定错误码和 HTTP 状态的 Desktop 业务异常。 */
+public final class DesktopHttpException extends RuntimeException {
+    private final String code;
+    private final int status;
+
+    public DesktopHttpException(String code, int status, String message) {
+        super(Objects.requireNonNull(message, "message"));
+        this.code = Objects.requireNonNull(code, "code");
+        this.status = status;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public int status() {
+        return status;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopAuthService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopAuthService.java
@@ -1,0 +1,14 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+
+/** Desktop 登录态与在线认证业务接口。 */
+public interface DesktopAuthService {
+    DesktopDtos.UserInfo login(String username, String password);
+
+    DesktopDtos.Success logout();
+
+    DesktopDtos.LoginState checkLoginState();
+
+    DesktopDtos.UserProfile getUserProfile(String uid);
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopCatalogService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopCatalogService.java
@@ -1,0 +1,18 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+
+/** Desktop 在线目录能力；HTTP handler 只依赖该业务接口。 */
+public interface DesktopCatalogService {
+    DesktopDtos.SearchResult search(DesktopDtos.SearchQuery query);
+
+    DesktopDtos.SearchResult categories(DesktopDtos.SearchQuery query);
+
+    DesktopDtos.AlbumDetail getAlbum(String id);
+
+    DesktopDtos.PhotoDetail getPhoto(String id);
+
+    DesktopDtos.CommentList getComments(String albumId, int page);
+
+    DesktopDtos.ImageResource getImage(String photoId, int sortOrder, String type);
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopDtoMapper.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopDtoMapper.java
@@ -1,0 +1,213 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.jmcomic.api.model.JmAlbum;
+import io.github.jukomu.jmcomic.api.model.JmAlbumMeta;
+import io.github.jukomu.jmcomic.api.model.JmCategoryMeta;
+import io.github.jukomu.jmcomic.api.model.JmComment;
+import io.github.jukomu.jmcomic.api.model.JmCommentList;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+import io.github.jukomu.jmcomic.api.model.JmPhoto;
+import io.github.jukomu.jmcomic.api.model.JmPhotoMeta;
+import io.github.jukomu.jmcomic.api.model.JmSearchPage;
+import io.github.jukomu.jmcomic.api.model.JmUserInfo;
+import io.github.jukomu.jmcomic.api.model.JmUserProfile;
+
+import java.util.List;
+import java.util.function.Function;
+
+/** 将 JMComic 模型转换为 Desktop HTTP 的稳定 JSON DTO。 */
+public final class DesktopDtoMapper {
+    private DesktopDtoMapper() {
+    }
+
+    public static DesktopDtos.SearchResult searchResult(
+            JmSearchPage page,
+            Function<String, String> coverUrl
+    ) {
+        List<DesktopDtos.SearchResultItem> content = safeList(page.getContent()).stream()
+                .map(item -> searchResultItem(item, coverUrl))
+                .toList();
+        return new DesktopDtos.SearchResult(
+                page.getCurrentPage(),
+                page.getTotalItems(),
+                page.getTotalPages(),
+                content
+        );
+    }
+
+    public static DesktopDtos.AlbumDetail album(
+            JmAlbum album,
+            Function<String, String> coverUrl
+    ) {
+        List<DesktopDtos.AlbumMeta> related = safeList(album.getRelatedAlbums()).stream()
+                .map(item -> albumMeta(item, coverUrl))
+                .toList();
+        List<DesktopDtos.PhotoMeta> photos = safeList(album.getPhotoMetas()).stream()
+                .map(DesktopDtoMapper::photoMeta)
+                .toList();
+        return new DesktopDtos.AlbumDetail(
+                text(album.getId()),
+                text(album.getTitle()),
+                text(album.getDescription()),
+                text(album.getAddTime()),
+                album.getPageCount(),
+                text(album.getLikes()),
+                text(album.getViews()),
+                album.getCommentCount(),
+                coverUrl.apply(text(album.getId())),
+                category(album.getCategory()),
+                category(album.getSubCategory()),
+                strings(album.getAuthors()),
+                strings(album.getWorks()),
+                strings(album.getActors()),
+                strings(album.getTags()),
+                related,
+                photos,
+                text(album.getSeriesId()),
+                album.isSingleAlbum(),
+                album.isFavorite(),
+                album.isLiked(),
+                text(album.getPrice()),
+                text(album.getPurchased())
+        );
+    }
+
+    public static DesktopDtos.PhotoDetail photo(JmPhoto photo) {
+        return new DesktopDtos.PhotoDetail(
+                text(photo.getId()),
+                text(photo.getTitle()),
+                text(photo.getAlbumId()),
+                photo.getSortOrder(),
+                text(photo.getAuthor()),
+                strings(photo.getTags()),
+                safeList(photo.getImages()).stream().map(DesktopDtoMapper::image).toList(),
+                photo.isSingleAlbum()
+        );
+    }
+
+    public static DesktopDtos.CommentList comments(JmCommentList comments) {
+        return new DesktopDtos.CommentList(
+                comments.getTotal(),
+                safeList(comments.getList()).stream().map(DesktopDtoMapper::comment).toList()
+        );
+    }
+
+    public static DesktopDtos.UserInfo userInfo(JmUserInfo userInfo) {
+        return new DesktopDtos.UserInfo(
+                text(userInfo.getUid()),
+                text(userInfo.getUsername()),
+                text(userInfo.getEmail()),
+                userInfo.isEmailVerified(),
+                text(userInfo.getPhotoUrl()),
+                text(userInfo.getFirstName()),
+                text(userInfo.getGender()),
+                text(userInfo.getMessage()),
+                userInfo.getLevel(),
+                text(userInfo.getLevelName()),
+                userInfo.getNextLevelExp(),
+                userInfo.getCurrentExp(),
+                userInfo.getExpPercent(),
+                userInfo.getCoin(),
+                userInfo.getAlbumFavorites(),
+                userInfo.getMaxAlbumFavorites()
+        );
+    }
+
+    public static DesktopDtos.UserProfile userProfile(JmUserProfile profile) {
+        return new DesktopDtos.UserProfile(
+                text(profile.username()),
+                text(profile.email()),
+                text(profile.nickname()),
+                text(profile.birthday()),
+                text(profile.city()),
+                text(profile.country()),
+                text(profile.occupation()),
+                text(profile.aboutMe()),
+                text(profile.website())
+        );
+    }
+
+    private static DesktopDtos.SearchResultItem searchResultItem(
+            JmAlbumMeta item,
+            Function<String, String> coverUrl
+    ) {
+        return new DesktopDtos.SearchResultItem(
+                text(item.getId()),
+                text(item.getTitle()),
+                coverUrl.apply(text(item.getId())),
+                strings(item.getAuthors()),
+                strings(item.getTags())
+        );
+    }
+
+    private static DesktopDtos.AlbumMeta albumMeta(
+            JmAlbumMeta item,
+            Function<String, String> coverUrl
+    ) {
+        return new DesktopDtos.AlbumMeta(
+                text(item.getId()),
+                text(item.getTitle()),
+                coverUrl.apply(text(item.getId())),
+                strings(item.getAuthors()),
+                strings(item.getTags()),
+                text(item.getDescription()),
+                text(item.getImage()),
+                category(item.getCategory()),
+                category(item.getSubCategory())
+        );
+    }
+
+    private static DesktopDtos.PhotoMeta photoMeta(JmPhotoMeta meta) {
+        return new DesktopDtos.PhotoMeta(text(meta.getId()), text(meta.getTitle()), meta.getSortOrder());
+    }
+
+    private static DesktopDtos.ImageInfo image(JmImage image) {
+        return new DesktopDtos.ImageInfo(
+                text(image.getPhotoId()),
+                text(image.getScrambleId()),
+                text(image.getFilename()),
+                text(image.getUrl()),
+                text(image.getQueryParams()),
+                image.getSortOrder()
+        );
+    }
+
+    private static DesktopDtos.CommentItem comment(JmComment comment) {
+        return new DesktopDtos.CommentItem(
+                text(comment.getCommentId()),
+                text(comment.getUserId()),
+                text(comment.getUsername()),
+                text(comment.getNickname()),
+                text(comment.getContent()),
+                text(comment.getPostDate()),
+                text(comment.getPhoto()),
+                text(comment.getExpinfo()),
+                text(comment.getAid()),
+                text(comment.getName()),
+                comment.getLikes(),
+                comment.getVoteUp(),
+                comment.getVoteDown(),
+                safeList(comment.getReplys()).stream().map(DesktopDtoMapper::comment).toList()
+        );
+    }
+
+    private static DesktopDtos.CategoryMeta category(JmCategoryMeta meta) {
+        if (meta == null) {
+            return null;
+        }
+        return new DesktopDtos.CategoryMeta(text(meta.getId()), text(meta.getTitle()));
+    }
+
+    private static List<String> strings(List<String> values) {
+        return safeList(values).stream().map(DesktopDtoMapper::text).toList();
+    }
+
+    private static <T> List<T> safeList(List<T> values) {
+        return values == null ? List.of() : values;
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopHistoryService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopHistoryService.java
@@ -1,0 +1,66 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.data.DesktopHistoryStore;
+import io.github.jukomu.desktop.dto.DesktopDtos;
+
+import java.sql.SQLException;
+import java.util.Objects;
+
+/** Desktop 浏览历史业务入口，保持分页、范围和去重语义集中在本端。 */
+public final class DesktopHistoryService {
+    private final DesktopHistoryStore store;
+
+    public DesktopHistoryService(DesktopHistoryStore store) {
+        this.store = Objects.requireNonNull(store, "store");
+    }
+
+    public DesktopDtos.HistoryPage getBrowseHistory(
+            int limit,
+            int offset,
+            Long startInclusive,
+            Long endExclusive
+    ) throws SQLException {
+        return store.getBrowseHistory(limit, offset, startInclusive, endExclusive);
+    }
+
+    public DesktopDtos.BrowseHistoryOverview getBrowseHistoryOverview(
+            java.util.List<DesktopDtos.BrowseHistoryRange> ranges
+    ) throws SQLException {
+        if (ranges == null) {
+            throw new IllegalArgumentException("ranges is required");
+        }
+        return store.getBrowseHistoryOverview(ranges);
+    }
+
+    public DesktopDtos.Success recordBrowse(DesktopDtos.RecordBrowseRequest request) throws SQLException {
+        if (request == null || text(request.albumId()).isEmpty()) {
+            throw new IllegalArgumentException("albumId is required");
+        }
+        store.recordBrowse(new DesktopDtos.RecordBrowseRequest(
+                text(request.albumId()),
+                text(request.albumTitle()),
+                text(request.coverUrl()),
+                text(request.authors()),
+                text(request.chapterId()),
+                text(request.chapterTitle())
+        ));
+        return new DesktopDtos.Success(true);
+    }
+
+    public DesktopDtos.Success clearBrowseHistory() throws SQLException {
+        store.clearBrowseHistory();
+        return new DesktopDtos.Success(true);
+    }
+
+    public DesktopDtos.Success deleteBrowseItem(long id) throws SQLException {
+        if (id < 1) {
+            throw new IllegalArgumentException("id must be greater than or equal to 1");
+        }
+        store.deleteBrowseItem(id);
+        return new DesktopDtos.Success(true);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopSettingsService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/DesktopSettingsService.java
@@ -1,0 +1,122 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.data.DesktopSettingsStore;
+import io.github.jukomu.desktop.dto.DesktopDtos;
+
+import java.sql.SQLException;
+import java.util.Objects;
+
+/** Desktop 基础设置服务；只持久化标量设置，不承载平台专属能力。 */
+public final class DesktopSettingsService {
+    public static final int DEFAULT_CONCURRENCY = 6;
+    public static final int DEFAULT_CACHE_CAPACITY_MB = 256;
+    public static final int DEFAULT_READER_PRELOAD_PAGES = 15;
+
+    private final DesktopSettingsStore store;
+
+    public DesktopSettingsService(DesktopSettingsStore store) {
+        this.store = Objects.requireNonNull(store, "store");
+    }
+
+    public DesktopDtos.AllSettings getAllSettings() throws SQLException {
+        return new DesktopDtos.AllSettings(
+                intValue("reader_preload_pages", DEFAULT_READER_PRELOAD_PAGES),
+                concurrency("preload_concurrency"),
+                concurrency("download_concurrency"),
+                booleanValue("download_public", false),
+                intValue("cache_capacity_mb", DEFAULT_CACHE_CAPACITY_MB),
+                intValue("cache_capacity_mb", DEFAULT_CACHE_CAPACITY_MB),
+                intValue("cache_capacity_mb", DEFAULT_CACHE_CAPACITY_MB),
+                false,
+                "requested-limit",
+                booleanValue("ocr_enabled", true),
+                textValue("reader_display_mode", "vertical"),
+                textValue("reader_screen_orientation", "auto"),
+                doubleValue("reader_brightness", -1.0),
+                booleanValue("reader_keep_screen_on", true),
+                booleanValue("reader_volume_navigation", false),
+                booleanValue("reader_auto_show_toolbar_at_end", true)
+        );
+    }
+
+    public void setPreloadConcurrency(Integer value) throws SQLException {
+        putConcurrency("preload_concurrency", value);
+    }
+
+    public void setDownloadConcurrency(Integer value) throws SQLException {
+        putConcurrency("download_concurrency", value);
+    }
+
+    public void setReaderPreloadPages(Integer value) throws SQLException {
+        if (value == null || value < 5 || value > 50) {
+            throw new IllegalArgumentException("n must be between 5 and 50");
+        }
+        store.putString("reader_preload_pages", String.valueOf(value));
+    }
+
+    public void setReaderDisplayMode(String value) throws SQLException {
+        String mode = requireText(value, "mode");
+        if (!mode.equals("vertical") && !mode.equals("horizontal")) {
+            throw new IllegalArgumentException("mode must be vertical or horizontal");
+        }
+        store.putString("reader_display_mode", mode);
+    }
+
+    public void setReaderAutoShowToolbarAtEnd(Boolean value) throws SQLException {
+        if (value == null) {
+            throw new IllegalArgumentException("enabled is required");
+        }
+        store.putString("reader_auto_show_toolbar_at_end", String.valueOf(value));
+    }
+
+    private void putConcurrency(String key, Integer value) throws SQLException {
+        if (value == null || value < 1 || value > 12) {
+            throw new IllegalArgumentException("n must be between 1 and 12");
+        }
+        store.putString(key, String.valueOf(value));
+    }
+
+    private int concurrency(String key) throws SQLException {
+        int value = intValue(key, DEFAULT_CONCURRENCY);
+        return value < 1 || value > 12 ? DEFAULT_CONCURRENCY : value;
+    }
+
+    private int intValue(String key, int fallback) throws SQLException {
+        String value = store.getString(key);
+        if (value == null) return fallback;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+
+    private double doubleValue(String key, double fallback) throws SQLException {
+        String value = store.getString(key);
+        if (value == null) return fallback;
+        try {
+            double parsed = Double.parseDouble(value);
+            return Double.isFinite(parsed) && parsed >= -1.0 && parsed <= 1.0 ? parsed : fallback;
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+
+    private boolean booleanValue(String key, boolean fallback) throws SQLException {
+        String value = store.getString(key);
+        return value == null ? fallback : Boolean.parseBoolean(value);
+    }
+
+    private String textValue(String key, String fallback) throws SQLException {
+        String value = store.getString(key);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return normalized;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/JmComicAuthService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/JmComicAuthService.java
@@ -1,0 +1,57 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
+
+import java.util.Objects;
+
+/** 使用单个 JmApiClient 持有浏览器刷新期间仍有效的进程内登录态。 */
+public final class JmComicAuthService implements DesktopAuthService {
+    private final JmApiClient client;
+    private DesktopDtos.UserInfo currentUser;
+
+    public JmComicAuthService(JmApiClient client) {
+        this.client = Objects.requireNonNull(client, "client");
+    }
+
+    @Override
+    public synchronized DesktopDtos.UserInfo login(String username, String password) {
+        String normalizedUsername = requireText(username, "username");
+        String normalizedPassword = requireText(password, "password");
+        DesktopDtos.UserInfo result = DesktopDtoMapper.userInfo(
+                client.login(normalizedUsername, normalizedPassword)
+        );
+        currentUser = result;
+        return result;
+    }
+
+    @Override
+    public synchronized DesktopDtos.Success logout() {
+        if (currentUser != null) {
+            client.logout();
+            currentUser = null;
+        }
+        return new DesktopDtos.Success(true);
+    }
+
+    @Override
+    public synchronized DesktopDtos.LoginState checkLoginState() {
+        if (currentUser == null) {
+            return new DesktopDtos.LoginState(false, null, null);
+        }
+        return new DesktopDtos.LoginState(true, currentUser.username(), currentUser);
+    }
+
+    @Override
+    public synchronized DesktopDtos.UserProfile getUserProfile(String uid) {
+        return DesktopDtoMapper.userProfile(client.getUserProfile(requireText(uid, "uid")));
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return normalized;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/service/JmComicCatalogService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/service/JmComicCatalogService.java
@@ -1,0 +1,190 @@
+package io.github.jukomu.desktop.service;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.error.DesktopHttpException;
+import io.github.jukomu.jmcomic.api.enums.Category;
+import io.github.jukomu.jmcomic.api.enums.ForumMode;
+import io.github.jukomu.jmcomic.api.enums.OrderBy;
+import io.github.jukomu.jmcomic.api.enums.SearchMainTag;
+import io.github.jukomu.jmcomic.api.enums.TimeOption;
+import io.github.jukomu.jmcomic.api.model.ForumQuery;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+import io.github.jukomu.jmcomic.api.model.JmPhoto;
+import io.github.jukomu.jmcomic.api.model.SearchQuery;
+import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** 使用真实 JmApiClient 提供目录、章节和图片资源。 */
+public final class JmComicCatalogService implements DesktopCatalogService {
+    private static final String SEARCH_COVER_SIZE = "_3x4";
+    private static final String TYPE_IMAGE = "image";
+    private static final String TYPE_THUMB = "thumb";
+
+    private final JmApiClient client;
+    private final Map<ImageKey, JmImage> knownImages = new ConcurrentHashMap<>();
+
+    public JmComicCatalogService(JmApiClient client) {
+        this.client = Objects.requireNonNull(client, "client");
+    }
+
+    @Override
+    public DesktopDtos.SearchResult search(DesktopDtos.SearchQuery query) {
+        SearchQuery jmQuery = buildSearchQuery(query, true);
+        return DesktopDtoMapper.searchResult(client.search(jmQuery), this::coverUrl);
+    }
+
+    @Override
+    public DesktopDtos.SearchResult categories(DesktopDtos.SearchQuery query) {
+        SearchQuery jmQuery = buildSearchQuery(query, false);
+        return DesktopDtoMapper.searchResult(client.getCategories(jmQuery), this::coverUrl);
+    }
+
+    @Override
+    public DesktopDtos.AlbumDetail getAlbum(String id) {
+        return DesktopDtoMapper.album(client.getAlbum(requireId(id)), this::coverUrl);
+    }
+
+    @Override
+    public DesktopDtos.PhotoDetail getPhoto(String id) {
+        JmPhoto photo = client.getPhoto(requireId(id));
+        List<JmImage> images = photo.getImages() == null ? List.of() : photo.getImages();
+        for (JmImage image : images) {
+            knownImages.put(new ImageKey(photo.getId(), image.getSortOrder()), image);
+        }
+        return DesktopDtoMapper.photo(photo);
+    }
+
+    @Override
+    public DesktopDtos.CommentList getComments(String albumId, int page) {
+        String id = requireId(albumId);
+        if (page < 1) {
+            throw new IllegalArgumentException("page must be greater than or equal to 1");
+        }
+        return DesktopDtoMapper.comments(
+                client.getComments(ForumQuery.album(id).mode(ForumMode.ALL).page(page).build())
+        );
+    }
+
+    @Override
+    public DesktopDtos.ImageResource getImage(String photoId, int sortOrder, String type) {
+        String id = requireId(photoId);
+        if (sortOrder < 1) {
+            throw new IllegalArgumentException("sortOrder must be greater than or equal to 1");
+        }
+        if (!TYPE_IMAGE.equals(type) && !TYPE_THUMB.equals(type)) {
+            throw new IllegalArgumentException("type must be image or thumb");
+        }
+        JmImage image = knownImages.get(new ImageKey(id, sortOrder));
+        if (image == null) {
+            throw new DesktopHttpException(
+                    "not-found",
+                    404,
+                    "章节图片尚未加载，请先打开章节详情"
+            );
+        }
+        byte[] bytes = client.fetchImageBytes(image);
+        return new DesktopDtos.ImageResource(bytes, mediaType(image.getFilename()));
+    }
+
+    private SearchQuery buildSearchQuery(DesktopDtos.SearchQuery query, boolean requireKeyword) {
+        if (query == null) {
+            throw new IllegalArgumentException("query is required");
+        }
+        String keyword = text(query.keyword()).trim();
+        if (requireKeyword && keyword.isEmpty()) {
+            throw new IllegalArgumentException("keyword is required");
+        }
+        if (requireKeyword && keyword.matches("\\d+")) {
+            throw new IllegalArgumentException("keyword must not be numeric");
+        }
+        int page = query.page() == null ? 1 : query.page();
+        if (page < 1) {
+            throw new IllegalArgumentException("page must be greater than or equal to 1");
+        }
+        return new SearchQuery.Builder()
+                .text(keyword)
+                .category(category(query.category()))
+                .orderBy(orderBy(query.orderBy()))
+                .time(time(query.time()))
+                .mainTag(searchMainTag(query.searchMainTag()))
+                .page(page)
+                .build();
+    }
+
+    private String coverUrl(String albumId) {
+        return client.getAlbumCoverUrl(albumId, SEARCH_COVER_SIZE);
+    }
+
+    private static Category category(String value) {
+        String candidate = text(value);
+        for (Category item : Category.values()) {
+            if (item.getValue().equals(candidate)) {
+                return item;
+            }
+        }
+        return Category.ALL;
+    }
+
+    private static OrderBy orderBy(String value) {
+        String candidate = text(value);
+        for (OrderBy item : OrderBy.values()) {
+            if (item.getValue().equals(candidate)) {
+                return item;
+            }
+        }
+        return OrderBy.LATEST;
+    }
+
+    private static TimeOption time(String value) {
+        String candidate = text(value);
+        for (TimeOption item : TimeOption.values()) {
+            if (item.getValue().equals(candidate)) {
+                return item;
+            }
+        }
+        return TimeOption.ALL;
+    }
+
+    private static SearchMainTag searchMainTag(Integer value) {
+        int candidate = value == null ? SearchMainTag.SITE_SEARCH.getValue() : value;
+        for (SearchMainTag item : SearchMainTag.values()) {
+            if (item.getValue() == candidate) {
+                return item;
+            }
+        }
+        return SearchMainTag.SITE_SEARCH;
+    }
+
+    private static String requireId(String value) {
+        String id = text(value).trim();
+        if (id.isEmpty()) {
+            throw new IllegalArgumentException("id is required");
+        }
+        if (!id.matches("[A-Za-z0-9_-]+")) {
+            throw new IllegalArgumentException("id contains unsupported characters");
+        }
+        return id;
+    }
+
+    private static String mediaType(String filename) {
+        String lower = text(filename).toLowerCase(Locale.ROOT);
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+        if (lower.endsWith(".png")) return "image/png";
+        if (lower.endsWith(".gif")) return "image/gif";
+        if (lower.endsWith(".webp")) return "image/webp";
+        if (lower.endsWith(".avif")) return "image/avif";
+        return "application/octet-stream";
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record ImageKey(String photoId, int sortOrder) {
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopBackendHttpTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopBackendHttpTest.java
@@ -30,7 +30,7 @@ class DesktopBackendHttpTest {
         );
         HttpClient client = HttpClient.newHttpClient();
 
-        DesktopBackend backend = new DesktopBackend(paths);
+        DesktopBackend backend = new DesktopBackend(paths, new InitOnlyPlugin());
         URI base;
         try (backend) {
             URI home = backend.start();

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopDtoMapperTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopDtoMapperTest.java
@@ -1,0 +1,63 @@
+package io.github.jukomu.desktop;
+
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.service.DesktopDtoMapper;
+import io.github.jukomu.jmcomic.api.model.JmAlbumMeta;
+import io.github.jukomu.jmcomic.api.model.JmComment;
+import io.github.jukomu.jmcomic.api.model.JmCommentList;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+import io.github.jukomu.jmcomic.api.model.JmPhoto;
+import io.github.jukomu.jmcomic.api.model.JmSearchPage;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DesktopDtoMapperTest {
+    @Test
+    void mapsCatalogModelsToTheFrontendContract() {
+        JmSearchPage page = new JmSearchPage(
+                2,
+                5,
+                3,
+                List.of(new JmAlbumMeta("album-1", "测试本子", List.of("作者"), List.of("标签")))
+        );
+
+        DesktopDtos.SearchResult result = DesktopDtoMapper.searchResult(
+                page,
+                id -> "https://example.test/" + id + ".jpg"
+        );
+
+        assertEquals(2, result.currentPage());
+        assertEquals(5, result.totalItems());
+        assertEquals("album-1", result.content().getFirst().id());
+        assertEquals("https://example.test/album-1.jpg", result.content().getFirst().coverUrl());
+        assertEquals(List.of("作者"), result.content().getFirst().authors());
+    }
+
+    @Test
+    void mapsPhotoImagesAndNestedCommentsWithoutNullCollections() {
+        JmImage image = new JmImage(
+                "photo-1", "scramble", "page.webp", "https://example.test/page.webp", "v=1", 1
+        );
+        DesktopDtos.PhotoDetail photo = DesktopDtoMapper.photo(new JmPhoto(
+                "photo-1", "第一章", "album-1", "scramble", 1, "作者", null, List.of(image), false
+        ));
+        JmComment comment = new JmComment(
+                "comment-1", "user-1", "user", "内容", "2026-09-11", "", "Lv.1",
+                "album-1", "JMalbum-1", List.of(), 3, 1
+        );
+        DesktopDtos.CommentList comments = DesktopDtoMapper.comments(
+                new JmCommentList(1, List.of(comment))
+        );
+
+        assertEquals("photo-1", photo.id());
+        assertEquals("作者", photo.author());
+        assertEquals("page.webp", photo.images().getFirst().filename());
+        assertEquals(1, comments.total());
+        assertEquals("内容", comments.list().getFirst().content());
+        assertEquals(3, comments.list().getFirst().voteUp());
+        assertEquals(List.of(), comments.list().getFirst().replys());
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopHistorySettingsTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopHistorySettingsTest.java
@@ -1,0 +1,133 @@
+package io.github.jukomu.desktop;
+
+import io.github.jukomu.desktop.data.DesktopDatabase;
+import io.github.jukomu.desktop.data.DesktopHistoryStore;
+import io.github.jukomu.desktop.data.DesktopSettingsStore;
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.service.DesktopHistoryService;
+import io.github.jukomu.desktop.service.DesktopSettingsService;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DesktopHistorySettingsTest {
+    @Test
+    void deduplicatesTheLatestAlbumAndPaginatesByTimestampAndId() throws Exception {
+        try (DesktopDatabase database = database()) {
+            DesktopHistoryService history = new DesktopHistoryService(new DesktopHistoryStore(database));
+            history.recordBrowse(record("album-1", "chapter-1", "第一章"));
+            history.recordBrowse(record("album-1", "chapter-2", "第二章"));
+            history.recordBrowse(record("album-2", "chapter-3", "第三章"));
+
+            DesktopDtos.HistoryPage page = history.getBrowseHistory(1, 1, null, null);
+
+            assertEquals(2, page.totalCount());
+            assertEquals(1, page.items().size());
+            assertEquals("album-1", page.items().getFirst().albumId());
+            assertEquals("chapter-2", page.items().getFirst().chapterId());
+        }
+    }
+
+    @Test
+    void returnsStableRangeCountsAndRejectsIncompleteRanges() throws Exception {
+        try (DesktopDatabase database = database()) {
+            DesktopHistoryService history = new DesktopHistoryService(new DesktopHistoryStore(database));
+            history.recordBrowse(record("album-1", "chapter-1", "第一章"));
+            history.recordBrowse(record("album-2", "chapter-2", "第二章"));
+            history.recordBrowse(record("album-3", "chapter-3", "第三章"));
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "UPDATE browse_history SET timestamp = ? WHERE album_id = ?")) {
+                updateTimestamp(statement, 100L, "album-1");
+                updateTimestamp(statement, 100L, "album-2");
+                updateTimestamp(statement, 50L, "album-3");
+            }
+
+            List<DesktopDtos.BrowseHistoryRange> ranges = new ArrayList<>();
+            ranges.add(new DesktopDtos.BrowseHistoryRange("today", 100L, null));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("yesterday", 50L, 100L));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("thisWeek", 0L, 50L));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("thisMonth", 0L, 0L));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("lastThreeMonths", 0L, 0L));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("lastSixMonths", 0L, 0L));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("thisYear", 0L, 0L));
+            ranges.add(new DesktopDtos.BrowseHistoryRange("earlier", null, 0L));
+
+            DesktopDtos.BrowseHistoryOverview overview = history.getBrowseHistoryOverview(ranges);
+
+            assertEquals(3, overview.totalCount());
+            assertEquals(2, overview.groupCounts().get("today"));
+            assertEquals(1, overview.groupCounts().get("yesterday"));
+            assertEquals(0, overview.groupCounts().get("thisYear"));
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> history.getBrowseHistoryOverview(ranges.subList(0, 7))
+            );
+        }
+    }
+
+    @Test
+    void persistsBasicSettingsWithValidation() throws Exception {
+        try (DesktopDatabase database = database()) {
+            DesktopSettingsService settings = new DesktopSettingsService(new DesktopSettingsStore(database));
+
+            DesktopDtos.AllSettings defaults = settings.getAllSettings();
+            assertEquals(15, defaults.readerPreloadPages());
+            assertEquals(6, defaults.preloadConcurrency());
+            assertEquals("vertical", defaults.readerDisplayMode());
+            assertTrue(defaults.readerKeepScreenOn());
+
+            settings.setReaderPreloadPages(24);
+            settings.setPreloadConcurrency(3);
+            settings.setReaderDisplayMode("horizontal");
+            settings.setReaderAutoShowToolbarAtEnd(false);
+            settings.setDownloadConcurrency(2);
+
+            DesktopDtos.AllSettings updated = settings.getAllSettings();
+            assertEquals(24, updated.readerPreloadPages());
+            assertEquals(3, updated.preloadConcurrency());
+            assertEquals(2, updated.downloadConcurrency());
+            assertEquals("horizontal", updated.readerDisplayMode());
+            assertFalse(updated.readerAutoShowToolbarAtEnd());
+            assertThrows(IllegalArgumentException.class, () -> settings.setReaderPreloadPages(4));
+            assertThrows(IllegalArgumentException.class, () -> settings.setReaderDisplayMode("invalid"));
+        }
+    }
+
+    private static DesktopDatabase database() throws Exception {
+        Path path = Files.createTempDirectory("jq-viewer-history-").resolve("data/desktop.sqlite3");
+        DesktopDatabase database = new DesktopDatabase(path);
+        database.open();
+        return database;
+    }
+
+    private static DesktopDtos.RecordBrowseRequest record(
+            String albumId,
+            String chapterId,
+            String chapterTitle
+    ) {
+        return new DesktopDtos.RecordBrowseRequest(
+                albumId,
+                albumId,
+                "https://example.test/cover.jpg",
+                "作者",
+                chapterId,
+                chapterTitle
+        );
+    }
+
+    private static void updateTimestamp(PreparedStatement statement, long timestamp, String albumId)
+            throws Exception {
+        statement.setLong(1, timestamp);
+        statement.setString(2, albumId);
+        statement.executeUpdate();
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopHostTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopHostTest.java
@@ -29,12 +29,12 @@ class DesktopHostTest {
         );
         List<String> opened = new ArrayList<>();
         DesktopHost primary = new DesktopHost(
-                new DesktopBackend(paths),
+                new DesktopBackend(paths, new InitOnlyPlugin()),
                 new SingleInstanceGuard(paths),
                 new BrowserLauncher(uri -> opened.add(uri.toString()))
         );
         DesktopHost secondary = new DesktopHost(
-                new DesktopBackend(paths),
+                new DesktopBackend(paths, new InitOnlyPlugin()),
                 new SingleInstanceGuard(paths),
                 new BrowserLauncher(uri -> opened.add(uri.toString()))
         );

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopPathsDatabaseTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopPathsDatabaseTest.java
@@ -95,7 +95,7 @@ class DesktopPathsDatabaseTest {
                     .createStatement()
                     .executeQuery("SELECT version FROM desktop_schema_version")) {
                 assertTrue(result.next());
-                assertEquals(1, result.getInt(1));
+                assertEquals(DesktopDatabase.CURRENT_SCHEMA_VERSION, result.getInt(1));
             }
             assertTrue(database.isOpen());
         }

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopStage2HttpTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopStage2HttpTest.java
@@ -1,0 +1,294 @@
+package io.github.jukomu.desktop;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jukomu.desktop.backend.DesktopBackend;
+import io.github.jukomu.desktop.bridge.DesktopPlugin;
+import io.github.jukomu.desktop.bridge.handler.ApiPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.AuthPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.HistoryPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SettingsPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SystemPluginHandler;
+import io.github.jukomu.desktop.data.DesktopDatabase;
+import io.github.jukomu.desktop.data.DesktopHistoryStore;
+import io.github.jukomu.desktop.data.DesktopPaths;
+import io.github.jukomu.desktop.data.DesktopSettingsStore;
+import io.github.jukomu.desktop.dto.DesktopDtos;
+import io.github.jukomu.desktop.error.DesktopHttpException;
+import io.github.jukomu.desktop.service.DesktopAuthService;
+import io.github.jukomu.desktop.service.DesktopCatalogService;
+import io.github.jukomu.desktop.service.DesktopHistoryService;
+import io.github.jukomu.desktop.service.DesktopSettingsService;
+import io.javalin.http.Context;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DesktopStage2HttpTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void servesStage2ContractsAsynchronousResultsAndImageContentType() throws Exception {
+        Path root = Files.createTempDirectory("jq-viewer-stage2-http-");
+        DesktopPaths paths = paths(root);
+        AtomicReference<String> catalogThread = new AtomicReference<>();
+        FakeCatalogService catalog = new FakeCatalogService(catalogThread);
+        ExecutorService executor = Executors.newFixedThreadPool(2, runnable -> {
+            Thread thread = new Thread(runnable, "jq-viewer-desktop-business-test");
+            thread.setDaemon(true);
+            return thread;
+        });
+        DesktopDatabase database = new DesktopDatabase(paths);
+        DesktopPlugin plugin = plugin(catalog, database, executor);
+        DesktopBackend backend = new DesktopBackend(
+                paths,
+                database,
+                executor,
+                () -> plugin,
+                catalog
+        );
+        HttpClient client = HttpClient.newHttpClient();
+
+        try (backend) {
+            URI home = backend.start();
+            URI base = URI.create("http://127.0.0.1:" + backend.port());
+
+            HttpResponse<String> init = sendJson(client, base.resolve("/api/getInitStatus"), "{}");
+            HttpResponse<String> search = sendJson(client, base.resolve("/api/search"), """
+                    {"query":{"keyword":"猫","orderBy":"mr","time":"a","searchMainTag":0,"page":2}}
+                    """);
+            HttpResponse<String> photo = sendJson(client, base.resolve("/api/getPhoto"), "{\"id\":\"photo-1\"}");
+            HttpResponse<String> loginState = sendJson(
+                    client,
+                    base.resolve("/api/checkLoginState"),
+                    "{}"
+            );
+            HttpResponse<String> settings = sendJson(
+                    client,
+                    base.resolve("/api/getAllSettings"),
+                    "{}"
+            );
+            HttpResponse<String> historyWrite = sendJson(
+                    client,
+                    base.resolve("/api/recordBrowse"),
+                    """
+                    {"albumId":"album-1","albumTitle":"测试本子","coverUrl":"/cover.jpg","authors":"作者","chapterId":"photo-1","chapterTitle":"测试章节"}
+                    """
+            );
+            HttpResponse<String> historyRead = sendJson(
+                    client,
+                    base.resolve("/api/getBrowseHistory"),
+                    "{\"limit\":10,\"offset\":0}"
+            );
+            HttpResponse<byte[]> image = client.send(
+                    HttpRequest.newBuilder(base.resolve("/image/photo-1/1")).GET().build(),
+                    HttpResponse.BodyHandlers.ofByteArray()
+            );
+
+            assertEquals(200, init.statusCode());
+            assertEquals("{\"complete\":true}", init.body());
+            assertEquals(200, search.statusCode());
+            assertTrue(search.body().contains("\"currentPage\":2"));
+            assertEquals(200, photo.statusCode());
+            assertTrue(photo.body().contains("\"photo-1\""));
+            assertEquals(200, loginState.statusCode());
+            assertTrue(loginState.body().contains("\"loggedIn\":false"));
+            assertEquals(200, settings.statusCode());
+            assertTrue(settings.body().contains("\"readerPreloadPages\":15"));
+            assertEquals(200, historyWrite.statusCode());
+            assertEquals("{\"success\":true}", historyWrite.body());
+            assertEquals(200, historyRead.statusCode());
+            assertTrue(historyRead.body().contains("\"totalCount\":1"));
+            assertEquals(200, image.statusCode());
+            assertEquals("image/png", image.headers().firstValue("content-type").orElse(""));
+            assertEquals(2, image.body().length);
+            assertTrue(catalogThread.get().startsWith("jq-viewer-desktop-business-test"));
+            assertTrue(backend.database().isOpen());
+        }
+
+        assertTrue(backend.businessExecutor().isShutdown());
+    }
+
+    @Test
+    void returnsStructuredBusinessErrorsAndLeavesUnregisteredMethodsUnmatched() throws Exception {
+        Path root = Files.createTempDirectory("jq-viewer-stage2-errors-");
+        DesktopPaths paths = paths(root);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        DesktopDatabase database = new DesktopDatabase(paths);
+        ErrorCatalogService errorCatalog = new ErrorCatalogService();
+        DesktopPlugin plugin = plugin(errorCatalog, database, executor);
+        DesktopBackend backend = new DesktopBackend(
+                paths,
+                database,
+                executor,
+                () -> plugin,
+                errorCatalog
+        );
+        HttpClient client = HttpClient.newHttpClient();
+
+        try (backend) {
+            URI base = URI.create("http://127.0.0.1:" + backend.start().getPort());
+            HttpResponse<String> missing = sendJson(
+                    client,
+                    base.resolve("/api/getAlbum"),
+                    "{\"id\":\"missing\"}"
+            );
+            HttpResponse<String> autoLogin = sendJson(
+                    client,
+                    base.resolve("/api/autoLogin"),
+                    "{}"
+            );
+
+            assertEquals(404, missing.statusCode());
+            assertEquals("not-found", mapper.readTree(missing.body()).get("code").asText());
+            assertEquals(404, autoLogin.statusCode());
+        }
+    }
+
+    private static DesktopPlugin plugin(
+            DesktopCatalogService catalog,
+            DesktopDatabase database,
+            ExecutorService executor
+    ) {
+        DesktopHistoryService history = new DesktopHistoryService(new DesktopHistoryStore(database));
+        DesktopSettingsService settings = new DesktopSettingsService(new DesktopSettingsStore(database));
+        return new DesktopPlugin(
+                new SystemPluginHandler(),
+                new ApiPluginHandler(catalog, executor),
+                new AuthPluginHandler(new FakeAuthService(), executor),
+                new HistoryPluginHandler(history, executor),
+                new SettingsPluginHandler(settings, executor)
+        );
+    }
+
+    private static DesktopPaths paths(Path root) {
+        return new DesktopPaths(
+                root.resolve("program"),
+                root.resolve("home"),
+                Map.of(),
+                "Linux"
+        );
+    }
+
+    private static HttpResponse<String> sendJson(
+            HttpClient client,
+            URI uri,
+            String body
+    ) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder(uri)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+        );
+    }
+
+    private static class FakeCatalogService implements DesktopCatalogService {
+        private final AtomicReference<String> catalogThread;
+
+        private FakeCatalogService(AtomicReference<String> catalogThread) {
+            this.catalogThread = catalogThread;
+        }
+
+        @Override
+        public DesktopDtos.SearchResult search(DesktopDtos.SearchQuery query) {
+            catalogThread.set(Thread.currentThread().getName());
+            return new DesktopDtos.SearchResult(
+                    query.page() == null ? 1 : query.page(),
+                    1,
+                    1,
+                    List.of(new DesktopDtos.SearchResultItem(
+                            "album-1", "测试本子", "/cover.jpg", List.of("作者"), List.of("标签")
+                    ))
+            );
+        }
+
+        @Override
+        public DesktopDtos.SearchResult categories(DesktopDtos.SearchQuery query) {
+            return search(query);
+        }
+
+        @Override
+        public DesktopDtos.AlbumDetail getAlbum(String id) {
+            return new DesktopDtos.AlbumDetail(
+                    id, "测试本子", "", "", 1, "0", "0", 0, "/cover.jpg",
+                    null, null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(),
+                    "0", true, false, false, "", ""
+            );
+        }
+
+        @Override
+        public DesktopDtos.PhotoDetail getPhoto(String id) {
+            return new DesktopDtos.PhotoDetail(
+                    id,
+                    "测试章节",
+                    "album-1",
+                    1,
+                    "作者",
+                    List.of(),
+                    List.of(new DesktopDtos.ImageInfo(id, "scramble", "page.png", "", "", 1)),
+                    true
+            );
+        }
+
+        @Override
+        public DesktopDtos.CommentList getComments(String albumId, int page) {
+            return new DesktopDtos.CommentList(0, List.of());
+        }
+
+        @Override
+        public DesktopDtos.ImageResource getImage(String photoId, int sortOrder, String type) {
+            return new DesktopDtos.ImageResource(new byte[]{1, 2}, "image/png");
+        }
+    }
+
+    private static final class ErrorCatalogService extends FakeCatalogService {
+        private ErrorCatalogService() {
+            super(new AtomicReference<>());
+        }
+
+        @Override
+        public DesktopDtos.AlbumDetail getAlbum(String id) {
+            throw new DesktopHttpException("not-found", 404, "测试资源不存在");
+        }
+    }
+
+    private static final class FakeAuthService implements DesktopAuthService {
+        @Override
+        public DesktopDtos.UserInfo login(String username, String password) {
+            return new DesktopDtos.UserInfo(
+                    "1", username, "", false, "", "", "", "", 0, "", 0, 0, 0, 0, 0, 0
+            );
+        }
+
+        @Override
+        public DesktopDtos.Success logout() {
+            return new DesktopDtos.Success(true);
+        }
+
+        @Override
+        public DesktopDtos.LoginState checkLoginState() {
+            return new DesktopDtos.LoginState(false, null, null);
+        }
+
+        @Override
+        public DesktopDtos.UserProfile getUserProfile(String uid) {
+            return new DesktopDtos.UserProfile("", "", "", "", "", "", "", "", "");
+        }
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/InitOnlyPlugin.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/InitOnlyPlugin.java
@@ -1,0 +1,14 @@
+package io.github.jukomu.desktop;
+
+import io.github.jukomu.desktop.bridge.PluginMethod;
+import io.javalin.http.Context;
+
+import java.util.Map;
+
+/** 阶段 1 生命周期测试用的最小 bridge，不创建真实上游客户端。 */
+final class InitOnlyPlugin {
+    @PluginMethod
+    public void getInitStatus(Context context) {
+        context.json(Map.of("complete", true));
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/PluginMethodRoutesTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/PluginMethodRoutesTest.java
@@ -11,6 +11,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -25,6 +26,40 @@ class PluginMethodRoutesTest {
         assertTrue(method.isAnnotationPresent(PluginMethod.class));
         assertEquals(RetentionPolicy.RUNTIME, PluginMethod.class.getAnnotation(Retention.class).value());
         assertTrue(Modifier.isPublic(method.getModifiers()));
+    }
+
+    @Test
+    void discoversExactlyTheStage2BridgeMethods() {
+        DesktopPlugin plugin = new DesktopPlugin(null, null, null, null, null);
+
+        assertEquals(
+                Set.of(
+                        "getInitStatus",
+                        "search",
+                        "categories",
+                        "getAlbum",
+                        "getPhoto",
+                        "getComments",
+                        "login",
+                        "logout",
+                        "checkLoginState",
+                        "getUserProfile",
+                        "getAllSettings",
+                        "setPreloadConcurrency",
+                        "setDownloadConcurrency",
+                        "setReaderPreloadPages",
+                        "setReaderDisplayMode",
+                        "setReaderAutoShowToolbarAtEnd",
+                        "getBrowseHistory",
+                        "getBrowseHistoryOverview",
+                        "recordBrowse",
+                        "clearBrowseHistory",
+                        "deleteBrowseItem"
+                ),
+                PluginMethodRoutes.discover(plugin).stream()
+                        .map(method -> method.method().getName())
+                        .collect(java.util.stream.Collectors.toSet())
+        );
     }
 
     @Test

--- a/src/runtime/desktop/desktopBackendClient.ts
+++ b/src/runtime/desktop/desktopBackendClient.ts
@@ -1,7 +1,30 @@
-import type { BackendClient } from '../BackendClient'
+import type { BackendClient, CommonBackendMethod } from '../BackendClient'
 import { RuntimeError, type RuntimeErrorCode } from '../errors'
 
-export const DESKTOP_BACKEND_METHODS = ['getInitStatus'] as const
+/** 阶段 2 已实际提供的 Desktop JSON 方法；未列入的方法不会绑定到运行时。 */
+export const DESKTOP_BACKEND_METHODS = [
+  'getInitStatus',
+  'search',
+  'categories',
+  'getAlbum',
+  'getPhoto',
+  'getComments',
+  'login',
+  'logout',
+  'checkLoginState',
+  'getUserProfile',
+  'getAllSettings',
+  'setPreloadConcurrency',
+  'setDownloadConcurrency',
+  'setReaderPreloadPages',
+  'setReaderDisplayMode',
+  'setReaderAutoShowToolbarAtEnd',
+  'getBrowseHistory',
+  'getBrowseHistoryOverview',
+  'recordBrowse',
+  'clearBrowseHistory',
+  'deleteBrowseItem',
+] as const satisfies readonly CommonBackendMethod[]
 
 export type DesktopFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
@@ -61,15 +84,19 @@ async function request<T>(fetcher: DesktopFetch, method: string, body: unknown):
 export function createDesktopBackendClient(
   fetcher: DesktopFetch = globalThis.fetch.bind(globalThis),
 ): BackendClient {
-  const client = {
-    getInitStatus: async () => {
-      const result = await request<{ complete?: unknown }>(fetcher, 'getInitStatus', {})
-      if (!result || typeof result.complete !== 'boolean') {
-        throw new RuntimeError('internal', 'Invalid getInitStatus response')
-      }
-      return { complete: result.complete }
-    },
+  const client = {} as BackendClient
+  for (const method of DESKTOP_BACKEND_METHODS) {
+    ;(client as Record<string, unknown>)[method] = (body?: unknown) =>
+      request(fetcher, method, body ?? {})
   }
 
-  return client as unknown as BackendClient
+  client.getInitStatus = async () => {
+    const result = await request<{ complete?: unknown }>(fetcher, 'getInitStatus', {})
+    if (!result || typeof result.complete !== 'boolean') {
+      throw new RuntimeError('internal', 'Invalid getInitStatus response')
+    }
+    return { complete: result.complete }
+  }
+
+  return client
 }

--- a/src/runtime/facadeClient.ts
+++ b/src/runtime/facadeClient.ts
@@ -124,18 +124,19 @@ export function createFacadeClient(runtime: FrontendRuntime): JmcomicClient {
     },
     consumeLaunchRoute: () => launchRoutes().consume(),
 
-    setReaderScreenOrientation: (options: Parameters<JmcomicClient['setReaderScreenOrientation']>[0]) =>
-      requireCapability(reader.orientation, '屏幕方向').set(options.orientation),
-    setReaderBrightness: (options: Parameters<JmcomicClient['setReaderBrightness']>[0]) =>
+    setReaderScreenOrientation: async (
+      options: Parameters<JmcomicClient['setReaderScreenOrientation']>[0],
+    ) => requireCapability(reader.orientation, '屏幕方向').set(options.orientation),
+    setReaderBrightness: async (options: Parameters<JmcomicClient['setReaderBrightness']>[0]) =>
       requireCapability(reader.brightness, '屏幕亮度').set(options.brightness),
-    setReaderKeepScreenOn: (options: Parameters<JmcomicClient['setReaderKeepScreenOn']>[0]) =>
+    setReaderKeepScreenOn: async (options: Parameters<JmcomicClient['setReaderKeepScreenOn']>[0]) =>
       requireCapability(reader.keepAwake, '防止熄屏').set(options.enabled),
-    setReaderFullscreen: (options: Parameters<JmcomicClient['setReaderFullscreen']>[0]) =>
+    setReaderFullscreen: async (options: Parameters<JmcomicClient['setReaderFullscreen']>[0]) =>
       requireCapability(reader.fullscreen, '全屏').set(options.enabled),
-    setReaderVolumeNavigation: (
+    setReaderVolumeNavigation: async (
       options: Parameters<JmcomicClient['setReaderVolumeNavigation']>[0],
     ) => requireCapability(reader.volumeKeys, '音量键翻页').setEnabled(options.enabled),
-    setReaderState: (options: Parameters<JmcomicClient['setReaderState']>[0]) =>
+    setReaderState: async (options: Parameters<JmcomicClient['setReaderState']>[0]) =>
       requireCapability(reader.hostState, '阅读器宿主状态').setState(
         options.isActive,
         options.isVertical,

--- a/src/services/jmcomic/JmcomicServiceFacade.ts
+++ b/src/services/jmcomic/JmcomicServiceFacade.ts
@@ -11,6 +11,7 @@ import type {
   PdfExportProgressEvent,
   PdfExportStatus,
   ImportedPdf,
+  PreloadResult,
   RelocationProgress,
   SearchQuery,
   SearchResultItem,
@@ -29,6 +30,22 @@ import { NotificationPermissionService } from '@/services/NotificationPermission
 
 /** 惰性 facade client：页面沿用旧 JmcomicClient 接口，底层由当前 runtime 端口动态提供。 */
 const native: JmcomicClient = createActiveFacadeClient(getRuntime)
+
+/** Desktop 通过同源资源 URL 按需加载图片，不依赖 Android ImageRegistry 或 SSE。 */
+function isDirectDesktopImageRuntime(): boolean {
+  return getRuntime().platform !== 'android'
+}
+
+function directDesktopPreloadResult(images: readonly ImageInfo[]): PreloadResult {
+  return {
+    cached: [...new Set(images.map((image) => image.sortOrder))],
+    pending: [],
+  }
+}
+
+function directDesktopImageListener(): Promise<JmcomicListenerHandle> {
+  return Promise.resolve({ remove: () => Promise.resolve() })
+}
 
 export const JmcomicService = {
   search(query: SearchQuery) {
@@ -132,11 +149,17 @@ export const JmcomicService = {
     type: 'image' | 'thumb' = 'image',
     options: { replacePending?: boolean } = {},
   ) {
+    if (isDirectDesktopImageRuntime()) {
+      return Promise.resolve(directDesktopPreloadResult(images))
+    }
     return native.preloadImages({ photoId, images, type, replacePending: options.replacePending })
   },
 
   /** 使用最新图片元数据绕过本地来源和旧缓存重试单页。 */
   retryImage(photoId: string, image: ImageInfo) {
+    if (isDirectDesktopImageRuntime()) {
+      return Promise.resolve({ success: true })
+    }
     return native.retryImage({ photoId, image })
   },
 
@@ -211,6 +234,9 @@ export const JmcomicService = {
     handler: (sortOrder: number) => void,
     options: { type?: 'image' | 'thumb' } = {},
   ): Promise<JmcomicListenerHandle> {
+    if (isDirectDesktopImageRuntime()) {
+      return directDesktopImageListener()
+    }
     return native.addListener('imageReady', (data: ImageReadyEvent) => {
       if (data.photoId === photoId && (!options.type || data.type === options.type)) {
         handler(data.sortOrder)
@@ -224,6 +250,9 @@ export const JmcomicService = {
     handler: (sortOrder: number) => void,
     options: { type?: 'image' | 'thumb' } = {},
   ): Promise<JmcomicListenerHandle> {
+    if (isDirectDesktopImageRuntime()) {
+      return directDesktopImageListener()
+    }
     return native.addListener('imageFailed', (data: ImageFailedEvent) => {
       if (data.photoId === photoId && (!options.type || data.type === options.type)) {
         handler(data.sortOrder)
@@ -240,18 +269,18 @@ export const JmcomicService = {
     return native.addListener('networkProbe', handler)
   },
 
-  /** 读取 domainManager 中已有的域名连通性状态（同步返回，不触发探活） */
-  getDomainStates() {
+  /** 读取 domainManager 中已有的域名连通性状态，不触发探活。 */
+  async getDomainStates() {
     return native.getDomainStates()
   },
 
   /** 手动触发域名重新探活（结果通过 networkProbe 事件推送） */
-  reprobeDomains() {
+  async reprobeDomains() {
     return native.reprobeDomains()
   },
 
   /** 对可达域名进行延迟测试（HEAD 请求计时，并行执行） */
-  measureLatency() {
+  async measureLatency() {
     return native.measureLatency()
   },
 

--- a/tests/unit/JmcomicServiceFacade.test.ts
+++ b/tests/unit/JmcomicServiceFacade.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  runtime: { platform: 'android' as 'android' | 'linux' },
   addListener: vi.fn(),
+  getDomainStates: vi.fn(),
+  preloadImages: vi.fn(),
   retryImage: vi.fn(),
   getBrowseHistory: vi.fn(),
   getBrowseHistoryOverview: vi.fn(),
@@ -15,6 +18,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/runtime/facadeClient', () => ({
   createActiveFacadeClient: () => ({
     addListener: mocks.addListener,
+    getDomainStates: mocks.getDomainStates,
+    preloadImages: mocks.preloadImages,
     retryImage: mocks.retryImage,
     getBrowseHistory: mocks.getBrowseHistory,
     getBrowseHistoryOverview: mocks.getBrowseHistoryOverview,
@@ -25,6 +30,10 @@ vi.mock('@/runtime/facadeClient', () => ({
   }),
 }))
 
+vi.mock('@/runtime/runtimeContext', () => ({
+  getRuntime: () => mocks.runtime,
+}))
+
 vi.mock('@/services/NotificationPermissionService', () => ({
   NotificationPermissionService: {
     ensureDownloadPermission: mocks.ensureDownloadPermission,
@@ -33,6 +42,57 @@ vi.mock('@/services/NotificationPermissionService', () => ({
 
 import type { ImageReadyEvent } from '@/services/jmcomic/JmcomicClient'
 import { JmcomicService } from '@/services/jmcomic/JmcomicServiceFacade'
+
+beforeEach(() => {
+  mocks.runtime.platform = 'android'
+  mocks.preloadImages.mockReset()
+})
+
+describe('Desktop 直接图片资源路径', () => {
+  test('不安装 Android 预加载方法也能返回待展示图片和空事件句柄', async () => {
+    mocks.runtime.platform = 'linux'
+    const images = [
+      {
+        photoId: 'chapter-1',
+        scrambleId: '0',
+        filename: '1.jpg',
+        url: 'https://latest.example.com/1.jpg',
+        queryParams: '',
+        sortOrder: 1,
+      },
+      {
+        photoId: 'chapter-1',
+        scrambleId: '0',
+        filename: '2.jpg',
+        url: 'https://latest.example.com/2.jpg',
+        queryParams: '',
+        sortOrder: 2,
+      },
+    ]
+
+    await expect(JmcomicService.preloadImages('chapter-1', images)).resolves.toEqual({
+      cached: [1, 2],
+      pending: [],
+    })
+    await expect(JmcomicService.retryImage('chapter-1', images[0])).resolves.toEqual({
+      success: true,
+    })
+    const listener = await JmcomicService.addImageReadyListener('chapter-1', vi.fn())
+    await listener.remove()
+
+    expect(mocks.preloadImages).not.toHaveBeenCalled()
+    expect(mocks.retryImage).not.toHaveBeenCalled()
+    expect(mocks.addListener).not.toHaveBeenCalled()
+  })
+
+  test('将 backend 的同步异常转换为可捕获的 Promise rejection', async () => {
+    mocks.getDomainStates.mockImplementation(() => {
+      throw new Error('domain state unavailable')
+    })
+
+    await expect(JmcomicService.getDomainStates()).rejects.toThrow('domain state unavailable')
+  })
+})
 
 describe('JmcomicService.addImageReadyListener', () => {
   let imageReadyHandler: ((event: ImageReadyEvent) => void) | null

--- a/tests/unit/desktopRuntime.test.ts
+++ b/tests/unit/desktopRuntime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, vi } from 'vitest'
-import { createDesktopBackendClient } from '@/runtime/desktop/desktopBackendClient'
+import {
+  createDesktopBackendClient,
+  DESKTOP_BACKEND_METHODS,
+} from '@/runtime/desktop/desktopBackendClient'
 import { createDesktopRuntime } from '@/runtime/desktop/createDesktopRuntime'
 import { RuntimeError } from '@/runtime/errors'
 
@@ -12,17 +15,84 @@ function response(payload: unknown, ok = true, status = 200): Response {
 }
 
 describe('Desktop runtime', () => {
-  test('only installs getInitStatus and sends the existing JSON command shape', async () => {
+  test('installs only the implemented methods and preserves their JSON command shape', async () => {
     const fetcher = vi.fn().mockResolvedValue(response({ complete: true }))
     const backend = createDesktopBackendClient(fetcher)
 
     await expect(backend.getInitStatus()).resolves.toEqual({ complete: true })
-    expect(Object.keys(backend)).toEqual(['getInitStatus'])
+    expect(Object.keys(backend)).toEqual([...DESKTOP_BACKEND_METHODS])
     expect(fetcher).toHaveBeenCalledWith('/api/getInitStatus', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{}',
     })
+  })
+
+  test('maps search, history, and settings calls without changing payload nesting', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(response({ currentPage: 2, totalItems: 0, totalPages: 0, content: [] }))
+      .mockResolvedValueOnce(response({ items: [], totalCount: 0 }))
+      .mockResolvedValueOnce(response({ success: true }))
+      .mockResolvedValueOnce(response({}))
+    const backend = createDesktopBackendClient(fetcher)
+
+    await backend.search({
+      query: {
+        keyword: '猫',
+        category: '0',
+        orderBy: 'mr',
+        time: 'a',
+        searchMainTag: 0,
+        page: 2,
+      },
+    })
+    await backend.getBrowseHistory({ limit: 20, offset: 40 })
+    await backend.setReaderDisplayMode({ mode: 'horizontal' })
+    await backend.getAllSettings()
+
+    expect(fetcher.mock.calls).toEqual([
+      [
+        '/api/search',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query: {
+              keyword: '猫',
+              category: '0',
+              orderBy: 'mr',
+              time: 'a',
+              searchMainTag: 0,
+              page: 2,
+            },
+          }),
+        },
+      ],
+      [
+        '/api/getBrowseHistory',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ limit: 20, offset: 40 }),
+        },
+      ],
+      [
+        '/api/setReaderDisplayMode',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode: 'horizontal' }),
+        },
+      ],
+      [
+        '/api/getAllSettings',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        },
+      ],
+    ])
   })
 
   test('normalizes transport and malformed response failures without adding a fallback method', async () => {
@@ -40,7 +110,7 @@ describe('Desktop runtime', () => {
     await expect(malformed.getInitStatus()).rejects.toMatchObject({
       code: 'internal',
     })
-    expect((backend as unknown as { search?: unknown }).search).toBeUndefined()
+    expect((backend as unknown as { autoLogin?: unknown }).autoLogin).toBeUndefined()
   })
 
   test('uses same-origin resources and explicit unavailable phase-1 capabilities', async () => {

--- a/tests/unit/runtimeContract.test.ts
+++ b/tests/unit/runtimeContract.test.ts
@@ -7,6 +7,7 @@ import { createAndroidBackendEvents } from '@/runtime/android/androidBackendEven
 import { createAndroidPlatformServices } from '@/runtime/android/androidPlatformServices'
 import { createAndroidResourceResolver } from '@/runtime/android/androidResourceResolver'
 import { createAndroidUpdater } from '@/runtime/android/androidUpdater'
+import { createFacadeClient } from '@/runtime/facadeClient'
 import { normalizeRuntimeError } from '@/runtime/errors'
 import { configureRuntime, getRuntime, resetRuntimeForTests } from '@/runtime/runtimeContext'
 
@@ -44,6 +45,34 @@ describe('runtime context', () => {
     configureRuntime(runtime)
     expect(getRuntime()).toBe(runtime)
     expect(() => configureRuntime(runtime)).toThrow('Frontend runtime already configured')
+  })
+})
+
+describe('Facade capability failures', () => {
+  test('unavailable reader capabilities become rejections', async () => {
+    const runtime = {
+      platform: 'linux',
+      backend: {},
+      events: {},
+      resources: {},
+      services: {
+        reader: {
+          orientation: { available: false, reason: 'orientation unavailable' },
+          brightness: { available: false, reason: 'brightness unavailable' },
+          keepAwake: { available: false, reason: 'keep-awake unavailable' },
+          fullscreen: { available: false, reason: 'fullscreen unavailable' },
+          volumeKeys: { available: false, reason: 'volume keys unavailable' },
+          hostState: { available: false, reason: 'host state unavailable' },
+        },
+        pdf: {},
+      },
+    } as unknown as Parameters<typeof createFacadeClient>[0]
+
+    const facade = createFacadeClient(runtime)
+    const keepAwake = facade.setReaderKeepScreenOn({ enabled: true })
+
+    expect(keepAwake).toBeInstanceOf(Promise)
+    await expect(keepAwake).rejects.toMatchObject({ code: 'unavailable' })
   })
 })
 


### PR DESCRIPTION
## 变更
- 使用 `JMComic-Api-Java` `jmcomic-core:1.1.8` 接通 Desktop 搜索、分类、作品/章节详情、评论、认证和图片资源。
- 增加 Desktop 自有 SQLite 设置与浏览历史、边界 DTO、结构化错误响应和有界业务 executor。
- Desktop runtime 仅暴露当前已实现的 21 个方法；在线阅读通过同源图片资源 URL 加载，不引入阶段 3 的下载、SSE 或通知 API。
- 登录态只保留在进程内的 `JmApiClient`，不持久化账号凭据。

## 验证
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit`（60 个文件，384 个测试）
- `npm run build`
- `npm run desktop:sync`
- `mvn -f desktop/pom.xml test`（23 个测试）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 桌面端新增搜索、分类、专辑、照片、评论及图片资源访问。
  - 新增登录、退出登录、登录状态和用户资料功能。
  - 新增浏览历史查询、记录、概览、清空和删除功能。
  - 新增阅读器设置读取与更新，支持并发、预读页数、显示模式等选项。
  - 桌面端支持直接加载图片资源，并完善请求错误响应。
- **改进**
  - 增强桌面端初始化、数据库迁移及资源清理流程。
  - 优化桌面运行时接口调用与响应校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->