### PR TITLE
feat(desktop): 实现在线浏览与本地状态能力

### DIFF
--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -16,6 +16,7 @@
         <javalin.version>7.2.2</javalin.version>
         <jackson.version>2.21.3</jackson.version>
         <sqlite.version>3.50.3.0</sqlite.version>
+        <jmcomic.version>1.1.8</jmcomic.version>
         <slf4j.version>2.0.17</slf4j.version>
         <junit.version>5.11.4</junit.version>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
@@ -23,6 +24,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.github.jukomu</groupId>
+            <artifactId>jmcomic-core</artifactId>
+            <version>${jmcomic.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>

--- a/desktop/src/main/java/io/github/jukomu/desktop/backend/DesktopBackend.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/backend/DesktopBackend.java
@@ -2,9 +2,23 @@ package io.github.jukomu.desktop.backend;
 
 import io.github.jukomu.desktop.bridge.DesktopPlugin;
 import io.github.jukomu.desktop.bridge.PluginMethodRoutes;
+import io.github.jukomu.desktop.bridge.handler.AsyncRequestHandler;
+import io.github.jukomu.desktop.bridge.handler.AuthPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.CatalogPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.HistoryPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SettingsPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SystemPluginHandler;
 import io.github.jukomu.desktop.data.DesktopDatabase;
 import io.github.jukomu.desktop.data.DesktopPaths;
+import io.github.jukomu.desktop.feature.auth.JmComicAuthService;
+import io.github.jukomu.desktop.feature.catalog.JmComicCatalogService;
+import io.github.jukomu.desktop.feature.history.DesktopHistory;
+import io.github.jukomu.desktop.feature.settings.DesktopSettings;
+import io.github.jukomu.jmcomic.core.JmComic;
+import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
+import io.github.jukomu.jmcomic.core.config.JmConfiguration;
 import io.javalin.Javalin;
+import io.javalin.http.Context;
 import io.javalin.http.staticfiles.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,14 +58,17 @@ public final class DesktopBackend implements AutoCloseable {
     private final DesktopPaths paths;
     private final DesktopDatabase database;
     private final ExecutorService businessExecutor;
+    private final Object routeOwnerOverride;
 
     private Javalin app;
     private URI homeUrl;
+    private JmApiClient client;
+    private JmComicCatalogService catalog;
     private boolean running;
     private boolean closed;
 
     public DesktopBackend(DesktopPaths paths) {
-        this(paths, new DesktopDatabase(paths), createBusinessExecutor());
+        this(paths, new DesktopDatabase(paths), createBusinessExecutor(), null);
     }
 
     public DesktopBackend(
@@ -59,9 +76,19 @@ public final class DesktopBackend implements AutoCloseable {
             DesktopDatabase database,
             ExecutorService businessExecutor
     ) {
+        this(paths, database, businessExecutor, null);
+    }
+
+    DesktopBackend(
+            DesktopPaths paths,
+            DesktopDatabase database,
+            ExecutorService businessExecutor,
+            Object routeOwnerOverride
+    ) {
         this.paths = Objects.requireNonNull(paths, "paths");
         this.database = Objects.requireNonNull(database, "database");
         this.businessExecutor = Objects.requireNonNull(businessExecutor, "businessExecutor");
+        this.routeOwnerOverride = routeOwnerOverride;
     }
 
     public synchronized URI start() throws Exception {
@@ -82,7 +109,8 @@ public final class DesktopBackend implements AutoCloseable {
             }
 
             database.open();
-            DesktopPlugin plugin = new DesktopPlugin();
+            Object routeOwner = routeOwnerOverride == null ? createPlugin() : routeOwnerOverride;
+            JmComicCatalogService imageCatalog = catalog;
             candidate = Javalin.create(config -> {
                 config.jetty.host = LOOPBACK_HOST;
                 config.jetty.port = 0;
@@ -92,7 +120,17 @@ public final class DesktopBackend implements AutoCloseable {
                     config.spaRoot.addFile(path, "static/index.html", Location.CLASSPATH);
                 }
                 config.routes.get("/", context -> context.redirect("/home"));
-                PluginMethodRoutes.register(config.routes, plugin);
+                PluginMethodRoutes.register(config.routes, routeOwner);
+                if (imageCatalog != null) {
+                    config.routes.get(
+                            "/image/{photoId}/{sortOrder}",
+                            context -> serveImage(context, imageCatalog)
+                    );
+                    config.routes.get(
+                            "/thumb/{photoId}/{sortOrder}",
+                            context -> serveImage(context, imageCatalog)
+                    );
+                }
             });
             candidate.start();
             int port = candidate.port();
@@ -115,7 +153,35 @@ public final class DesktopBackend implements AutoCloseable {
             }
             database.close();
             businessExecutor.shutdownNow();
+            closeClient();
             throw exception;
+        }
+    }
+
+    private DesktopPlugin createPlugin() {
+        client = JmComic.newApiClient(new JmConfiguration.Builder().build());
+        catalog = new JmComicCatalogService(client);
+        return new DesktopPlugin(
+                new SystemPluginHandler(),
+                new CatalogPluginHandler(catalog, businessExecutor),
+                new AuthPluginHandler(new JmComicAuthService(client), businessExecutor),
+                new SettingsPluginHandler(new DesktopSettings(database), businessExecutor),
+                new HistoryPluginHandler(new DesktopHistory(database), businessExecutor)
+        );
+    }
+
+    private void serveImage(Context context, JmComicCatalogService imageCatalog) {
+        try {
+            String photoId = context.pathParam("photoId");
+            int sortOrder = Integer.parseInt(context.pathParam("sortOrder"));
+            AsyncRequestHandler.submit(
+                    context,
+                    businessExecutor,
+                    () -> imageCatalog.getImage(photoId, sortOrder),
+                    resource -> context.contentType(resource.mediaType()).result(resource.bytes())
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
         }
     }
 
@@ -186,6 +252,17 @@ public final class DesktopBackend implements AutoCloseable {
             businessExecutor.shutdownNow();
             Thread.currentThread().interrupt();
         }
+        closeClient();
         database.close();
+    }
+
+    private void closeClient() {
+        JmComicCatalogService currentCatalog = catalog;
+        catalog = null;
+        if (currentCatalog != null) currentCatalog.close();
+
+        JmApiClient currentClient = client;
+        client = null;
+        if (currentClient != null) currentClient.close();
     }
 }

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/DesktopPlugin.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/DesktopPlugin.java
@@ -1,22 +1,136 @@
 package io.github.jukomu.desktop.bridge;
 
+import io.github.jukomu.desktop.bridge.handler.AuthPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.CatalogPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.HistoryPluginHandler;
+import io.github.jukomu.desktop.bridge.handler.SettingsPluginHandler;
 import io.github.jukomu.desktop.bridge.handler.SystemPluginHandler;
 import io.javalin.http.Context;
 
 /** 向本地 HTTP backend 暴露的唯一 Desktop bridge。 */
 public final class DesktopPlugin {
+    private final CatalogPluginHandler catalogHandler;
+    private final AuthPluginHandler authHandler;
+    private final SettingsPluginHandler settingsHandler;
+    private final HistoryPluginHandler historyHandler;
     private final SystemPluginHandler systemHandler;
 
-    public DesktopPlugin() {
-        this(new SystemPluginHandler());
-    }
-
-    public DesktopPlugin(SystemPluginHandler systemHandler) {
+    public DesktopPlugin(
+            SystemPluginHandler systemHandler,
+            CatalogPluginHandler catalogHandler,
+            AuthPluginHandler authHandler,
+            SettingsPluginHandler settingsHandler,
+            HistoryPluginHandler historyHandler
+    ) {
         this.systemHandler = systemHandler;
+        this.catalogHandler = catalogHandler;
+        this.authHandler = authHandler;
+        this.settingsHandler = settingsHandler;
+        this.historyHandler = historyHandler;
     }
 
     @PluginMethod
     public void getInitStatus(Context context) {
         systemHandler.getInitStatus(context);
+    }
+
+    @PluginMethod
+    public void search(Context context) {
+        catalogHandler.search(context);
+    }
+
+    @PluginMethod
+    public void categories(Context context) {
+        catalogHandler.categories(context);
+    }
+
+    @PluginMethod
+    public void getAlbum(Context context) {
+        catalogHandler.getAlbum(context);
+    }
+
+    @PluginMethod
+    public void getPhoto(Context context) {
+        catalogHandler.getPhoto(context);
+    }
+
+    @PluginMethod
+    public void getComments(Context context) {
+        catalogHandler.getComments(context);
+    }
+
+    @PluginMethod
+    public void login(Context context) {
+        authHandler.login(context);
+    }
+
+    @PluginMethod
+    public void logout(Context context) {
+        authHandler.logout(context);
+    }
+
+    @PluginMethod
+    public void checkLoginState(Context context) {
+        authHandler.checkLoginState(context);
+    }
+
+    @PluginMethod
+    public void getUserProfile(Context context) {
+        authHandler.getUserProfile(context);
+    }
+
+    @PluginMethod
+    public void getAllSettings(Context context) {
+        settingsHandler.getAllSettings(context);
+    }
+
+    @PluginMethod
+    public void setPreloadConcurrency(Context context) {
+        settingsHandler.setPreloadConcurrency(context);
+    }
+
+    @PluginMethod
+    public void setDownloadConcurrency(Context context) {
+        settingsHandler.setDownloadConcurrency(context);
+    }
+
+    @PluginMethod
+    public void setReaderPreloadPages(Context context) {
+        settingsHandler.setReaderPreloadPages(context);
+    }
+
+    @PluginMethod
+    public void setReaderDisplayMode(Context context) {
+        settingsHandler.setReaderDisplayMode(context);
+    }
+
+    @PluginMethod
+    public void setReaderAutoShowToolbarAtEnd(Context context) {
+        settingsHandler.setReaderAutoShowToolbarAtEnd(context);
+    }
+
+    @PluginMethod
+    public void getBrowseHistory(Context context) {
+        historyHandler.getBrowseHistory(context);
+    }
+
+    @PluginMethod
+    public void getBrowseHistoryOverview(Context context) {
+        historyHandler.getBrowseHistoryOverview(context);
+    }
+
+    @PluginMethod
+    public void recordBrowse(Context context) {
+        historyHandler.recordBrowse(context);
+    }
+
+    @PluginMethod
+    public void clearBrowseHistory(Context context) {
+        historyHandler.clearBrowseHistory(context);
+    }
+
+    @PluginMethod
+    public void deleteBrowseItem(Context context) {
+        historyHandler.deleteBrowseItem(context);
     }
 }

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AsyncRequestHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AsyncRequestHandler.java
@@ -1,0 +1,116 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.error.DesktopHttpException;
+import io.github.jukomu.jmcomic.api.exception.JmComicException;
+import io.github.jukomu.jmcomic.api.exception.NetworkException;
+import io.github.jukomu.jmcomic.api.exception.ResourceNotFoundException;
+import io.github.jukomu.jmcomic.api.exception.ResponseException;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/** 在业务线程池执行阻塞调用，并保证每个请求只写入一次响应。 */
+public final class AsyncRequestHandler {
+    private AsyncRequestHandler() {
+    }
+
+    public static <T> void submitJson(Context context, Executor executor, Callable<T> operation) {
+        submit(context, executor, operation, context::json);
+    }
+
+    public static <T> void submit(
+            Context context,
+            Executor executor,
+            Callable<T> operation,
+            Consumer<T> writer
+    ) {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(executor, "executor");
+        Objects.requireNonNull(operation, "operation");
+        Objects.requireNonNull(writer, "writer");
+
+        AtomicBoolean responded = new AtomicBoolean();
+        CompletableFuture<Void> response;
+        try {
+            response = CompletableFuture.supplyAsync(() -> call(operation), executor)
+                    .thenAccept(result -> respondOnce(responded, () -> writer.accept(result)))
+                    .exceptionally(error -> {
+                        respondOnce(responded, () -> writeError(context, error));
+                        return null;
+                    });
+        } catch (RejectedExecutionException error) {
+            writeError(context, error);
+            return;
+        }
+        context.future(() -> response);
+    }
+
+    public static void writeError(Context context, Throwable error) {
+        DesktopHttpException mapped = mapError(unwrap(error));
+        ObjectNode body = JsonNodeFactory.instance.objectNode()
+                .put("code", mapped.code())
+                .put("message", mapped.getMessage());
+        context.status(mapped.status()).json(body);
+    }
+
+    private static <T> T call(Callable<T> operation) {
+        try {
+            return operation.call();
+        } catch (Exception error) {
+            throw new CompletionException(error);
+        }
+    }
+
+    private static void respondOnce(AtomicBoolean responded, Runnable response) {
+        if (responded.compareAndSet(false, true)) response.run();
+    }
+
+    private static DesktopHttpException mapError(Throwable error) {
+        if (error instanceof DesktopHttpException desktopError) return desktopError;
+        if (error instanceof ResourceNotFoundException) {
+            return new DesktopHttpException("not-found", 404, message(error));
+        }
+        if (error instanceof NetworkException) {
+            return new DesktopHttpException("network", 502, message(error));
+        }
+        if (error instanceof ResponseException || error instanceof JmComicException) {
+            return new DesktopHttpException("internal", 502, message(error));
+        }
+        if (error instanceof IllegalArgumentException) {
+            return new DesktopHttpException("internal", 400, message(error));
+        }
+        if (error instanceof RejectedExecutionException) {
+            return new DesktopHttpException("internal", 503, "Desktop 业务线程池暂时不可用");
+        }
+        if (error instanceof java.util.concurrent.CancellationException
+                || error instanceof InterruptedException) {
+            return new DesktopHttpException("cancelled", 499, "Desktop 请求已取消");
+        }
+        return new DesktopHttpException("internal", 500, message(error));
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        Throwable current = error;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static String message(Throwable error) {
+        return error != null && error.getMessage() != null && !error.getMessage().isBlank()
+                ? error.getMessage()
+                : "Desktop 请求失败";
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AuthPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/AuthPluginHandler.java
@@ -1,0 +1,47 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.feature.auth.JmComicAuthService;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 解析认证请求，并维护当前 Desktop 进程的登录态。 */
+public final class AuthPluginHandler {
+    private final JmComicAuthService auth;
+    private final Executor executor;
+
+    public AuthPluginHandler(JmComicAuthService auth, Executor executor) {
+        this.auth = Objects.requireNonNull(auth, "auth");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void login(Context context) {
+        try {
+            ObjectNode body = RequestJson.body(context);
+            String username = RequestJson.requiredText(body, "username");
+            String password = RequestJson.requiredText(body, "password");
+            AsyncRequestHandler.submitJson(context, executor, () -> auth.login(username, password));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void logout(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, auth::logout);
+    }
+
+    public void checkLoginState(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, auth::checkLoginState);
+    }
+
+    public void getUserProfile(Context context) {
+        try {
+            String uid = RequestJson.requiredText(RequestJson.body(context), "uid");
+            AsyncRequestHandler.submitJson(context, executor, () -> auth.getUserProfile(uid));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/CatalogPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/CatalogPluginHandler.java
@@ -1,0 +1,56 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.feature.catalog.JmComicCatalogService;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 解析目录请求，并把阻塞的远程调用调度到业务线程池。 */
+public final class CatalogPluginHandler {
+    private final JmComicCatalogService catalog;
+    private final Executor executor;
+
+    public CatalogPluginHandler(JmComicCatalogService catalog, Executor executor) {
+        this.catalog = Objects.requireNonNull(catalog, "catalog");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void search(Context context) {
+        handle(context, body -> catalog.search(RequestJson.object(body, "query")));
+    }
+
+    public void categories(Context context) {
+        handle(context, body -> catalog.categories(RequestJson.object(body, "query")));
+    }
+
+    public void getAlbum(Context context) {
+        handle(context, body -> catalog.getAlbum(RequestJson.requiredText(body, "id")));
+    }
+
+    public void getPhoto(Context context) {
+        handle(context, body -> catalog.getPhoto(RequestJson.requiredText(body, "id")));
+    }
+
+    public void getComments(Context context) {
+        handle(context, body -> catalog.getComments(
+                RequestJson.requiredText(body, "albumId"),
+                RequestJson.integer(body, "page", 1)
+        ));
+    }
+
+    private void handle(Context context, RequestOperation operation) {
+        try {
+            ObjectNode body = RequestJson.body(context);
+            AsyncRequestHandler.submitJson(context, executor, () -> operation.call(body));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    @FunctionalInterface
+    private interface RequestOperation {
+        ObjectNode call(ObjectNode body) throws Exception;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/HistoryPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/HistoryPluginHandler.java
@@ -1,0 +1,76 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.feature.history.DesktopHistory;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 解析浏览历史请求，并在业务线程池完成 SQLite 访问。 */
+public final class HistoryPluginHandler {
+    private final DesktopHistory history;
+    private final Executor executor;
+
+    public HistoryPluginHandler(DesktopHistory history, Executor executor) {
+        this.history = Objects.requireNonNull(history, "history");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void getBrowseHistory(Context context) {
+        try {
+            ObjectNode body = RequestJson.body(context);
+            int limit = RequestJson.integer(body, "limit", 0);
+            int offset = RequestJson.integer(body, "offset", 0);
+            Long start = RequestJson.nullableLong(body, "startInclusive");
+            Long end = RequestJson.nullableLong(body, "endExclusive");
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> history.getBrowseHistory(limit, offset, start, end)
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void getBrowseHistoryOverview(Context context) {
+        try {
+            JsonNode ranges = RequestJson.body(context).get("ranges");
+            if (!(ranges instanceof ArrayNode array)) {
+                throw new IllegalArgumentException("ranges is required");
+            }
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> history.getBrowseHistoryOverview(array)
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void recordBrowse(Context context) {
+        try {
+            ObjectNode body = RequestJson.body(context);
+            AsyncRequestHandler.submitJson(context, executor, () -> history.recordBrowse(body));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void clearBrowseHistory(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, history::clearBrowseHistory);
+    }
+
+    public void deleteBrowseItem(Context context) {
+        try {
+            long id = RequestJson.longValue(RequestJson.body(context), "id", 0);
+            AsyncRequestHandler.submitJson(context, executor, () -> history.deleteBrowseItem(id));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/RequestJson.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/RequestJson.java
@@ -1,0 +1,75 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.javalin.http.Context;
+
+/** 读取并校验 Desktop bridge 的 JSON 请求参数。 */
+public final class RequestJson {
+    private RequestJson() {
+    }
+
+    public static ObjectNode body(Context context) {
+        JsonNode body = context.bodyAsClass(JsonNode.class);
+        if (!(body instanceof ObjectNode object)) {
+            throw new IllegalArgumentException("request body must be a JSON object");
+        }
+        return object;
+    }
+
+    public static ObjectNode object(ObjectNode body, String name) {
+        JsonNode value = body.get(name);
+        if (!(value instanceof ObjectNode object)) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return object;
+    }
+
+    public static String requiredText(ObjectNode body, String name) {
+        String value = text(body, name, "").trim();
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+
+    public static String text(ObjectNode body, String name, String fallback) {
+        JsonNode value = body.get(name);
+        return value == null || value.isNull() ? fallback : value.asText(fallback);
+    }
+
+    public static int integer(ObjectNode body, String name, int fallback) {
+        JsonNode value = body.get(name);
+        if (value == null || value.isNull()) return fallback;
+        if (!value.isIntegralNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        return value.intValue();
+    }
+
+    public static long longValue(ObjectNode body, String name, long fallback) {
+        JsonNode value = body.get(name);
+        if (value == null || value.isNull()) return fallback;
+        if (!value.isIntegralNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        return value.longValue();
+    }
+
+    public static Long nullableLong(ObjectNode body, String name) {
+        JsonNode value = body.get(name);
+        if (value == null || value.isNull()) return null;
+        if (!value.isIntegralNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer or null");
+        }
+        return value.longValue();
+    }
+
+    public static boolean requiredBoolean(ObjectNode body, String name) {
+        JsonNode value = body.get(name);
+        if (value == null || !value.isBoolean()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value.booleanValue();
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/SettingsPluginHandler.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/bridge/handler/SettingsPluginHandler.java
@@ -1,0 +1,71 @@
+package io.github.jukomu.desktop.bridge.handler;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.feature.settings.DesktopSettings;
+import io.javalin.http.Context;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/** 解析 Desktop 设置请求，并在业务线程池完成 SQLite 访问。 */
+public final class SettingsPluginHandler {
+    private final DesktopSettings settings;
+    private final Executor executor;
+
+    public SettingsPluginHandler(DesktopSettings settings, Executor executor) {
+        this.settings = Objects.requireNonNull(settings, "settings");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public void getAllSettings(Context context) {
+        AsyncRequestHandler.submitJson(context, executor, settings::getAllSettings);
+    }
+
+    public void setPreloadConcurrency(Context context) {
+        number(context, settings::setPreloadConcurrency);
+    }
+
+    public void setDownloadConcurrency(Context context) {
+        number(context, settings::setDownloadConcurrency);
+    }
+
+    public void setReaderPreloadPages(Context context) {
+        number(context, settings::setReaderPreloadPages);
+    }
+
+    public void setReaderDisplayMode(Context context) {
+        try {
+            String mode = RequestJson.requiredText(RequestJson.body(context), "mode");
+            AsyncRequestHandler.submitJson(context, executor, () -> settings.setReaderDisplayMode(mode));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    public void setReaderAutoShowToolbarAtEnd(Context context) {
+        try {
+            boolean enabled = RequestJson.requiredBoolean(RequestJson.body(context), "enabled");
+            AsyncRequestHandler.submitJson(
+                    context,
+                    executor,
+                    () -> settings.setReaderAutoShowToolbarAtEnd(enabled)
+            );
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    private void number(Context context, NumberOperation operation) {
+        try {
+            int value = RequestJson.integer(RequestJson.body(context), "n", Integer.MIN_VALUE);
+            AsyncRequestHandler.submitJson(context, executor, () -> operation.call(value));
+        } catch (Exception error) {
+            AsyncRequestHandler.writeError(context, error);
+        }
+    }
+
+    @FunctionalInterface
+    private interface NumberOperation {
+        ObjectNode call(int value) throws Exception;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopDatabase.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/data/DesktopDatabase.java
@@ -52,12 +52,40 @@ public final class DesktopDatabase implements AutoCloseable {
                     "CREATE TABLE IF NOT EXISTS desktop_schema_version "
                             + "(version INTEGER NOT NULL)"
             );
+            statement.executeUpdate("""
+                    CREATE TABLE IF NOT EXISTS desktop_settings (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL,
+                        updated_at INTEGER NOT NULL
+                    )
+                    """);
+            statement.executeUpdate("""
+                    CREATE TABLE IF NOT EXISTS browse_history (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        album_id TEXT NOT NULL,
+                        album_title TEXT NOT NULL,
+                        cover_url TEXT NOT NULL,
+                        authors TEXT NOT NULL,
+                        chapter_id TEXT NOT NULL,
+                        chapter_title TEXT NOT NULL,
+                        timestamp INTEGER NOT NULL
+                    )
+                    """);
+            statement.executeUpdate("""
+                    CREATE INDEX IF NOT EXISTS idx_browse_history_timestamp
+                    ON browse_history(timestamp DESC, id DESC)
+                    """);
         }
 
         try (PreparedStatement statement = connection.prepareStatement(
                 "INSERT INTO desktop_schema_version(version) "
-                        + "SELECT 1 WHERE NOT EXISTS "
+                        + "SELECT 2 WHERE NOT EXISTS "
                         + "(SELECT 1 FROM desktop_schema_version)"
+        )) {
+            statement.executeUpdate();
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "UPDATE desktop_schema_version SET version = 2 WHERE version < 2"
         )) {
             statement.executeUpdate();
         }

--- a/desktop/src/main/java/io/github/jukomu/desktop/error/DesktopHttpException.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/error/DesktopHttpException.java
@@ -1,0 +1,23 @@
+package io.github.jukomu.desktop.error;
+
+import java.util.Objects;
+
+/** 表示可稳定映射为 Desktop HTTP 错误响应的业务异常。 */
+public final class DesktopHttpException extends RuntimeException {
+    private final String code;
+    private final int status;
+
+    public DesktopHttpException(String code, int status, String message) {
+        super(Objects.requireNonNull(message, "message"));
+        this.code = Objects.requireNonNull(code, "code");
+        this.status = status;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public int status() {
+        return status;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/feature/auth/AuthJson.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/feature/auth/AuthJson.java
@@ -1,0 +1,49 @@
+package io.github.jukomu.desktop.feature.auth;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.jmcomic.api.model.JmUserInfo;
+import io.github.jukomu.jmcomic.api.model.JmUserProfile;
+
+/** 将上游认证模型转换为前端既有的认证 JSON 契约。 */
+public final class AuthJson {
+    private AuthJson() {
+    }
+
+    public static ObjectNode userInfo(JmUserInfo user) {
+        return JsonNodeFactory.instance.objectNode()
+                .put("uid", text(user.getUid()))
+                .put("username", text(user.getUsername()))
+                .put("email", text(user.getEmail()))
+                .put("emailVerified", user.isEmailVerified())
+                .put("avatarUrl", text(user.getPhotoUrl()))
+                .put("firstName", text(user.getFirstName()))
+                .put("gender", text(user.getGender()))
+                .put("message", text(user.getMessage()))
+                .put("level", user.getLevel())
+                .put("levelName", text(user.getLevelName()))
+                .put("nextLevelExp", user.getNextLevelExp())
+                .put("currentExp", user.getCurrentExp())
+                .put("expPercent", user.getExpPercent())
+                .put("coin", user.getCoin())
+                .put("albumFavorites", user.getAlbumFavorites())
+                .put("maxAlbumFavorites", user.getMaxAlbumFavorites());
+    }
+
+    public static ObjectNode profile(JmUserProfile profile) {
+        return JsonNodeFactory.instance.objectNode()
+                .put("username", text(profile.username()))
+                .put("email", text(profile.email()))
+                .put("nickname", text(profile.nickname()))
+                .put("birthday", text(profile.birthday()))
+                .put("city", text(profile.city()))
+                .put("country", text(profile.country()))
+                .put("occupation", text(profile.occupation()))
+                .put("aboutMe", text(profile.aboutMe()))
+                .put("website", text(profile.website()));
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/feature/auth/JmComicAuthService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/feature/auth/JmComicAuthService.java
@@ -1,0 +1,52 @@
+package io.github.jukomu.desktop.feature.auth;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
+
+import java.util.Objects;
+
+/** 使用当前进程的 JmApiClient 管理不落盘的 Desktop 登录态。 */
+public final class JmComicAuthService {
+    private final JmApiClient client;
+    private ObjectNode currentUser;
+
+    public JmComicAuthService(JmApiClient client) {
+        this.client = Objects.requireNonNull(client, "client");
+    }
+
+    public synchronized ObjectNode login(String username, String password) {
+        ObjectNode user = AuthJson.userInfo(client.login(
+                requireText(username, "username"),
+                requireText(password, "password")
+        ));
+        currentUser = user.deepCopy();
+        return user;
+    }
+
+    public synchronized ObjectNode logout() {
+        if (currentUser != null) client.logout();
+        currentUser = null;
+        return JsonNodeFactory.instance.objectNode().put("success", true);
+    }
+
+    public synchronized ObjectNode checkLoginState() {
+        ObjectNode result = JsonNodeFactory.instance.objectNode()
+                .put("loggedIn", currentUser != null);
+        if (currentUser != null) {
+            result.put("username", currentUser.path("username").asText(""));
+            result.set("userInfo", currentUser.deepCopy());
+        }
+        return result;
+    }
+
+    public ObjectNode getUserProfile(String uid) {
+        return AuthJson.profile(client.getUserProfile(requireText(uid, "uid")));
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()) throw new IllegalArgumentException(name + " is required");
+        return normalized;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/feature/catalog/CatalogJson.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/feature/catalog/CatalogJson.java
@@ -1,0 +1,161 @@
+package io.github.jukomu.desktop.feature.catalog;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.jmcomic.api.model.JmAlbum;
+import io.github.jukomu.jmcomic.api.model.JmAlbumMeta;
+import io.github.jukomu.jmcomic.api.model.JmCategoryMeta;
+import io.github.jukomu.jmcomic.api.model.JmComment;
+import io.github.jukomu.jmcomic.api.model.JmCommentList;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+import io.github.jukomu.jmcomic.api.model.JmPhoto;
+import io.github.jukomu.jmcomic.api.model.JmPhotoMeta;
+import io.github.jukomu.jmcomic.api.model.JmSearchPage;
+
+import java.util.List;
+import java.util.function.Function;
+
+/** 将上游 JM 模型转换为前端既有的目录 JSON 契约。 */
+public final class CatalogJson {
+    private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
+
+    private CatalogJson() {
+    }
+
+    public static ObjectNode searchPage(JmSearchPage page, Function<String, String> coverUrl) {
+        ObjectNode result = JSON.objectNode()
+                .put("currentPage", page.getCurrentPage())
+                .put("totalItems", page.getTotalItems())
+                .put("totalPages", page.getTotalPages());
+        ArrayNode content = result.putArray("content");
+        for (JmAlbumMeta item : list(page.getContent())) {
+            ObjectNode row = content.addObject()
+                    .put("id", text(item.getId()))
+                    .put("title", text(item.getTitle()))
+                    .put("coverUrl", text(coverUrl.apply(item.getId())));
+            strings(row.putArray("authors"), item.getAuthors());
+            strings(row.putArray("tags"), item.getTags());
+        }
+        return result;
+    }
+
+    public static ObjectNode album(JmAlbum album, Function<String, String> coverUrl) {
+        ObjectNode result = JSON.objectNode()
+                .put("id", text(album.getId()))
+                .put("title", text(album.getTitle()))
+                .put("description", text(album.getDescription()))
+                .put("addTime", text(album.getAddTime()))
+                .put("pageCount", album.getPageCount())
+                .put("likes", text(album.getLikes()))
+                .put("views", text(album.getViews()))
+                .put("commentCount", album.getCommentCount())
+                .put("image", text(coverUrl.apply(album.getId())))
+                .put("seriesId", text(album.getSeriesId()))
+                .put("isSingleEpisode", album.isSingleAlbum())
+                .put("isFavorite", album.isFavorite())
+                .put("isLiked", album.isLiked())
+                .put("price", text(album.getPrice()))
+                .put("purchased", text(album.getPurchased()));
+        putCategory(result, "category", album.getCategory());
+        putCategory(result, "subCategory", album.getSubCategory());
+        strings(result.putArray("authors"), album.getAuthors());
+        strings(result.putArray("works"), album.getWorks());
+        strings(result.putArray("actors"), album.getActors());
+        strings(result.putArray("tags"), album.getTags());
+
+        ArrayNode related = result.putArray("relatedAlbums");
+        for (JmAlbumMeta item : list(album.getRelatedAlbums())) {
+            ObjectNode row = related.addObject()
+                    .put("id", text(item.getId()))
+                    .put("title", text(item.getTitle()))
+                    .put("coverUrl", text(coverUrl.apply(item.getId())))
+                    .put("description", text(item.getDescription()))
+                    .put("image", text(item.getImage()));
+            strings(row.putArray("authors"), item.getAuthors());
+            strings(row.putArray("tags"), item.getTags());
+            putCategory(row, "category", item.getCategory());
+            putCategory(row, "subCategory", item.getSubCategory());
+        }
+
+        ArrayNode photos = result.putArray("photoMetas");
+        for (JmPhotoMeta item : list(album.getPhotoMetas())) {
+            photos.addObject()
+                    .put("id", text(item.getId()))
+                    .put("title", text(item.getTitle()))
+                    .put("sortOrder", item.getSortOrder());
+        }
+        return result;
+    }
+
+    public static ObjectNode photo(JmPhoto photo) {
+        ObjectNode result = JSON.objectNode()
+                .put("id", text(photo.getId()))
+                .put("title", text(photo.getTitle()))
+                .put("albumId", text(photo.getAlbumId()))
+                .put("sortOrder", photo.getSortOrder())
+                .put("author", text(photo.getAuthor()))
+                .put("isSingleEpisode", photo.isSingleAlbum());
+        strings(result.putArray("tags"), photo.getTags());
+        ArrayNode images = result.putArray("images");
+        for (JmImage image : list(photo.getImages())) {
+            images.addObject()
+                    .put("photoId", text(image.getPhotoId()))
+                    .put("scrambleId", text(image.scrambleId()))
+                    .put("filename", text(image.getFilename()))
+                    .put("url", text(image.getUrl()))
+                    .put("queryParams", text(image.getQueryParams()))
+                    .put("sortOrder", image.getSortOrder());
+        }
+        return result;
+    }
+
+    public static ObjectNode comments(JmCommentList comments) {
+        ObjectNode result = JSON.objectNode().put("total", comments.getTotal());
+        ArrayNode list = result.putArray("list");
+        for (JmComment comment : list(comments.getList())) list.add(comment(comment));
+        return result;
+    }
+
+    private static ObjectNode comment(JmComment comment) {
+        ObjectNode result = JSON.objectNode()
+                .put("commentId", text(comment.getCommentId()))
+                .put("userId", text(comment.getUserId()))
+                .put("username", text(comment.getUsername()))
+                .put("nickname", text(comment.getNickname()))
+                .put("content", text(comment.getContent()))
+                .put("postDate", text(comment.getPostDate()))
+                .put("photo", text(comment.getPhoto()))
+                .put("expinfo", text(comment.getExpinfo()))
+                .put("aid", text(comment.getAid()))
+                .put("name", text(comment.getName()))
+                .put("likes", comment.getLikes())
+                .put("voteUp", comment.getVoteUp())
+                .put("voteDown", comment.getVoteDown());
+        ArrayNode replies = result.putArray("replys");
+        for (JmComment reply : list(comment.getReplys())) replies.add(comment(reply));
+        return result;
+    }
+
+    private static void putCategory(ObjectNode target, String name, JmCategoryMeta category) {
+        if (category == null) {
+            target.putNull(name);
+            return;
+        }
+        target.putObject(name)
+                .put("id", text(category.getId()))
+                .put("title", text(category.getTitle()));
+    }
+
+    private static void strings(ArrayNode target, List<String> values) {
+        for (String value : list(values)) target.add(text(value));
+    }
+
+    private static <T> List<T> list(List<T> value) {
+        return value == null ? List.of() : value;
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/feature/catalog/JmComicCatalogService.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/feature/catalog/JmComicCatalogService.java
@@ -1,0 +1,191 @@
+package io.github.jukomu.desktop.feature.catalog;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.error.DesktopHttpException;
+import io.github.jukomu.jmcomic.api.enums.Category;
+import io.github.jukomu.jmcomic.api.enums.ForumMode;
+import io.github.jukomu.jmcomic.api.enums.OrderBy;
+import io.github.jukomu.jmcomic.api.enums.SearchMainTag;
+import io.github.jukomu.jmcomic.api.enums.TimeOption;
+import io.github.jukomu.jmcomic.api.model.ForumQuery;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+import io.github.jukomu.jmcomic.api.model.JmPhoto;
+import io.github.jukomu.jmcomic.api.model.SearchQuery;
+import io.github.jukomu.jmcomic.core.client.impl.JmApiClient;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/** 使用当前进程的 JmApiClient 提供目录数据和图片资源。 */
+public final class JmComicCatalogService implements AutoCloseable {
+    private static final String SEARCH_COVER_SIZE = "_3x4";
+    private static final int MAX_KNOWN_IMAGES = 512;
+
+    private final JmApiClient client;
+    private final Map<ImageKey, JmImage> knownImages = new LinkedHashMap<>(64, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<ImageKey, JmImage> eldest) {
+            return size() > MAX_KNOWN_IMAGES;
+        }
+    };
+
+    public JmComicCatalogService(JmApiClient client) {
+        this.client = Objects.requireNonNull(client, "client");
+    }
+
+    public ObjectNode search(ObjectNode query) {
+        return CatalogJson.searchPage(client.search(buildQuery(query, true)), this::coverUrl);
+    }
+
+    public ObjectNode categories(ObjectNode query) {
+        return CatalogJson.searchPage(client.getCategories(buildQuery(query, false)), this::coverUrl);
+    }
+
+    public ObjectNode getAlbum(String id) {
+        return CatalogJson.album(client.getAlbum(requireId(id, "id")), this::coverUrl);
+    }
+
+    public ObjectNode getPhoto(String id) {
+        JmPhoto photo = client.getPhoto(requireId(id, "id"));
+        remember(photo);
+        return CatalogJson.photo(photo);
+    }
+
+    public ObjectNode getComments(String albumId, int page) {
+        if (page < 1) throw new IllegalArgumentException("page must be greater than or equal to 1");
+        ForumQuery query = ForumQuery.album(requireId(albumId, "albumId"))
+                .mode(ForumMode.ALL)
+                .page(page)
+                .build();
+        return CatalogJson.comments(client.getComments(query));
+    }
+
+    public ImageResource getImage(String photoId, int sortOrder) {
+        String id = requireId(photoId, "photoId");
+        if (sortOrder < 1) {
+            throw new IllegalArgumentException("sortOrder must be greater than or equal to 1");
+        }
+        JmImage image;
+        synchronized (knownImages) {
+            image = knownImages.get(new ImageKey(id, sortOrder));
+        }
+        if (image == null) {
+            remember(client.getPhoto(id));
+            synchronized (knownImages) {
+                image = knownImages.get(new ImageKey(id, sortOrder));
+            }
+        }
+        if (image == null) {
+            throw new DesktopHttpException("not-found", 404, "章节中不存在指定图片");
+        }
+        return new ImageResource(client.fetchImageBytes(image), mediaType(image.getFilename()));
+    }
+
+    private SearchQuery buildQuery(ObjectNode query, boolean requireKeyword) {
+        String keyword = text(query, "keyword", "").trim();
+        if (requireKeyword && keyword.isEmpty()) {
+            throw new IllegalArgumentException("keyword is required");
+        }
+        int page = integer(query, "page", 1);
+        if (page < 1) throw new IllegalArgumentException("page must be greater than or equal to 1");
+        return new SearchQuery.Builder()
+                .text(keyword)
+                .category(category(text(query, "category", "0")))
+                .orderBy(orderBy(text(query, "orderBy", "mr")))
+                .time(time(text(query, "time", "a")))
+                .mainTag(mainTag(integer(query, "searchMainTag", 0)))
+                .page(page)
+                .build();
+    }
+
+    private void remember(JmPhoto photo) {
+        synchronized (knownImages) {
+            for (JmImage image : list(photo.getImages())) {
+                knownImages.put(new ImageKey(photo.getId(), image.getSortOrder()), image);
+            }
+        }
+    }
+
+    private String coverUrl(String albumId) {
+        return client.getAlbumCoverUrl(albumId, SEARCH_COVER_SIZE);
+    }
+
+    private static SearchMainTag mainTag(int value) {
+        for (SearchMainTag item : SearchMainTag.values()) {
+            if (item.getValue() == value) return item;
+        }
+        return SearchMainTag.SITE_SEARCH;
+    }
+
+    private static Category category(String value) {
+        for (Category item : Category.values()) {
+            if (item.getValue().equals(value)) return item;
+        }
+        return Category.ALL;
+    }
+
+    private static OrderBy orderBy(String value) {
+        for (OrderBy item : OrderBy.values()) {
+            if (item.getValue().equals(value)) return item;
+        }
+        return OrderBy.LATEST;
+    }
+
+    private static TimeOption time(String value) {
+        for (TimeOption item : TimeOption.values()) {
+            if (item.getValue().equals(value)) return item;
+        }
+        return TimeOption.ALL;
+    }
+
+    private static String requireId(String value, String name) {
+        String id = value == null ? "" : value.trim();
+        if (id.isEmpty()) throw new IllegalArgumentException(name + " is required");
+        if (!id.matches("[A-Za-z0-9_-]+")) {
+            throw new IllegalArgumentException(name + " contains unsupported characters");
+        }
+        return id;
+    }
+
+    private static String text(ObjectNode node, String name, String fallback) {
+        return node.hasNonNull(name) ? node.get(name).asText(fallback) : fallback;
+    }
+
+    private static int integer(ObjectNode node, String name, int fallback) {
+        if (!node.hasNonNull(name)) return fallback;
+        if (!node.get(name).isIntegralNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        return node.get(name).intValue();
+    }
+
+    private static List<JmImage> list(List<JmImage> value) {
+        return value == null ? List.of() : value;
+    }
+
+    static String mediaType(String filename) {
+        String lower = filename == null ? "" : filename.toLowerCase(Locale.ROOT);
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+        if (lower.endsWith(".png")) return "image/png";
+        if (lower.endsWith(".gif")) return "image/gif";
+        if (lower.endsWith(".webp")) return "image/webp";
+        if (lower.endsWith(".avif")) return "image/avif";
+        return "application/octet-stream";
+    }
+
+    @Override
+    public void close() {
+        synchronized (knownImages) {
+            knownImages.clear();
+        }
+    }
+
+    public record ImageResource(byte[] bytes, String mediaType) {
+    }
+
+    private record ImageKey(String photoId, int sortOrder) {
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/feature/history/DesktopHistory.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/feature/history/DesktopHistory.java
@@ -1,0 +1,259 @@
+package io.github.jukomu.desktop.feature.history;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.data.DesktopDatabase;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** 实现 Desktop 浏览历史的去重写入、分页查询和时间分组统计。 */
+public final class DesktopHistory {
+    private static final List<String> GROUP_KEYS = List.of(
+            "today", "yesterday", "thisWeek", "thisMonth",
+            "lastThreeMonths", "lastSixMonths", "thisYear", "earlier"
+    );
+
+    private final DesktopDatabase database;
+
+    public DesktopHistory(DesktopDatabase database) {
+        this.database = Objects.requireNonNull(database, "database");
+    }
+
+    public ObjectNode recordBrowse(ObjectNode request) throws SQLException {
+        String albumId = text(request, "albumId").trim();
+        if (albumId.isEmpty()) throw new IllegalArgumentException("albumId is required");
+        synchronized (database) {
+            Connection connection = database.connection();
+            boolean autoCommit = connection.getAutoCommit();
+            try {
+                connection.setAutoCommit(false);
+                Long latestId = latestMatchingId(connection, albumId);
+                if (latestId == null) insert(connection, request, albumId);
+                else update(connection, request, latestId);
+                connection.commit();
+            } catch (SQLException | RuntimeException error) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackError) {
+                    error.addSuppressed(rollbackError);
+                }
+                throw error;
+            } finally {
+                connection.setAutoCommit(autoCommit);
+            }
+        }
+        return success();
+    }
+
+    public ObjectNode getBrowseHistory(
+            int limit,
+            int offset,
+            Long startInclusive,
+            Long endExclusive
+    ) throws SQLException {
+        if (limit < 0 || offset < 0) {
+            throw new IllegalArgumentException("limit and offset must be non-negative");
+        }
+        Range range = Range.of(startInclusive, endExclusive);
+        synchronized (database) {
+            ObjectNode result = JsonNodeFactory.instance.objectNode();
+            result.put("totalCount", count(range));
+            ArrayNode items = result.putArray("items");
+            String sql = """
+                    SELECT id, album_id, album_title, cover_url, authors,
+                           chapter_id, chapter_title, timestamp
+                    FROM browse_history
+                    %s
+                    ORDER BY timestamp DESC, id DESC
+                    %s
+                    """.formatted(range.where(), limit > 0 ? "LIMIT ? OFFSET ?" : "");
+            try (PreparedStatement statement = database.connection().prepareStatement(sql)) {
+                int index = range.bind(statement, 1);
+                if (limit > 0) {
+                    statement.setInt(index++, limit);
+                    statement.setInt(index, offset);
+                }
+                try (ResultSet rows = statement.executeQuery()) {
+                    while (rows.next()) {
+                        items.addObject()
+                                .put("id", rows.getLong("id"))
+                                .put("albumId", rows.getString("album_id"))
+                                .put("albumTitle", rows.getString("album_title"))
+                                .put("coverUrl", rows.getString("cover_url"))
+                                .put("authors", rows.getString("authors"))
+                                .put("chapterId", rows.getString("chapter_id"))
+                                .put("chapterTitle", rows.getString("chapter_title"))
+                                .put("timestamp", rows.getLong("timestamp"));
+                    }
+                }
+            }
+            return result;
+        }
+    }
+
+    public ObjectNode getBrowseHistoryOverview(ArrayNode ranges) throws SQLException {
+        if (ranges.size() != GROUP_KEYS.size()) {
+            throw new IllegalArgumentException("ranges must contain exactly eight groups");
+        }
+        Map<String, Long> counts = new LinkedHashMap<>();
+        Set<String> seen = new HashSet<>();
+        synchronized (database) {
+            for (JsonNode value : ranges) {
+                if (!(value instanceof ObjectNode rangeNode)) {
+                    throw new IllegalArgumentException("each range must be a JSON object");
+                }
+                String key = text(rangeNode, "key");
+                if (!GROUP_KEYS.contains(key) || !seen.add(key)) {
+                    throw new IllegalArgumentException("invalid or duplicate browse group key: " + key);
+                }
+                counts.put(key, count(Range.of(nullableLong(rangeNode, "startInclusive"),
+                        nullableLong(rangeNode, "endExclusive"))));
+            }
+            if (!seen.containsAll(GROUP_KEYS)) {
+                throw new IllegalArgumentException("ranges must contain all browse group keys");
+            }
+            ObjectNode result = JsonNodeFactory.instance.objectNode()
+                    .put("totalCount", count(Range.unbounded()));
+            ObjectNode groupCounts = result.putObject("groupCounts");
+            GROUP_KEYS.forEach(key -> groupCounts.put(key, counts.get(key)));
+            return result;
+        }
+    }
+
+    public ObjectNode clearBrowseHistory() throws SQLException {
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "DELETE FROM browse_history"
+            )) {
+                statement.executeUpdate();
+            }
+        }
+        return success();
+    }
+
+    public ObjectNode deleteBrowseItem(long id) throws SQLException {
+        if (id < 1) throw new IllegalArgumentException("id must be greater than or equal to 1");
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "DELETE FROM browse_history WHERE id = ?"
+            )) {
+                statement.setLong(1, id);
+                statement.executeUpdate();
+            }
+        }
+        return success();
+    }
+
+    private Long latestMatchingId(Connection connection, String albumId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("""
+                SELECT id, album_id
+                FROM browse_history
+                ORDER BY id DESC
+                LIMIT 1
+                """)) {
+            try (ResultSet row = statement.executeQuery()) {
+                if (!row.next() || !albumId.equals(row.getString("album_id"))) return null;
+                return row.getLong("id");
+            }
+        }
+    }
+
+    private void insert(Connection connection, ObjectNode request, String albumId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("""
+                INSERT INTO browse_history(
+                    album_id, album_title, cover_url, authors,
+                    chapter_id, chapter_title, timestamp
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """)) {
+            statement.setString(1, albumId);
+            bindValues(statement, request, 2);
+            statement.executeUpdate();
+        }
+    }
+
+    private void update(Connection connection, ObjectNode request, long id) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("""
+                UPDATE browse_history
+                SET album_title = ?, cover_url = ?, authors = ?,
+                    chapter_id = ?, chapter_title = ?, timestamp = ?
+                WHERE id = ?
+                """)) {
+            bindValues(statement, request, 1);
+            statement.setLong(7, id);
+            statement.executeUpdate();
+        }
+    }
+
+    private void bindValues(PreparedStatement statement, ObjectNode request, int offset)
+            throws SQLException {
+        statement.setString(offset, text(request, "albumTitle"));
+        statement.setString(offset + 1, text(request, "coverUrl"));
+        statement.setString(offset + 2, text(request, "authors"));
+        statement.setString(offset + 3, text(request, "chapterId"));
+        statement.setString(offset + 4, text(request, "chapterTitle"));
+        statement.setLong(offset + 5, System.currentTimeMillis());
+    }
+
+    private long count(Range range) throws SQLException {
+        try (PreparedStatement statement = database.connection().prepareStatement(
+                "SELECT COUNT(*) FROM browse_history " + range.where()
+        )) {
+            range.bind(statement, 1);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) throw new SQLException("count query returned no row");
+                return result.getLong(1);
+            }
+        }
+    }
+
+    private static String text(ObjectNode node, String name) {
+        JsonNode value = node.get(name);
+        return value == null || value.isNull() ? "" : value.asText("");
+    }
+
+    private static Long nullableLong(ObjectNode node, String name) {
+        JsonNode value = node.get(name);
+        if (value == null || value.isNull()) return null;
+        if (!value.isIntegralNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer or null");
+        }
+        return value.longValue();
+    }
+
+    private static ObjectNode success() {
+        return JsonNodeFactory.instance.objectNode().put("success", true);
+    }
+
+    private record Range(String where, Long first, Long second) {
+        static Range of(Long startInclusive, Long endExclusive) {
+            if (startInclusive != null && endExclusive != null && startInclusive >= endExclusive) {
+                return new Range("WHERE 1 = 0", null, null);
+            }
+            if (startInclusive == null && endExclusive == null) return unbounded();
+            if (startInclusive == null) return new Range("WHERE timestamp < ?", endExclusive, null);
+            if (endExclusive == null) return new Range("WHERE timestamp >= ?", startInclusive, null);
+            return new Range("WHERE timestamp >= ? AND timestamp < ?", startInclusive, endExclusive);
+        }
+
+        static Range unbounded() {
+            return new Range("", null, null);
+        }
+
+        int bind(PreparedStatement statement, int index) throws SQLException {
+            if (first != null) statement.setLong(index++, first);
+            if (second != null) statement.setLong(index++, second);
+            return index;
+        }
+    }
+}

--- a/desktop/src/main/java/io/github/jukomu/desktop/feature/settings/DesktopSettings.java
+++ b/desktop/src/main/java/io/github/jukomu/desktop/feature/settings/DesktopSettings.java
@@ -1,0 +1,135 @@
+package io.github.jukomu.desktop.feature.settings;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.data.DesktopDatabase;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+/** 持久化 Desktop 可配置项，并返回当前实际生效的设置快照。 */
+public final class DesktopSettings {
+    public static final int DEFAULT_CONCURRENCY = 6;
+    public static final int DEFAULT_READER_PRELOAD_PAGES = 15;
+
+    private final DesktopDatabase database;
+
+    public DesktopSettings(DesktopDatabase database) {
+        this.database = Objects.requireNonNull(database, "database");
+    }
+
+    public ObjectNode getAllSettings() throws SQLException {
+        return JsonNodeFactory.instance.objectNode()
+                .put("readerPreloadPages", integer("reader_preload_pages", DEFAULT_READER_PRELOAD_PAGES))
+                .put("preloadConcurrency", concurrency("preload_concurrency"))
+                .put("downloadConcurrency", concurrency("download_concurrency"))
+                .put("downloadPublic", false)
+                .put("cacheCapacityMb", 0)
+                .put("ocrEnabled", false)
+                .put("readerDisplayMode", text("reader_display_mode", "vertical"))
+                .put("readerScreenOrientation", "auto")
+                .put("readerBrightness", -1.0)
+                .put("readerKeepScreenOn", false)
+                .put("readerVolumeNavigation", false)
+                .put("readerAutoShowToolbarAtEnd", bool("reader_auto_show_toolbar_at_end", true));
+    }
+
+    public ObjectNode setPreloadConcurrency(int value) throws SQLException {
+        return setConcurrency("preload_concurrency", value);
+    }
+
+    public ObjectNode setDownloadConcurrency(int value) throws SQLException {
+        return setConcurrency("download_concurrency", value);
+    }
+
+    public ObjectNode setReaderPreloadPages(int value) throws SQLException {
+        if (value < 5 || value > 50) {
+            throw new IllegalArgumentException("n must be between 5 and 50");
+        }
+        put("reader_preload_pages", String.valueOf(value));
+        return success();
+    }
+
+    public ObjectNode setReaderDisplayMode(String value) throws SQLException {
+        String mode = value == null ? "" : value.trim();
+        if (!mode.equals("vertical") && !mode.equals("horizontal")) {
+            throw new IllegalArgumentException("mode must be vertical or horizontal");
+        }
+        put("reader_display_mode", mode);
+        return success();
+    }
+
+    public ObjectNode setReaderAutoShowToolbarAtEnd(boolean value) throws SQLException {
+        put("reader_auto_show_toolbar_at_end", String.valueOf(value));
+        return success();
+    }
+
+    private ObjectNode setConcurrency(String key, int value) throws SQLException {
+        if (value < 1 || value > 12) {
+            throw new IllegalArgumentException("n must be between 1 and 12");
+        }
+        put(key, String.valueOf(value));
+        return success();
+    }
+
+    private int concurrency(String key) throws SQLException {
+        int value = integer(key, DEFAULT_CONCURRENCY);
+        return value >= 1 && value <= 12 ? value : DEFAULT_CONCURRENCY;
+    }
+
+    private int integer(String key, int fallback) throws SQLException {
+        String value = get(key);
+        if (value == null) return fallback;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+
+    private boolean bool(String key, boolean fallback) throws SQLException {
+        String value = get(key);
+        return value == null ? fallback : Boolean.parseBoolean(value);
+    }
+
+    private String text(String key, String fallback) throws SQLException {
+        String value = get(key);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private String get(String key) throws SQLException {
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement(
+                    "SELECT value FROM desktop_settings WHERE key = ?"
+            )) {
+                statement.setString(1, key);
+                try (ResultSet result = statement.executeQuery()) {
+                    return result.next() ? result.getString(1) : null;
+                }
+            }
+        }
+    }
+
+    private void put(String key, String value) throws SQLException {
+        synchronized (database) {
+            try (PreparedStatement statement = database.connection().prepareStatement("""
+                    INSERT INTO desktop_settings(key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                        value = excluded.value,
+                        updated_at = excluded.updated_at
+                    """)) {
+                statement.setString(1, key);
+                statement.setString(2, value);
+                statement.setLong(3, System.currentTimeMillis());
+                statement.executeUpdate();
+            }
+        }
+    }
+
+    private static ObjectNode success() {
+        return JsonNodeFactory.instance.objectNode().put("success", true);
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/AsyncRequestHandlerTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/AsyncRequestHandlerTest.java
@@ -1,0 +1,77 @@
+package io.github.jukomu.desktop;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.jukomu.desktop.bridge.handler.AsyncRequestHandler;
+import io.javalin.Javalin;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AsyncRequestHandlerTest {
+    @Test
+    void runsBusinessWorkOffTheRequestThreadAndMapsFailures() throws Exception {
+        ExecutorService worker = Executors.newSingleThreadExecutor(runnable ->
+                new Thread(runnable, "desktop-contract-worker"));
+        Javalin app = Javalin.create(config -> {
+            config.jetty.host = "127.0.0.1";
+            config.jetty.port = 0;
+            config.routes.post("/ok", context -> AsyncRequestHandler.submitJson(
+                    context,
+                    worker,
+                    () -> JsonNodeFactory.instance.objectNode()
+                            .put("thread", Thread.currentThread().getName())
+            ));
+            config.routes.post("/invalid", context -> AsyncRequestHandler.submitJson(
+                    context,
+                    worker,
+                    () -> {
+                        throw new IllegalArgumentException("bad request");
+                    }
+            ));
+            config.routes.post("/rejected", context -> AsyncRequestHandler.submitJson(
+                    context,
+                    command -> {
+                        throw new RejectedExecutionException();
+                    },
+                    () -> JsonNodeFactory.instance.objectNode()
+            ));
+        }).start();
+
+        try {
+            URI base = URI.create("http://127.0.0.1:" + app.port());
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> ok = post(client, base.resolve("/ok"));
+            HttpResponse<String> invalid = post(client, base.resolve("/invalid"));
+            HttpResponse<String> rejected = post(client, base.resolve("/rejected"));
+
+            assertEquals(200, ok.statusCode());
+            assertTrue(ok.body().contains("desktop-contract-worker"));
+            assertEquals(400, invalid.statusCode());
+            assertTrue(invalid.body().contains("bad request"));
+            assertEquals(503, rejected.statusCode());
+            assertTrue(rejected.body().contains("业务线程池暂时不可用"));
+        } finally {
+            app.stop();
+            worker.shutdownNow();
+        }
+    }
+
+    private static HttpResponse<String> post(HttpClient client, URI uri) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder(uri)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString()
+        );
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/DesktopPathsDatabaseTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/DesktopPathsDatabaseTest.java
@@ -95,7 +95,15 @@ class DesktopPathsDatabaseTest {
                     .createStatement()
                     .executeQuery("SELECT version FROM desktop_schema_version")) {
                 assertTrue(result.next());
-                assertEquals(1, result.getInt(1));
+                assertEquals(2, result.getInt(1));
+            }
+            try (ResultSet result = database.connection()
+                    .createStatement()
+                    .executeQuery("SELECT name FROM sqlite_master WHERE type = 'table'")) {
+                java.util.Set<String> tables = new java.util.HashSet<>();
+                while (result.next()) tables.add(result.getString(1));
+                assertTrue(tables.contains("desktop_settings"));
+                assertTrue(tables.contains("browse_history"));
             }
             assertTrue(database.isOpen());
         }

--- a/desktop/src/test/java/io/github/jukomu/desktop/PluginMethodRoutesTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/PluginMethodRoutesTest.java
@@ -11,6 +11,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -25,6 +27,25 @@ class PluginMethodRoutesTest {
         assertTrue(method.isAnnotationPresent(PluginMethod.class));
         assertEquals(RetentionPolicy.RUNTIME, PluginMethod.class.getAnnotation(Retention.class).value());
         assertTrue(Modifier.isPublic(method.getModifiers()));
+    }
+
+    @Test
+    void desktopPluginExposesOnlyTheImplementedMethodSurface() {
+        Set<String> methods = java.util.Arrays.stream(DesktopPlugin.class.getDeclaredMethods())
+                .filter(method -> method.isAnnotationPresent(PluginMethod.class))
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+
+        assertEquals(Set.of(
+                "getInitStatus",
+                "search", "categories", "getAlbum", "getPhoto", "getComments",
+                "login", "logout", "checkLoginState", "getUserProfile",
+                "getAllSettings", "setPreloadConcurrency", "setDownloadConcurrency",
+                "setReaderPreloadPages", "setReaderDisplayMode",
+                "setReaderAutoShowToolbarAtEnd",
+                "getBrowseHistory", "getBrowseHistoryOverview", "recordBrowse",
+                "clearBrowseHistory", "deleteBrowseItem"
+        ), methods);
     }
 
     @Test

--- a/desktop/src/test/java/io/github/jukomu/desktop/backend/DesktopBackendHttpTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/backend/DesktopBackendHttpTest.java
@@ -1,6 +1,6 @@
-package io.github.jukomu.desktop;
+package io.github.jukomu.desktop.backend;
 
-import io.github.jukomu.desktop.backend.DesktopBackend;
+import io.github.jukomu.desktop.data.DesktopDatabase;
 import io.github.jukomu.desktop.data.DesktopPaths;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +12,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -30,7 +31,7 @@ class DesktopBackendHttpTest {
         );
         HttpClient client = HttpClient.newHttpClient();
 
-        DesktopBackend backend = new DesktopBackend(paths);
+        DesktopBackend backend = testBackend(paths);
         URI base;
         try (backend) {
             URI home = backend.start();
@@ -77,6 +78,15 @@ class DesktopBackendHttpTest {
                 () -> send(client, HttpRequest.newBuilder(base.resolve("/home")).GET().build())
         );
         assertTrue(backend.businessExecutor().isShutdown());
+    }
+
+    static DesktopBackend testBackend(DesktopPaths paths) {
+        return new DesktopBackend(
+                paths,
+                new DesktopDatabase(paths),
+                Executors.newSingleThreadExecutor(),
+                new InitOnlyPlugin()
+        );
     }
 
     private static HttpResponse<String> send(

--- a/desktop/src/test/java/io/github/jukomu/desktop/backend/DesktopHostTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/backend/DesktopHostTest.java
@@ -1,6 +1,5 @@
-package io.github.jukomu.desktop;
+package io.github.jukomu.desktop.backend;
 
-import io.github.jukomu.desktop.backend.DesktopBackend;
 import io.github.jukomu.desktop.data.DesktopPaths;
 import io.github.jukomu.desktop.host.BrowserLauncher;
 import io.github.jukomu.desktop.host.DesktopHost;
@@ -29,12 +28,12 @@ class DesktopHostTest {
         );
         List<String> opened = new ArrayList<>();
         DesktopHost primary = new DesktopHost(
-                new DesktopBackend(paths),
+                DesktopBackendHttpTest.testBackend(paths),
                 new SingleInstanceGuard(paths),
                 new BrowserLauncher(uri -> opened.add(uri.toString()))
         );
         DesktopHost secondary = new DesktopHost(
-                new DesktopBackend(paths),
+                DesktopBackendHttpTest.testBackend(paths),
                 new SingleInstanceGuard(paths),
                 new BrowserLauncher(uri -> opened.add(uri.toString()))
         );

--- a/desktop/src/test/java/io/github/jukomu/desktop/backend/InitOnlyPlugin.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/backend/InitOnlyPlugin.java
@@ -1,10 +1,11 @@
-package io.github.jukomu.desktop.bridge.handler;
+package io.github.jukomu.desktop.backend;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.jukomu.desktop.bridge.PluginMethod;
 import io.javalin.http.Context;
 
-/** 报告 Desktop bridge 已完成装配，可以接收业务请求。 */
-public final class SystemPluginHandler {
+public final class InitOnlyPlugin {
+    @PluginMethod
     public void getInitStatus(Context context) {
         context.json(JsonNodeFactory.instance.objectNode().put("complete", true));
     }

--- a/desktop/src/test/java/io/github/jukomu/desktop/feature/AuthJsonTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/feature/AuthJsonTest.java
@@ -1,0 +1,32 @@
+package io.github.jukomu.desktop.feature;
+
+import io.github.jukomu.desktop.feature.auth.AuthJson;
+import io.github.jukomu.jmcomic.api.model.JmUserInfo;
+import io.github.jukomu.jmcomic.api.model.JmUserProfile;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class AuthJsonTest {
+    @Test
+    void mapsUserAndProfileToTheExistingFrontendFieldNames() {
+        var user = AuthJson.userInfo(new JmUserInfo(
+                "1", "user", null, true, "https://avatar", "name", "x", "message",
+                10, 20, 3, "Lv.3", 100, 40, 0.4, 500
+        ));
+
+        assertEquals("", user.path("email").asText());
+        assertEquals("https://avatar", user.path("avatarUrl").asText());
+        assertEquals(40, user.path("currentExp").asLong());
+
+        var profile = AuthJson.profile(new JmUserProfile(
+                "user", "mail@example.com", "nick", "last", "first", "2000-01-01",
+                "", "", "https://site", "", "city", "country", "job", "", "",
+                "about", "", "", "", "", "", ""
+        ));
+        assertEquals("nick", profile.path("nickname").asText());
+        assertEquals("about", profile.path("aboutMe").asText());
+        assertFalse(profile.has("lastName"));
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/feature/DesktopSettingsHistoryTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/feature/DesktopSettingsHistoryTest.java
@@ -1,0 +1,91 @@
+package io.github.jukomu.desktop.feature;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jukomu.desktop.data.DesktopDatabase;
+import io.github.jukomu.desktop.feature.history.DesktopHistory;
+import io.github.jukomu.desktop.feature.settings.DesktopSettings;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DesktopSettingsHistoryTest {
+    @Test
+    void persistsOnlySupportedSettingsAndReturnsStableDesktopValues() throws Exception {
+        try (DesktopDatabase database = database()) {
+            DesktopSettings settings = new DesktopSettings(database);
+            assertEquals(6, settings.getAllSettings().path("preloadConcurrency").asInt());
+            assertFalse(settings.getAllSettings().has("cacheRequestedMb"));
+
+            settings.setPreloadConcurrency(4);
+            settings.setDownloadConcurrency(8);
+            settings.setReaderPreloadPages(20);
+            settings.setReaderDisplayMode("horizontal");
+            settings.setReaderAutoShowToolbarAtEnd(false);
+
+            var result = settings.getAllSettings();
+            assertEquals(4, result.path("preloadConcurrency").asInt());
+            assertEquals(8, result.path("downloadConcurrency").asInt());
+            assertEquals(20, result.path("readerPreloadPages").asInt());
+            assertEquals("horizontal", result.path("readerDisplayMode").asText());
+            assertFalse(result.path("readerAutoShowToolbarAtEnd").asBoolean());
+            assertThrows(IllegalArgumentException.class, () -> settings.setDownloadConcurrency(13));
+        }
+    }
+
+    @Test
+    void deduplicatesOnlyTheLatestAlbumAndSupportsPagingAndRanges() throws Exception {
+        try (DesktopDatabase database = database()) {
+            DesktopHistory history = new DesktopHistory(database);
+            history.recordBrowse(browse("a", "第一章"));
+            history.recordBrowse(browse("a", "第二章"));
+            history.recordBrowse(browse("b", "第一章"));
+
+            var page = history.getBrowseHistory(1, 0, null, null);
+            assertEquals(2, page.path("totalCount").asInt());
+            assertEquals("b", page.path("items").get(0).path("albumId").asText());
+
+            long now = System.currentTimeMillis();
+            var ranged = history.getBrowseHistory(0, 0, now + 1, null);
+            assertEquals(0, ranged.path("totalCount").asInt());
+
+            var ranges = JsonNodeFactory.instance.arrayNode();
+            for (String key : new String[]{
+                    "today", "yesterday", "thisWeek", "thisMonth",
+                    "lastThreeMonths", "lastSixMonths", "thisYear", "earlier"
+            }) {
+                ranges.addObject().put("key", key).putNull("startInclusive").putNull("endExclusive");
+            }
+            var overview = history.getBrowseHistoryOverview(ranges);
+            assertEquals(2, overview.path("totalCount").asInt());
+            assertEquals(2, overview.path("groupCounts").path("today").asInt());
+
+            long id = page.path("items").get(0).path("id").asLong();
+            assertTrue(history.deleteBrowseItem(id).path("success").asBoolean());
+            assertEquals(1, history.getBrowseHistory(0, 0, null, null).path("totalCount").asInt());
+        }
+    }
+
+    private static DesktopDatabase database() throws Exception {
+        DesktopDatabase database = new DesktopDatabase(
+                Files.createTempDirectory("jq-viewer-feature-").resolve("desktop.sqlite3")
+        );
+        database.open();
+        return database;
+    }
+
+    private static ObjectNode browse(String albumId, String chapterTitle) {
+        return JsonNodeFactory.instance.objectNode()
+                .put("albumId", albumId)
+                .put("albumTitle", "专辑 " + albumId)
+                .put("coverUrl", "https://cover/" + albumId)
+                .put("authors", "作者")
+                .put("chapterId", albumId + "-1")
+                .put("chapterTitle", chapterTitle);
+    }
+}

--- a/desktop/src/test/java/io/github/jukomu/desktop/feature/catalog/CatalogJsonTest.java
+++ b/desktop/src/test/java/io/github/jukomu/desktop/feature/catalog/CatalogJsonTest.java
@@ -1,0 +1,58 @@
+package io.github.jukomu.desktop.feature.catalog;
+
+import io.github.jukomu.jmcomic.api.model.JmAlbumMeta;
+import io.github.jukomu.jmcomic.api.model.JmComment;
+import io.github.jukomu.jmcomic.api.model.JmCommentList;
+import io.github.jukomu.jmcomic.api.model.JmImage;
+import io.github.jukomu.jmcomic.api.model.JmPhoto;
+import io.github.jukomu.jmcomic.api.model.JmSearchPage;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogJsonTest {
+    @Test
+    void mapsSearchAndPhotoToTheExistingFrontendFieldNames() {
+        JmAlbumMeta meta = new JmAlbumMeta("10", "标题", List.of("作者"), List.of("标签"));
+        var search = CatalogJson.searchPage(new JmSearchPage(2, 21, 3, List.of(meta)),
+                id -> "https://cover/" + id);
+
+        assertEquals(2, search.path("currentPage").asInt());
+        assertEquals("https://cover/10", search.path("content").get(0).path("coverUrl").asText());
+        assertEquals("作者", search.path("content").get(0).path("authors").get(0).asText());
+
+        JmImage image = new JmImage("20", "300000", "001.webp", "https://image/001.webp", "v=1", 1);
+        var photo = CatalogJson.photo(new JmPhoto(
+                "20", "章节", "10", "300000", 1, "作者", List.of("标签"), List.of(image), false
+        ));
+        assertEquals("20", photo.path("images").get(0).path("photoId").asText());
+        assertEquals("v=1", photo.path("images").get(0).path("queryParams").asText());
+        assertFalse(photo.path("isSingleEpisode").asBoolean());
+    }
+
+    @Test
+    void mapsNestedCommentRepliesAndEmptyCollections() {
+        JmComment reply = new JmComment(
+                "2", "u2", "reply", "内容", "now", "", "Lv.1", "10", "JM10", List.of(), 1, 0
+        );
+        JmComment root = new JmComment(
+                "1", "u1", "root", "正文", "now", "", "Lv.2", "10", "JM10", List.of(reply), 2, 0
+        );
+        var comments = CatalogJson.comments(new JmCommentList(1, List.of(root)));
+
+        assertEquals(1, comments.path("total").asInt());
+        assertEquals("2", comments.path("list").get(0).path("replys").get(0).path("commentId").asText());
+        assertTrue(CatalogJson.comments(new JmCommentList(0, null)).path("list").isEmpty());
+    }
+
+    @Test
+    void derivesTheImageContentTypeFromTheUpstreamFilename() {
+        assertEquals("image/jpeg", JmComicCatalogService.mediaType("001.JPG"));
+        assertEquals("image/webp", JmComicCatalogService.mediaType("001.webp"));
+        assertEquals("application/octet-stream", JmComicCatalogService.mediaType("001.bin"));
+    }
+}

--- a/src/runtime/desktop/createDesktopRuntime.ts
+++ b/src/runtime/desktop/createDesktopRuntime.ts
@@ -1,3 +1,4 @@
+import type { BackendClient } from '../BackendClient'
 import type { FrontendRuntime } from '../FrontendRuntime'
 import { createDesktopBackendClient, type DesktopFetch } from './desktopBackendClient'
 import { createDesktopBackendEvents } from './desktopBackendEvents'
@@ -9,7 +10,7 @@ export function createDesktopRuntime(fetcher?: DesktopFetch): FrontendRuntime {
   const events = createDesktopBackendEvents()
   return {
     platform: 'linux',
-    backend: createDesktopBackendClient(fetcher),
+    backend: createDesktopBackendClient(fetcher) as BackendClient,
     events,
     resources: createDesktopResourceResolver(),
     services: createDesktopPlatformServices(events),

--- a/src/runtime/desktop/desktopBackendClient.ts
+++ b/src/runtime/desktop/desktopBackendClient.ts
@@ -1,9 +1,32 @@
 import type { BackendClient } from '../BackendClient'
 import { RuntimeError, type RuntimeErrorCode } from '../errors'
 
-export const DESKTOP_BACKEND_METHODS = ['getInitStatus'] as const
-
 export type DesktopFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+export type DesktopBackendClient = Pick<
+  BackendClient,
+  | 'search'
+  | 'categories'
+  | 'getAlbum'
+  | 'getPhoto'
+  | 'getComments'
+  | 'getInitStatus'
+  | 'login'
+  | 'logout'
+  | 'checkLoginState'
+  | 'getUserProfile'
+  | 'getAllSettings'
+  | 'setPreloadConcurrency'
+  | 'setDownloadConcurrency'
+  | 'setReaderPreloadPages'
+  | 'setReaderDisplayMode'
+  | 'setReaderAutoShowToolbarAtEnd'
+  | 'getBrowseHistory'
+  | 'getBrowseHistoryOverview'
+  | 'recordBrowse'
+  | 'clearBrowseHistory'
+  | 'deleteBrowseItem'
+>
 
 function isRuntimeErrorCode(value: unknown): value is RuntimeErrorCode {
   return (
@@ -60,8 +83,14 @@ async function request<T>(fetcher: DesktopFetch, method: string, body: unknown):
 /** 构建 Desktop backend 能力面；未实现的方法不会暴露到运行时。 */
 export function createDesktopBackendClient(
   fetcher: DesktopFetch = globalThis.fetch.bind(globalThis),
-): BackendClient {
-  const client = {
+): DesktopBackendClient {
+  return {
+    search: (options) => request(fetcher, 'search', options),
+    categories: (options) => request(fetcher, 'categories', options),
+    getAlbum: (options) => request(fetcher, 'getAlbum', options),
+    getPhoto: (options) => request(fetcher, 'getPhoto', options),
+    getComments: (options) => request(fetcher, 'getComments', options),
+
     getInitStatus: async () => {
       const result = await request<{ complete?: unknown }>(fetcher, 'getInitStatus', {})
       if (!result || typeof result.complete !== 'boolean') {
@@ -69,7 +98,24 @@ export function createDesktopBackendClient(
       }
       return { complete: result.complete }
     },
-  }
 
-  return client as unknown as BackendClient
+    login: (options) => request(fetcher, 'login', options),
+    logout: () => request(fetcher, 'logout', {}),
+    checkLoginState: () => request(fetcher, 'checkLoginState', {}),
+    getUserProfile: (options) => request(fetcher, 'getUserProfile', options),
+
+    getAllSettings: () => request(fetcher, 'getAllSettings', {}),
+    setPreloadConcurrency: (options) => request(fetcher, 'setPreloadConcurrency', options),
+    setDownloadConcurrency: (options) => request(fetcher, 'setDownloadConcurrency', options),
+    setReaderPreloadPages: (options) => request(fetcher, 'setReaderPreloadPages', options),
+    setReaderDisplayMode: (options) => request(fetcher, 'setReaderDisplayMode', options),
+    setReaderAutoShowToolbarAtEnd: (options) =>
+      request(fetcher, 'setReaderAutoShowToolbarAtEnd', options),
+
+    getBrowseHistory: (options) => request(fetcher, 'getBrowseHistory', options),
+    getBrowseHistoryOverview: (options) => request(fetcher, 'getBrowseHistoryOverview', options),
+    recordBrowse: (options) => request(fetcher, 'recordBrowse', options),
+    clearBrowseHistory: () => request(fetcher, 'clearBrowseHistory', {}),
+    deleteBrowseItem: (options) => request(fetcher, 'deleteBrowseItem', options),
+  }
 }

--- a/tests/unit/desktopRuntime.test.ts
+++ b/tests/unit/desktopRuntime.test.ts
@@ -12,17 +12,112 @@ function response(payload: unknown, ok = true, status = 200): Response {
 }
 
 describe('Desktop runtime', () => {
-  test('only installs getInitStatus and sends the existing JSON command shape', async () => {
+  test('sends the existing JSON command shape for every implemented method', async () => {
     const fetcher = vi.fn().mockResolvedValue(response({ complete: true }))
     const backend = createDesktopBackendClient(fetcher)
 
     await expect(backend.getInitStatus()).resolves.toEqual({ complete: true })
-    expect(Object.keys(backend)).toEqual(['getInitStatus'])
-    expect(fetcher).toHaveBeenCalledWith('/api/getInitStatus', {
+    expect(fetcher).toHaveBeenLastCalledWith('/api/getInitStatus', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{}',
     })
+
+    fetcher.mockResolvedValue(response({ value: 'ok' }))
+    const calls: Array<[() => Promise<unknown>, string, unknown]> = [
+      [
+        () => backend.search({ query: { orderBy: 'mr', time: 'a', searchMainTag: 0 } }),
+        'search',
+        { query: { orderBy: 'mr', time: 'a', searchMainTag: 0 } },
+      ],
+      [
+        () => backend.categories({ query: { orderBy: 'mr', time: 'a', searchMainTag: 0 } }),
+        'categories',
+        { query: { orderBy: 'mr', time: 'a', searchMainTag: 0 } },
+      ],
+      [() => backend.getAlbum({ id: '10' }), 'getAlbum', { id: '10' }],
+      [() => backend.getPhoto({ id: '20' }), 'getPhoto', { id: '20' }],
+      [
+        () => backend.getComments({ albumId: '10', page: 2 }),
+        'getComments',
+        { albumId: '10', page: 2 },
+      ],
+      [
+        () => backend.login({ username: 'user', password: 'pass' }),
+        'login',
+        { username: 'user', password: 'pass' },
+      ],
+      [() => backend.logout(), 'logout', {}],
+      [() => backend.checkLoginState(), 'checkLoginState', {}],
+      [() => backend.getUserProfile({ uid: '1' }), 'getUserProfile', { uid: '1' }],
+      [() => backend.getAllSettings(), 'getAllSettings', {}],
+      [() => backend.setPreloadConcurrency({ n: 4 }), 'setPreloadConcurrency', { n: 4 }],
+      [
+        () => backend.setDownloadConcurrency({ n: 5 }),
+        'setDownloadConcurrency',
+        { n: 5 },
+      ],
+      [
+        () => backend.setReaderPreloadPages({ n: 20 }),
+        'setReaderPreloadPages',
+        { n: 20 },
+      ],
+      [
+        () => backend.setReaderDisplayMode({ mode: 'horizontal' }),
+        'setReaderDisplayMode',
+        { mode: 'horizontal' },
+      ],
+      [
+        () => backend.setReaderAutoShowToolbarAtEnd({ enabled: false }),
+        'setReaderAutoShowToolbarAtEnd',
+        { enabled: false },
+      ],
+      [
+        () => backend.getBrowseHistory({ limit: 20, offset: 0 }),
+        'getBrowseHistory',
+        { limit: 20, offset: 0 },
+      ],
+      [
+        () => backend.getBrowseHistoryOverview({ ranges: [] }),
+        'getBrowseHistoryOverview',
+        { ranges: [] },
+      ],
+      [
+        () =>
+          backend.recordBrowse({
+            albumId: '10',
+            albumTitle: 'A',
+            coverUrl: '',
+            authors: '',
+            chapterId: '20',
+            chapterTitle: 'C',
+          }),
+        'recordBrowse',
+        {
+          albumId: '10',
+          albumTitle: 'A',
+          coverUrl: '',
+          authors: '',
+          chapterId: '20',
+          chapterTitle: 'C',
+        },
+      ],
+      [() => backend.clearBrowseHistory(), 'clearBrowseHistory', {}],
+      [() => backend.deleteBrowseItem({ id: 7 }), 'deleteBrowseItem', { id: 7 }],
+    ]
+
+    for (const [invoke, method, body] of calls) {
+      await expect(invoke()).resolves.toEqual({ value: 'ok' })
+      expect(fetcher).toHaveBeenLastCalledWith(`/api/${method}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    }
+
+    expect(Object.keys(backend)).toHaveLength(21)
+    expect((backend as unknown as { autoLogin?: unknown }).autoLogin).toBeUndefined()
+    expect((backend as unknown as { retryImage?: unknown }).retryImage).toBeUndefined()
   })
 
   test('normalizes transport and malformed response failures without adding a fallback method', async () => {
@@ -40,10 +135,10 @@ describe('Desktop runtime', () => {
     await expect(malformed.getInitStatus()).rejects.toMatchObject({
       code: 'internal',
     })
-    expect((backend as unknown as { search?: unknown }).search).toBeUndefined()
+    expect((backend as unknown as { autoLogin?: unknown }).autoLogin).toBeUndefined()
   })
 
-  test('uses same-origin resources and explicit unavailable phase-1 capabilities', async () => {
+  test('uses same-origin resources and explicit unavailable Desktop capabilities', async () => {
     const runtime = createDesktopRuntime(vi.fn().mockResolvedValue(response({ complete: true })))
 
     expect(runtime.platform).toBe('linux')


### PR DESCRIPTION
## 功能

- 接通 Desktop 的搜索、分类、作品详情、章节详情、评论和图片读取。
- 接通进程内登录态、基础阅读设置和浏览历史，共实现 21 个 Desktop bridge 方法。
- 使用 `jmcomic-core` 既有模型，在目录和认证模块内分别完成前端 JSON 契约转换，不新增重复 DTO。
- 使用单一 `JmApiClient` 和有界业务线程池执行阻塞调用；HTTP 边界统一处理异步响应和错误码。
- 使用 Desktop SQLite 持久化设置和浏览历史，支持连续专辑去重、分页及时间范围统计。
- 未实现的方法不注册，不提供 stub 或统一成功响应。

## 验证

- `cd desktop && mvn verify`：通过，25 项测试，0 failure / 0 error。
- `git diff --check`：通过。
- 前端单测和类型检查未在本地执行：依赖尚未安装，`npm ci` 被运行环境以 `EALLOWREMOTE` 拒绝；Frontend CI 已由本 PR 触发。

## 尚未验证

- 未在图形桌面环境执行端到端操作。合并前需要实际启动 Desktop 应用，验证搜索、进入作品与章节、加载图片以及刷新后继续访问页面。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 桌面端新增搜索、分类、专辑、照片和评论功能。
  - 新增登录、登出、登录状态检查及用户资料查询。
  - 新增设置读取与更新，支持阅读器及并发相关选项。
  - 新增浏览历史记录、分页查询、概览、删除和清空功能。
  - 桌面运行时现可调用上述完整功能。

- **改进**
  - 统一请求错误响应，提升异常处理的一致性与可读性。
  - 初始化状态接口返回更简洁稳定的数据格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->